### PR TITLE
Add Base1 secure host foundation

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -4,10 +4,7 @@ on:
   pull_request:
     branches: [master, main]
   push:
-    branches:
-      - master
-      - main
-      - "release/**"
+    branches: ["*"]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [master]
   push:
-    branches: ["release/**"]
+    branches: ["*"]
   workflow_dispatch:
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -15,11 +15,15 @@
   <a href="https://bryforge.github.io/phase1/"><strong>Open the Phase1 website</strong></a>
   ·
   <a href="WIKI_ROADMAP.md">Website + wiki roadmap</a>
+  ·
+  <a href="base1/README.md">Base1 secure host foundation</a>
 </p>
 
-![Edge](https://img.shields.io/badge/edge-v4.0.0--dev-00d8ff) ![Stable](https://img.shields.io/badge/stable-v3.10.9-39ff88) ![Rust](https://img.shields.io/badge/language-Rust-ff8a00) ![Security](https://img.shields.io/badge/default-safe%20mode%20on-39ff88)
+![Edge](https://img.shields.io/badge/edge-v4.0.0--dev-00d8ff) ![Stable](https://img.shields.io/badge/stable-v3.10.9-39ff88) ![Rust](https://img.shields.io/badge/language-Rust-ff8a00) ![Security](https://img.shields.io/badge/default-safe%20mode%20on-39ff88) ![Base1](https://img.shields.io/badge/base1-secure%20host%20foundation-8a5cff)
 
 Phase1 is a Rust-built, terminal-first educational virtual operating-system console. It models boot profiles, a virtual kernel, a VFS, process scheduling, `/proc`, `/dev`, `/var/log`, guarded networking, command capability metadata, pipelines, update tooling, runtime management, and a guarded terminal browser.
+
+Base1 is the planned secure hardware host foundation for Phase1 on Raspberry Pi and ThinkPad X200-class systems. Its mission is to keep the host bootable, recoverable, and protected if Phase1 is damaged, corrupted, or reset.
 
 ## Website
 
@@ -38,6 +42,7 @@ It uses a dark live-space background, moving rainbow visuals, the Phase1 neon lo
 | Edge | `v4.0.0-dev` | Current `master` development build |
 | Stable | `v3.10.9` | Current stable reference line |
 | Compatibility base | `v3.6.0` | Historical comparison base |
+| Base1 | `foundation` | Secure host design for Raspberry Pi and X200 targets |
 
 The package version is the booted Phase1 version. Boot, ready line, `/proc/version`, dashboard, audit boot record, `/home/readme.txt`, and shutdown dynamically reflect `CARGO_PKG_VERSION`.
 
@@ -61,6 +66,26 @@ security
 sysinfo
 roadmap
 ```
+
+## Base1 secure host foundation
+
+Base1 is designed as the real-hardware host layer below Phase1. It treats Phase1 as a contained workload and keeps host boot files, host packages, host secrets, recovery paths, and security policy outside Phase1 control.
+
+Start here:
+
+- [`base1/README.md`](base1/README.md) - Base1 overview.
+- [`base1/SECURITY_MODEL.md`](base1/SECURITY_MODEL.md) - threat model and security architecture.
+- [`base1/HARDWARE_TARGETS.md`](base1/HARDWARE_TARGETS.md) - Raspberry Pi and X200 target matrix.
+- [`base1/PHASE1_COMPATIBILITY.md`](base1/PHASE1_COMPATIBILITY.md) - Base1 and Phase1 compatibility contract.
+- [`base1/ROADMAP.md`](base1/ROADMAP.md) - staged Base1 roadmap.
+
+First safe checks:
+
+```bash
+sh scripts/base1-preflight.sh
+```
+
+The preflight checker is read-only. It reports readiness and warnings without changing the host.
 
 ## In-system wiki
 
@@ -107,6 +132,7 @@ Use `:help` inside `avim` for movement, edit, search, save, and quit commands.
 - Improve logical wrapping for narrow terminals.
 - Improve Linux color fallback for older systems such as ThinkPad X200 running Trisquel.
 - Improve Raspberry Pi 5 default OS text and color compatibility.
+- Build Base1 compatibility around secure Raspberry Pi and X200 host profiles.
 
 ## Run checks
 
@@ -128,7 +154,7 @@ cargo audit
 cargo deny check
 ```
 
-`cargo test --all-targets` includes unit tests plus scripted smoke tests for the main Phase1 shell and the guarded `phase1-storage` helper.
+`cargo test --all-targets` includes unit tests plus scripted smoke tests for the main Phase1 shell, the guarded `phase1-storage` helper, and the Base1 secure host foundation files.
 
 CI runs the same quality gate on pull requests, `master`, `main`, `release/**`, and manual dispatch. It also installs and runs RustSec advisory checks and dependency policy validation.
 
@@ -163,6 +189,8 @@ The public website/wiki roadmap lives in [`WIKI_ROADMAP.md`](WIKI_ROADMAP.md).
 Phase1 is an educational simulator. It should never need your GitHub password, personal access token, SSH private key, browser cookies, Apple ID, email password, or recovery codes.
 
 Host-backed commands are explicit and guarded. Runtime files such as `phase1.state`, `phase1.history`, and `phase1.log` are local operational artifacts.
+
+Base1 is a secure host foundation, not a destructive installer. Its first tooling is intentionally read-only and compatibility-focused. Base1 security claims should remain conservative until backed by repeatable builds, audits, and hardware validation.
 
 ## License
 

--- a/base1/HARDWARE_TARGETS.md
+++ b/base1/HARDWARE_TARGETS.md
@@ -1,0 +1,159 @@
+# Base1 Hardware Targets
+
+Base1 starts with two target classes: Raspberry Pi and ThinkPad X200-class hardware. The goal is to support small, recoverable security appliances and durable laptop-style operator consoles.
+
+## Target A: Raspberry Pi
+
+### Intended role
+
+- Dedicated Phase1 terminal node.
+- Portable security lab host.
+- Low-cost recovery and monitoring box.
+- Offline or limited-network Phase1 appliance.
+
+### Security goals
+
+- Bootable from known-good removable media.
+- Easy rebuild and recovery.
+- Default-deny inbound network policy.
+- No host secrets inside Phase1 workspace.
+- Phase1 runs as an unprivileged contained service or interactive app.
+- Logs stored outside Phase1 workspace.
+
+### Compatibility requirements
+
+- ARM Linux profile.
+- Conservative terminal color profile.
+- Low-memory safe mode.
+- No assumptions about desktop environment.
+- Serial console friendly output.
+- Works with keyboard-only operation.
+
+### Storage guidance
+
+Preferred first layout:
+
+```text
+boot media      OS boot files
+root filesystem Base1 host
+/var/lib/phase1 Phase1 workspace
+/var/log/base1  Base1 host logs
+```
+
+Future hardened layout:
+
+```text
+read-only root
+writable /var
+separate Phase1 workspace
+optional recovery image
+```
+
+### Risks to handle
+
+- Power loss and removable-media corruption.
+- Inconsistent USB power supplies.
+- Removable media replacement.
+- Network exposure when used headless.
+- Operator accidentally running Phase1 with host privileges.
+
+## Target B: ThinkPad X200-class systems
+
+### Intended role
+
+- Durable Phase1 operator laptop.
+- Offline-first local system.
+- Security-focused development host.
+- Legacy hardware with predictable terminal performance.
+
+### Security goals
+
+- Support firmware-aware documentation for libreboot or coreboot-friendly use cases.
+- Keep Phase1 isolated from host package, boot, and recovery controls.
+- Prefer minimal desktop or terminal-only install.
+- Prefer storage encryption where practical.
+- Keep logs and recovery tools outside Phase1 workspace.
+
+### Compatibility requirements
+
+- x86_64 Linux profile where available.
+- Legacy terminal and limited color handling.
+- Low-resolution display friendly layouts.
+- Keyboard-first operation.
+- Offline install path.
+- No requirement for modern GPU features.
+
+### Storage guidance
+
+Preferred first layout:
+
+```text
+/boot              host boot files
+/                  Base1 root
+/home/phase1       phase1 user home, minimal
+/var/lib/phase1    Phase1 workspace
+/var/log/base1     Base1 logs
+```
+
+Future hardened layout:
+
+```text
+encrypted root
+read-only base profile
+separate Phase1 data volume
+snapshot or rollback support
+external recovery USB
+```
+
+### Risks to handle
+
+- Legacy wireless firmware availability.
+- Battery-backed clock drift.
+- Older CPU mitigations and performance constraints.
+- Legacy display size and color handling.
+- Operator mixing host shell and Phase1 shell authority.
+
+## Common hardening requirements
+
+Both hardware classes need:
+
+- Dedicated `phase1` runtime user.
+- No passwordless host mutation from Phase1.
+- No direct Phase1 write access to boot or package files.
+- Optional offline-only profile.
+- Firewall default deny inbound.
+- Explicit maintenance mode for host changes.
+- Recovery path tested before field use.
+- Clear warning when running as root.
+- Clear warning when host tools are enabled.
+
+## Compatibility mode names
+
+Base1 should expose stable target names:
+
+```text
+BASE1_HARDWARE_TARGET=raspberry-pi
+BASE1_HARDWARE_TARGET=x200
+BASE1_HARDWARE_TARGET=generic
+```
+
+The Phase1 UI can use this variable for color, terminal, runtime, and documentation hints without needing host-specific probing inside Phase1.
+
+## First validation checklist
+
+For each target, Base1 should validate:
+
+- CPU architecture.
+- Kernel name and version.
+- Available RAM.
+- Available disk space.
+- Presence of `git` and `cargo` only when needed.
+- Writable Phase1 workspace.
+- Non-root Phase1 runtime account.
+- Inbound network exposure.
+- Recovery notes location.
+- Host log path.
+
+## Foundation-stage limits
+
+The first Base1 foundation does not perform destructive setup. It only documents the target model and provides non-destructive readiness checks. Firmware updates, storage migration, SSH enablement, and network exposure remain explicit operator-controlled tasks.

--- a/base1/PHASE1_COMPATIBILITY.md
+++ b/base1/PHASE1_COMPATIBILITY.md
@@ -1,0 +1,144 @@
+# Base1 and Phase1 Compatibility Contract
+
+Base1 and Phase1 are separate layers with a deliberate trust boundary.
+
+Base1 provides a secure hardware host. Phase1 provides the terminal-first virtual operating-system experience. Base1 should preserve Phase1 compatibility while preventing Phase1 from becoming host authority.
+
+## Contract version
+
+```text
+BASE1_PHASE1_CONTRACT=0.1
+```
+
+This first contract is intentionally small. Future versions can add features without breaking safe defaults.
+
+## Required environment variables
+
+Base1 may provide these variables when launching Phase1:
+
+```text
+BASE1_PROFILE=secure-default
+BASE1_HARDWARE_TARGET=raspberry-pi | x200 | generic
+BASE1_PHASE1_CONTRACT=0.1
+PHASE1_STORAGE_ROOT=/var/lib/phase1/workspace
+PHASE1_SAFE_MODE=1
+PHASE1_ALLOW_HOST_TOOLS=0
+```
+
+## Default compatibility posture
+
+By default:
+
+- Phase1 safe mode stays enabled.
+- Host-backed tools stay disabled.
+- Phase1 storage is placed under a Base1-owned workspace path.
+- Phase1 runs as a dedicated unprivileged user.
+- Phase1 does not receive host secrets.
+- Phase1 does not control Base1 boot, packages, services, keys, or firewall policy.
+
+## Maintenance posture
+
+A future Base1 maintenance mode may temporarily allow host-backed Phase1 helper flows. That mode must be separate from normal boot.
+
+Maintenance mode requirements:
+
+- Operator explicitly enters maintenance mode.
+- Base1 records an audit entry outside the Phase1 workspace.
+- Host-backed tools receive the minimum required permission.
+- The session ends with a clear return to secure-default mode.
+- Phase1 cannot silently persist maintenance mode.
+
+## Stable paths
+
+Base1 should provide these stable paths:
+
+```text
+/opt/phase1            Read-only Phase1 executable and assets
+/var/lib/phase1        Phase1 persistent state and workspace
+/var/log/phase1-host   Host-side Phase1 service logs
+/run/phase1            Ephemeral runtime directory
+/base1                 Base1 local policy and metadata
+```
+
+Phase1 must treat `/opt/phase1`, `/base1`, and host log paths as read-only.
+
+## Runtime account
+
+Preferred account:
+
+```text
+user:  phase1
+group: phase1
+home:  /var/lib/phase1
+shell: nologin for service mode, normal shell only for explicit interactive mode
+```
+
+The `phase1` user should not have passwordless administrator rights.
+
+## Host tool gating
+
+The existing Phase1 host-tool gate remains part of the contract:
+
+```text
+PHASE1_SAFE_MODE=1
+PHASE1_ALLOW_HOST_TOOLS=0
+```
+
+Base1 must not invert this default. Any host tool enablement should be temporary, logged, and operator-approved.
+
+## Hardware hints
+
+Phase1 may use `BASE1_HARDWARE_TARGET` to tune UI and runtime behavior:
+
+### raspberry-pi
+
+- Prefer conservative color output.
+- Avoid heavy default workloads.
+- Keep serial-console friendly output.
+- Prefer low-memory docs and commands.
+
+### x200
+
+- Prefer legacy terminal compatibility.
+- Avoid assuming modern GPU or high-DPI display features.
+- Keep keyboard-first workflows.
+- Keep offline-first docs available.
+
+### generic
+
+- Use normal Phase1 defaults.
+
+## Failure behavior
+
+If Phase1 state is damaged:
+
+- Base1 should still boot.
+- Host logs should remain readable.
+- The Phase1 workspace can be reset without changing Base1 boot or system files.
+- Known-good Phase1 assets under `/opt/phase1` should remain protected.
+
+If Base1 detects unsafe Phase1 launch conditions:
+
+- Refuse to launch as root unless explicitly configured for development.
+- Warn when safe mode is disabled.
+- Warn when host tools are allowed.
+- Warn when the workspace path is missing or world-writable.
+
+## Phase1 development compatibility
+
+Phase1 should continue to work without Base1. Base1 variables are optional hints, not mandatory dependencies. When Base1 variables are absent, Phase1 should use normal development defaults.
+
+## Base1 development compatibility
+
+Base1 should not require Phase1 internals beyond documented launch and storage behavior. This keeps Base1 useful even as Phase1 evolves.
+
+## Compatibility test requirements
+
+Future tests should verify:
+
+- Phase1 runs with Base1 environment variables set.
+- Phase1 safe mode remains enabled by default.
+- `phase1-storage storage status` works without host-tool permissions.
+- Mutating storage, Git, and Rust actions remain blocked unless the explicit trust gate is set.
+- Base1 preflight never changes the host.
+- Base1 launcher refuses unsafe root execution unless development override is set.

--- a/base1/README.md
+++ b/base1/README.md
@@ -1,0 +1,106 @@
+# Base1
+
+Base1 is the planned secure hardware host for Phase1.
+
+It is designed for machines where Phase1 should be useful, portable, and recoverable without giving Phase1 the power to destroy the underlying host. The first hardware targets are:
+
+- Raspberry Pi systems, especially a small dedicated terminal/security node.
+- ThinkPad X200-class systems, especially libreboot/coreboot-friendly legacy laptops.
+
+Base1 is not presented as more secure than OpenBSD today. The project goal is to build toward that level of discipline: simple design, small trusted computing base, secure defaults, aggressive compartmentalization, clear code paths, excellent documentation, and repeatable audits.
+
+## Mission
+
+Base1 exists to keep the hardware safe while Phase1 runs above it.
+
+If Phase1 is corrupted, crashed, misconfigured, wiped, or intentionally destroyed, Base1 should remain intact, bootable, recoverable, and able to reinstall or rebuild a known-good Phase1 environment.
+
+## Initial design principles
+
+1. Secure by default.
+2. Minimal base install.
+3. Phase1 is treated as contained application workload, not as the host authority.
+4. Host mutation is denied unless the operator explicitly enters a maintenance mode.
+5. Runtime state is separated from system state.
+6. Recovery paths are designed before convenience features.
+7. Every host integration must have a compatibility contract with Phase1.
+8. Raspberry Pi and X200 support must be designed from the beginning, not bolted on later.
+
+## Trust boundary
+
+Base1 owns:
+
+- Boot and recovery policy.
+- Disk layout and rollback policy.
+- Kernel, init, networking, firewalling, logging, and update channels.
+- Host secrets and operator credentials.
+- Phase1 install, update, and reset controls.
+
+Phase1 owns:
+
+- The terminal-first virtual OS experience.
+- Simulated kernel, VFS, process table, audit log, language runtime interface, and operator console.
+- Its own workspace and user data inside the controlled Phase1 storage area.
+
+Phase1 must not own:
+
+- Base1 boot files.
+- Base1 package manager keys.
+- Host SSH credentials.
+- Host firewall rules.
+- Host persistent secrets.
+- Host recovery images.
+
+## First implementation layer
+
+This repository now contains the first Base1 foundation files:
+
+- `SECURITY_MODEL.md` - threat model and security architecture.
+- `HARDWARE_TARGETS.md` - Raspberry Pi and X200 target requirements.
+- `PHASE1_COMPATIBILITY.md` - compatibility contract between Base1 and Phase1.
+- `config/base1-secure-profile.toml` - machine-readable secure profile draft.
+- `scripts/base1-preflight.sh` - non-destructive host readiness checker.
+- `scripts/base1-phase1-run.sh` - hardened Phase1 launcher wrapper.
+- `systemd/phase1-base1.service` - hardened systemd unit template.
+
+## Install strategy
+
+Base1 installation must be staged:
+
+1. Preflight only: detect hardware, OS, storage, boot mode, and hardening capability.
+2. Dry-run plan: print exactly what would change.
+3. Operator confirmation: require explicit maintenance mode.
+4. Build immutable/recoverable host profile.
+5. Install Phase1 into a contained runtime account.
+6. Verify recovery path before enabling convenience features.
+
+No Base1 script should silently repartition, erase, or reconfigure a host.
+
+## Security posture
+
+Base1 should prefer:
+
+- Read-only or rollback-capable root where practical.
+- Separate writable Phase1 workspace.
+- Dedicated low-privilege `phase1` runtime account.
+- No passwordless host mutation from Phase1.
+- Firewall default deny inbound.
+- SSH disabled by default unless explicitly enabled for a managed appliance use case.
+- Logs retained outside Phase1 workspace.
+- Tight service sandboxing.
+- Measured and documented boot chain where hardware supports it.
+
+## Current status
+
+Base1 is at foundation stage. The current files establish the secure architecture, hardware constraints, and first operator tooling. They do not yet constitute a destructive installer or complete operating system image.
+
+## Next milestones
+
+- Add a reproducible Base1 image build path.
+- Add Raspberry Pi image profile.
+- Add X200 installer profile.
+- Add immutable/rollback storage layout documentation.
+- Add signed Phase1 release installation flow.
+- Add network lockdown and offline-mode profiles.
+- Add recovery media and reset workflow.
+- Add Base1 integration tests in CI.

--- a/base1/ROADMAP.md
+++ b/base1/ROADMAP.md
@@ -1,0 +1,155 @@
+# Base1 Roadmap
+
+Base1 is the secure host layer for Phase1. This roadmap keeps the work staged so the project does not jump directly into risky installer behavior.
+
+## Phase B0 - Foundation
+
+Status: started
+
+Goals:
+
+- Define Base1 mission and trust boundary.
+- Define Raspberry Pi and X200 target classes.
+- Define Base1 and Phase1 compatibility contract.
+- Add secure-default profile metadata.
+- Add non-destructive preflight checker.
+- Add hardened Phase1 launcher wrapper.
+- Add systemd service sandbox template.
+- Add CI-visible tests for the foundation assumptions.
+
+Exit criteria:
+
+- Documentation is present and linked.
+- Preflight script is read-only.
+- Launcher refuses root by default.
+- Service template uses hardening directives.
+- Tests validate the foundation files.
+
+## Phase B1 - Reproducible host profile
+
+Goals:
+
+- Choose first reproducible image path.
+- Generate package manifest.
+- Generate users, directories, and permissions plan.
+- Generate firewall profile plan.
+- Add dry-run output for every planned host change.
+- Add checksums for generated artifacts.
+
+Exit criteria:
+
+- Operator can generate a Base1 plan without changing the host.
+- Generated plan is reviewable in plain text.
+- No secrets are stored in generated files.
+
+## Phase B2 - Raspberry Pi profile
+
+Goals:
+
+- Add Raspberry Pi profile defaults.
+- Add serial-console friendly output.
+- Add low-memory profile.
+- Add removable-media recovery notes.
+- Add offline mode.
+- Add service-mode launch path.
+
+Exit criteria:
+
+- Raspberry Pi profile can run Phase1 under the Base1 contract.
+- Recovery process is documented.
+- Network profile starts with deny-inbound behavior.
+
+## Phase B3 - X200 profile
+
+Goals:
+
+- Add X200 profile defaults.
+- Add legacy terminal compatibility profile.
+- Add offline-first operator notes.
+- Add storage-encryption planning docs.
+- Add minimal desktop or terminal-only deployment notes.
+
+Exit criteria:
+
+- X200 profile can run Phase1 under the Base1 contract.
+- Offline docs are available.
+- Compatibility notes cover legacy display and terminal constraints.
+
+## Phase B4 - Phase1 release installation flow
+
+Goals:
+
+- Install Phase1 from a known-good release artifact.
+- Verify artifact checksums.
+- Keep Phase1 assets read-only from the Phase1 runtime account.
+- Keep workspace separate and resettable.
+- Add rollback to previous Phase1 release.
+
+Exit criteria:
+
+- Damaged Phase1 workspace can be reset without damaging Base1.
+- Known-good Phase1 assets remain protected.
+- Update and rollback actions are logged outside the Phase1 workspace.
+
+## Phase B5 - Hardened runtime profiles
+
+Goals:
+
+- Add service mode.
+- Add interactive operator mode.
+- Add offline-only mode.
+- Add maintenance mode.
+- Add restricted-network mode.
+- Add development mode with clear warnings.
+
+Exit criteria:
+
+- Secure-default remains the default.
+- Maintenance and development modes are explicit and logged.
+- Phase1 cannot silently persist elevated host permissions.
+
+## Phase B6 - Recovery and resilience
+
+Goals:
+
+- Add recovery media plan.
+- Add workspace reset workflow.
+- Add host log preservation workflow.
+- Add Base1 profile backup and restore.
+- Add first rollback or snapshot profile.
+
+Exit criteria:
+
+- A destroyed Phase1 workspace can be recovered.
+- Base1 remains bootable and auditable.
+- Recovery steps are simple enough for field use.
+
+## Phase B7 - Audit maturity
+
+Goals:
+
+- Add threat-model review checklist.
+- Add shell script linting.
+- Add service hardening review.
+- Add secret scanning to Base1 files.
+- Add hardware target test reports.
+- Add release checklist.
+
+Exit criteria:
+
+- Every release has a documented Base1 security review.
+- Known limitations are visible.
+- Security claims remain accurate and conservative.
+
+## Long-term direction
+
+Base1 should build toward operating-system-level security discipline:
+
+- Minimal trusted computing base.
+- Privilege separation.
+- Reproducible builds.
+- Conservative defaults.
+- Documented recovery.
+- Operator-readable configuration.
+- Clear compatibility with Phase1.
+- Honest security claims backed by tests and audits.

--- a/base1/SECURITY_MODEL.md
+++ b/base1/SECURITY_MODEL.md
@@ -1,0 +1,256 @@
+# Base1 Security Model
+
+Base1 is the secure hardware host layer for Phase1. Its purpose is to make Phase1 useful on real hardware without making the host disposable, fragile, or easy to compromise.
+
+## Security objective
+
+Base1 should preserve host integrity when Phase1 fails.
+
+A Phase1 failure includes:
+
+- Accidental deletion of Phase1 workspace files.
+- Corruption of Phase1 runtime state.
+- A malicious command typed into Phase1.
+- A bug in Phase1 runtime integration.
+- A hostile project cloned into the Phase1 workspace.
+- A compromised language runtime launched from Phase1.
+- A crash or denial-of-service attempt inside the Phase1 layer.
+
+Base1 should keep boot, recovery, logs, host secrets, and update authority outside Phase1 control.
+
+## Non-goals for the first foundation
+
+- Do not claim formal verification.
+- Do not claim OpenBSD-equivalent maturity.
+- Do not bypass the operator's existing OS security model.
+- Do not build a destructive installer before preflight and dry-run tooling exists.
+- Do not grant Phase1 direct root privileges.
+
+## Threat model
+
+### In scope
+
+- Host command abuse from Phase1.
+- Accidental host file deletion.
+- Phase1 workspace compromise.
+- Untrusted cloned repositories.
+- Language runtime escape attempts.
+- Network exposure from operator tools.
+- Supply-chain drift in Phase1 builds.
+- Log destruction inside Phase1.
+- Misconfiguration on Raspberry Pi and X200 target hardware.
+
+### Out of scope for foundation stage
+
+- Physical attacks by a skilled adversary with unrestricted device access.
+- CPU microcode or silicon attacks.
+- Malicious firmware that already controls the machine.
+- Nation-state level implants.
+- Fully verified kernel correctness.
+
+These may become future hardening topics, but Base1 must be honest about what it currently protects.
+
+## Core isolation model
+
+Base1 treats Phase1 as a contained workload.
+
+Base1 should run Phase1 as:
+
+- A dedicated unprivileged user.
+- A process with a private runtime directory.
+- A process with a bounded writable workspace.
+- A process denied write access to host boot, package, service, key, and recovery paths.
+- A process with network access disabled or restricted unless the operator chooses a network profile.
+
+## Security rings
+
+### Ring B0: firmware and boot
+
+Owns hardware initialization, bootloader, kernel handoff, and recovery boot path.
+
+Required direction:
+
+- Document firmware state for each hardware target.
+- Prefer libreboot/coreboot-friendly flows on X200-class hardware.
+- Prefer signed or checksummed image workflows for Raspberry Pi.
+- Keep recovery media independent of Phase1.
+
+### Ring B1: Base1 host
+
+Owns the installed OS, kernel, init, users, firewall, storage, logs, and update trust.
+
+Required direction:
+
+- Minimal package set.
+- Default-deny inbound networking.
+- Host logs outside Phase1 workspace.
+- No host mutation from Phase1 except through explicit maintenance tools.
+- Reproducible build and install manifests.
+
+### Ring B2: Phase1 runtime account
+
+Owns the Phase1 process and runtime account.
+
+Required direction:
+
+- Dedicated `phase1` user.
+- No shell escalation by default.
+- No passwordless sudo.
+- No host package manager access.
+- Controlled workspace path.
+
+### Ring B3: Phase1 workspace
+
+Owns user projects, clones, temporary build output, and VFS persistence.
+
+Required direction:
+
+- Clearly bounded directory.
+- Easy reset and rebuild.
+- No stored host secrets.
+- Backups optional and explicit.
+
+## Default-deny host mutation
+
+Phase1 must not be able to directly change:
+
+- `/boot`
+- `/etc`
+- `/usr`
+- `/bin`
+- `/sbin`
+- `/lib`
+- package manager databases
+- service definitions
+- firewall policy
+- SSH host keys
+- Base1 signing keys
+- recovery partitions or media
+
+When host mutation is needed, Base1 should require:
+
+1. Maintenance mode.
+2. Clear prompt.
+3. Dry-run plan.
+4. Explicit operator approval.
+5. Log entry outside the Phase1 workspace.
+
+## Filesystem policy
+
+Recommended initial layout:
+
+```text
+/base1                 Base1 manifests and local policy
+/opt/phase1            Phase1 executable and read-only assets
+/var/lib/phase1        Phase1 persistent workspace
+/var/log/base1         Base1 host logs
+/var/log/phase1-host   Host-side Phase1 supervision logs
+/run/phase1            Runtime files, deleted at reboot
+```
+
+Optional hardening profiles:
+
+- Read-only root with separate writable `/var`.
+- Snapshot/rollback capable root.
+- Separate Phase1 data partition.
+- External recovery image.
+- Offline-only appliance mode.
+
+## Network policy
+
+Default network posture:
+
+- Deny inbound connections.
+- Permit outbound package/update traffic only in maintenance or update mode.
+- Permit Phase1 network features only through an explicit Base1 network profile.
+- Keep SSH disabled by default on single-user appliance deployments.
+- If SSH is enabled, require key-only login and rate limiting.
+
+## Update policy
+
+Base1 updates and Phase1 updates are separate.
+
+Base1 owns:
+
+- OS updates.
+- Kernel updates.
+- Bootloader updates.
+- Firewall and service updates.
+- Recovery updates.
+
+Phase1 owns:
+
+- Phase1 application version.
+- Phase1 docs/wiki assets.
+- Phase1 test fixtures.
+
+Base1 should be able to reinstall Phase1 from a known-good release without trusting a damaged Phase1 workspace.
+
+## Logging and audit
+
+Base1 logs must survive Phase1 destruction.
+
+Minimum host logs:
+
+- Phase1 start/stop events.
+- Phase1 update attempts.
+- Maintenance mode entry and exit.
+- Host mutation dry-run and apply summaries.
+- Network profile changes.
+- Failed privilege attempts.
+
+Logs should avoid storing secrets.
+
+## Secret handling
+
+Base1 and Phase1 should never request or store:
+
+- GitHub passwords.
+- Personal access tokens in repository files.
+- SSH private keys in Phase1 workspace.
+- Browser cookies.
+- Apple ID or email passwords.
+- Recovery codes.
+
+If a credential is needed for an operator workflow, it must be stored outside Phase1 using host-controlled secret storage or provided interactively for the single operation.
+
+## Compatibility contract
+
+Base1 should expose a small stable interface to Phase1:
+
+- `BASE1_PROFILE`
+- `BASE1_HARDWARE_TARGET`
+- `PHASE1_STORAGE_ROOT`
+- `PHASE1_SAFE_MODE`
+- `PHASE1_ALLOW_HOST_TOOLS`
+
+The default should keep `PHASE1_SAFE_MODE=1` and `PHASE1_ALLOW_HOST_TOOLS=0`.
+
+## Security quality bar
+
+Base1 development must require:
+
+- Secure defaults.
+- Tests for security-critical scripts.
+- Shell scripts using strict mode.
+- No silent destructive behavior.
+- No secrets in repository files.
+- Clear rollback and recovery plan.
+- Minimal dependencies.
+- Repeatable builds.
+- Documentation for every privilege boundary.
+
+## OpenBSD-inspired discipline
+
+Base1 should borrow principles from hardened operating systems:
+
+- Small pieces.
+- Clear privilege separation.
+- Defense in depth.
+- Conservative defaults.
+- Code readability over cleverness.
+- Man-page-level documentation.
+- Disable what is not needed.
+- Assume mistakes happen and contain them.
+
+The project should not claim OpenBSD parity until it has years of audit, releases, exploit history, and operational maturity.

--- a/base1/config/base1-secure-profile.toml
+++ b/base1/config/base1-secure-profile.toml
@@ -1,0 +1,83 @@
+# Base1 secure-default profile
+#
+# This is a declarative foundation profile, not an installer. Tools should read
+# this file to print plans, validate readiness, and generate target-specific
+# configs only after explicit operator approval.
+
+[base1]
+name = "base1"
+profile = "secure-default"
+phase1_contract = "0.1"
+status = "foundation"
+default_hardware_target = "generic"
+
+[targets.raspberry_pi]
+enabled = true
+arch_family = "arm"
+role = "dedicated-phase1-terminal-node"
+console_profile = "conservative-color"
+default_network = "deny-inbound"
+recommended_mode = "service-or-interactive"
+
+[targets.x200]
+enabled = true
+arch_family = "x86_64"
+role = "durable-offline-first-operator-console"
+console_profile = "legacy-terminal"
+default_network = "deny-inbound"
+recommended_mode = "interactive-or-service"
+
+[phase1]
+install_dir = "/opt/phase1"
+workspace_dir = "/var/lib/phase1/workspace"
+runtime_dir = "/run/phase1"
+host_log_dir = "/var/log/phase1-host"
+default_safe_mode = true
+default_allow_host_tools = false
+runtime_user = "phase1"
+runtime_group = "phase1"
+
+[security]
+treat_phase1_as_untrusted_workload = true
+require_explicit_maintenance_mode = true
+allow_passwordless_host_mutation = false
+allow_phase1_to_manage_boot = false
+allow_phase1_to_manage_packages = false
+allow_phase1_to_manage_firewall = false
+allow_phase1_to_read_host_secrets = false
+default_inbound_network = "deny"
+ssh_default = "disabled"
+logs_outside_phase1_workspace = true
+
+[filesystem]
+root_strategy = "minimal-host-first-rollback-later"
+phase1_workspace_separate_from_system = true
+protect_boot_paths = true
+protect_package_paths = true
+protect_service_paths = true
+protect_host_key_paths = true
+
+[observability]
+record_phase1_start_stop = true
+record_maintenance_mode = true
+record_host_mutation_plan = true
+record_network_profile_changes = true
+redact_secrets = true
+
+[preflight]
+mode = "read-only"
+check_architecture = true
+check_kernel = true
+check_memory = true
+check_disk_space = true
+check_phase1_user = true
+check_workspace_path = true
+check_inbound_network_hint = true
+check_required_tools = false
+
+[future]
+image_builder = "planned"
+rollback_layout = "planned"
+signed_phase1_release_flow = "planned"
+offline_update_media = "planned"
+integration_tests = "planned"

--- a/base1/systemd/phase1-base1.service
+++ b/base1/systemd/phase1-base1.service
@@ -1,0 +1,65 @@
+# Phase1 on Base1 hardened service template
+#
+# Copy or generate this unit only after Base1 preflight and operator review.
+# It assumes Phase1 is installed at /opt/phase1/phase1 and runs as the
+# dedicated phase1 user with state under /var/lib/phase1.
+
+[Unit]
+Description=Phase1 terminal OS runtime on Base1
+Documentation=https://github.com/Bryforge/phase1
+After=local-fs.target network-online.target
+Wants=network-online.target
+ConditionPathExists=/opt/phase1/phase1
+ConditionPathIsDirectory=/var/lib/phase1/workspace
+
+[Service]
+Type=simple
+User=phase1
+Group=phase1
+WorkingDirectory=/var/lib/phase1
+Environment=BASE1_PROFILE=secure-default
+Environment=BASE1_HARDWARE_TARGET=generic
+Environment=BASE1_PHASE1_CONTRACT=0.1
+Environment=PHASE1_STORAGE_ROOT=/var/lib/phase1/workspace
+Environment=PHASE1_SAFE_MODE=1
+Environment=PHASE1_ALLOW_HOST_TOOLS=0
+ExecStart=/opt/phase1/phase1
+Restart=on-failure
+RestartSec=5s
+
+# Keep Phase1 contained as an application workload.
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/phase1 /run/phase1
+ReadOnlyPaths=/opt/phase1
+InaccessiblePaths=/boot /root
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+RemoveIPC=true
+UMask=0077
+
+# Conservative syscall and namespace posture. These may need adjustment for
+# specific runtime features, but secure-default starts small.
+SystemCallArchitectures=native
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProcSubset=pid
+
+# Base1 should log supervision outside the Phase1 workspace.
+LogsDirectory=phase1-host
+RuntimeDirectory=phase1
+StateDirectory=phase1
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/base1-phase1-run.sh
+++ b/scripts/base1-phase1-run.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env sh
+# Hardened Phase1 launcher for Base1.
+#
+# This wrapper sets the Base1 compatibility environment and refuses unsafe root
+# launches unless explicitly allowed for development.
+
+set -eu
+
+BASE1_PROFILE=${BASE1_PROFILE:-secure-default}
+BASE1_HARDWARE_TARGET=${BASE1_HARDWARE_TARGET:-generic}
+BASE1_PHASE1_CONTRACT=${BASE1_PHASE1_CONTRACT:-0.1}
+PHASE1_INSTALL_DIR=${PHASE1_INSTALL_DIR:-/opt/phase1}
+PHASE1_BIN=${PHASE1_BIN:-$PHASE1_INSTALL_DIR/phase1}
+PHASE1_STORAGE_ROOT=${PHASE1_STORAGE_ROOT:-/var/lib/phase1/workspace}
+PHASE1_SAFE_MODE=${PHASE1_SAFE_MODE:-1}
+PHASE1_ALLOW_HOST_TOOLS=${PHASE1_ALLOW_HOST_TOOLS:-0}
+BASE1_ALLOW_ROOT_PHASE1=${BASE1_ALLOW_ROOT_PHASE1:-0}
+
+warn() {
+  printf 'base1 launcher warning: %s\n' "$1" >&2
+}
+
+fail() {
+  printf 'base1 launcher: %s\n' "$1" >&2
+  exit 1
+}
+
+if [ "$(id -u)" = "0" ] && [ "$BASE1_ALLOW_ROOT_PHASE1" != "1" ]; then
+  fail "refusing to launch Phase1 as root; run as the dedicated phase1 user or set BASE1_ALLOW_ROOT_PHASE1=1 only for development"
+fi
+
+if [ "$PHASE1_SAFE_MODE" != "1" ]; then
+  warn "PHASE1_SAFE_MODE is not 1; secure-default expects safe mode on"
+fi
+
+if [ "$PHASE1_ALLOW_HOST_TOOLS" != "0" ]; then
+  warn "PHASE1_ALLOW_HOST_TOOLS is not 0; host tools should be allowed only in explicit maintenance mode"
+fi
+
+if [ ! -d "$PHASE1_STORAGE_ROOT" ]; then
+  fail "workspace is missing: $PHASE1_STORAGE_ROOT"
+fi
+
+if [ ! -w "$PHASE1_STORAGE_ROOT" ]; then
+  fail "workspace is not writable by current user: $PHASE1_STORAGE_ROOT"
+fi
+
+if [ ! -x "$PHASE1_BIN" ]; then
+  fail "Phase1 executable not found or not executable: $PHASE1_BIN"
+fi
+
+export BASE1_PROFILE
+export BASE1_HARDWARE_TARGET
+export BASE1_PHASE1_CONTRACT
+export PHASE1_STORAGE_ROOT
+export PHASE1_SAFE_MODE
+export PHASE1_ALLOW_HOST_TOOLS
+
+exec "$PHASE1_BIN" "$@"

--- a/scripts/base1-preflight.sh
+++ b/scripts/base1-preflight.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env sh
+# Base1 non-destructive readiness checker.
+#
+# This script prints host facts and warnings only. It does not install packages,
+# create users, change services, edit firewall policy, or write system files.
+
+set -eu
+
+BASE1_PROFILE=${BASE1_PROFILE:-secure-default}
+BASE1_HARDWARE_TARGET=${BASE1_HARDWARE_TARGET:-auto}
+PHASE1_STORAGE_ROOT=${PHASE1_STORAGE_ROOT:-/var/lib/phase1/workspace}
+PHASE1_RUNTIME_USER=${PHASE1_RUNTIME_USER:-phase1}
+MIN_MEM_KB=${BASE1_MIN_MEM_KB:-262144}
+MIN_WORKSPACE_MB=${BASE1_MIN_WORKSPACE_MB:-512}
+
+info() {
+  printf 'base1: %s\n' "$1"
+}
+
+warn() {
+  printf 'base1 warning: %s\n' "$1" >&2
+}
+
+have() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+read_mem_kb() {
+  if [ -r /proc/meminfo ]; then
+    awk '/^MemTotal:/ { print $2; exit }' /proc/meminfo
+  else
+    printf '0\n'
+  fi
+}
+
+workspace_available_mb() {
+  parent=$PHASE1_STORAGE_ROOT
+  while [ ! -d "$parent" ] && [ "$parent" != "/" ]; do
+    parent=$(dirname "$parent")
+  done
+  df -Pm "$parent" 2>/dev/null | awk 'NR == 2 { print $4; exit }'
+}
+
+detect_target() {
+  arch=$(uname -m 2>/dev/null || printf unknown)
+  model=''
+  if [ -r /proc/device-tree/model ]; then
+    model=$(tr -d '\000' < /proc/device-tree/model 2>/dev/null || true)
+  elif [ -r /sys/class/dmi/id/product_version ]; then
+    model=$(cat /sys/class/dmi/id/product_version 2>/dev/null || true)
+  elif [ -r /sys/class/dmi/id/product_name ]; then
+    model=$(cat /sys/class/dmi/id/product_name 2>/dev/null || true)
+  fi
+
+  case "$model" in
+    *Raspberry*Pi*) printf 'raspberry-pi\n' ;;
+    *ThinkPad*X200*|*X200*) printf 'x200\n' ;;
+    *)
+      case "$arch" in
+        arm*|aarch64) printf 'raspberry-pi-candidate\n' ;;
+        x86_64|amd64) printf 'x200-or-generic-candidate\n' ;;
+        *) printf 'generic\n' ;;
+      esac
+      ;;
+  esac
+}
+
+info "profile: $BASE1_PROFILE"
+info "requested hardware target: $BASE1_HARDWARE_TARGET"
+info "detected target hint: $(detect_target)"
+info "kernel: $(uname -s 2>/dev/null || printf unknown) $(uname -r 2>/dev/null || printf unknown)"
+info "architecture: $(uname -m 2>/dev/null || printf unknown)"
+
+mem_kb=$(read_mem_kb)
+info "memory-kb: $mem_kb"
+if [ "$mem_kb" -gt 0 ] && [ "$mem_kb" -lt "$MIN_MEM_KB" ]; then
+  warn "memory is below recommended minimum ${MIN_MEM_KB}KB"
+fi
+
+available_mb=$(workspace_available_mb || printf '0')
+info "workspace: $PHASE1_STORAGE_ROOT"
+info "workspace-available-mb: ${available_mb:-0}"
+if [ "${available_mb:-0}" -gt 0 ] && [ "${available_mb:-0}" -lt "$MIN_WORKSPACE_MB" ]; then
+  warn "workspace parent has less than recommended ${MIN_WORKSPACE_MB}MB available"
+fi
+
+if [ "$(id -u)" = "0" ]; then
+  warn "preflight is running as root; Base1 prefers Phase1 runtime checks from an unprivileged context"
+fi
+
+if id "$PHASE1_RUNTIME_USER" >/dev/null 2>&1; then
+  info "runtime-user: $PHASE1_RUNTIME_USER exists"
+else
+  warn "runtime-user $PHASE1_RUNTIME_USER does not exist yet"
+fi
+
+if [ -d "$PHASE1_STORAGE_ROOT" ]; then
+  if [ -w "$PHASE1_STORAGE_ROOT" ]; then
+    info "workspace-writable: yes"
+  else
+    warn "workspace exists but is not writable by this user"
+  fi
+else
+  warn "workspace does not exist yet: $PHASE1_STORAGE_ROOT"
+fi
+
+for tool in sh awk sed grep df uname id; do
+  if have "$tool"; then
+    info "tool:$tool ok"
+  else
+    warn "required basic tool missing: $tool"
+  fi
+done
+
+for optional_tool in git cargo rustc systemctl; do
+  if have "$optional_tool"; then
+    info "optional-tool:$optional_tool present"
+  else
+    info "optional-tool:$optional_tool not present"
+  fi
+done
+
+if have ss; then
+  inbound=$(ss -ltn 2>/dev/null | awk 'NR > 1 { count++ } END { print count + 0 }')
+  info "tcp-listeners: $inbound"
+  if [ "$inbound" -gt 0 ]; then
+    warn "listening TCP sockets detected; Base1 secure-default prefers no unexpected inbound services"
+  fi
+else
+  info "tcp-listeners: not checked; ss not available"
+fi
+
+info "safe-mode-default: PHASE1_SAFE_MODE=1"
+info "host-tools-default: PHASE1_ALLOW_HOST_TOOLS=0"
+info "preflight complete; no host changes were made"

--- a/tests/base1_foundation.rs
+++ b/tests/base1_foundation.rs
@@ -151,6 +151,9 @@ fn assert_contains_all(text: &str, needles: &[&str]) {
 
 fn assert_not_contains_any(text: &str, needles: &[&str]) {
     for needle in needles {
-        assert!(!text.contains(needle), "unexpected unsafe pattern {needle:?}");
+        assert!(
+            !text.contains(needle),
+            "unexpected unsafe pattern {needle:?}"
+        );
     }
 }

--- a/tests/base1_foundation.rs
+++ b/tests/base1_foundation.rs
@@ -1,0 +1,156 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn base1_foundation_docs_exist() {
+    for path in [
+        "base1/README.md",
+        "base1/SECURITY_MODEL.md",
+        "base1/HARDWARE_TARGETS.md",
+        "base1/PHASE1_COMPATIBILITY.md",
+        "base1/ROADMAP.md",
+        "base1/config/base1-secure-profile.toml",
+        "base1/systemd/phase1-base1.service",
+        "scripts/base1-preflight.sh",
+        "scripts/base1-phase1-run.sh",
+    ] {
+        assert!(Path::new(path).is_file(), "missing Base1 file: {path}");
+    }
+}
+
+#[test]
+fn base1_security_model_preserves_phase1_host_boundary() {
+    let model = read("base1/SECURITY_MODEL.md");
+    assert_contains_all(
+        &model,
+        &[
+            "Base1 should preserve host integrity when Phase1 fails",
+            "Base1 treats Phase1 as a contained workload",
+            "No host mutation from Phase1 except through explicit maintenance tools",
+            "The project should not claim OpenBSD parity",
+            "Phase1 must not be able to directly change",
+        ],
+    );
+}
+
+#[test]
+fn base1_compatibility_contract_defaults_to_safe_mode() {
+    let contract = read("base1/PHASE1_COMPATIBILITY.md");
+    assert_contains_all(
+        &contract,
+        &[
+            "BASE1_PHASE1_CONTRACT=0.1",
+            "PHASE1_SAFE_MODE=1",
+            "PHASE1_ALLOW_HOST_TOOLS=0",
+            "Phase1 safe mode stays enabled",
+            "Host-backed tools stay disabled",
+        ],
+    );
+}
+
+#[test]
+fn base1_hardware_targets_include_raspberry_pi_and_x200() {
+    let targets = read("base1/HARDWARE_TARGETS.md");
+    assert_contains_all(
+        &targets,
+        &[
+            "Raspberry Pi",
+            "ThinkPad X200",
+            "BASE1_HARDWARE_TARGET=raspberry-pi",
+            "BASE1_HARDWARE_TARGET=x200",
+            "Firewall default deny inbound",
+        ],
+    );
+}
+
+#[test]
+fn base1_profile_is_secure_by_default() {
+    let profile = read("base1/config/base1-secure-profile.toml");
+    assert_contains_all(
+        &profile,
+        &[
+            "profile = \"secure-default\"",
+            "default_safe_mode = true",
+            "default_allow_host_tools = false",
+            "allow_passwordless_host_mutation = false",
+            "default_inbound_network = \"deny\"",
+            "ssh_default = \"disabled\"",
+        ],
+    );
+}
+
+#[test]
+fn base1_preflight_is_non_destructive() {
+    let script = read("scripts/base1-preflight.sh");
+    assert_contains_all(
+        &script,
+        &[
+            "non-destructive readiness checker",
+            "no host changes were made",
+            "PHASE1_SAFE_MODE=1",
+            "PHASE1_ALLOW_HOST_TOOLS=0",
+        ],
+    );
+    assert_not_contains_any(
+        &script,
+        &[
+            " useradd ",
+            " adduser ",
+            " systemctl enable ",
+            " mkfs.",
+            " parted ",
+            " sgdisk ",
+            " iptables -A ",
+            " nft add ",
+        ],
+    );
+}
+
+#[test]
+fn base1_launcher_refuses_root_by_default() {
+    let launcher = read("scripts/base1-phase1-run.sh");
+    assert_contains_all(
+        &launcher,
+        &[
+            "refusing to launch Phase1 as root",
+            "BASE1_ALLOW_ROOT_PHASE1",
+            "PHASE1_SAFE_MODE",
+            "PHASE1_ALLOW_HOST_TOOLS",
+            "exec \"$PHASE1_BIN\"",
+        ],
+    );
+}
+
+#[test]
+fn base1_systemd_template_has_hardening_directives() {
+    let unit = read("base1/systemd/phase1-base1.service");
+    assert_contains_all(
+        &unit,
+        &[
+            "User=phase1",
+            "NoNewPrivileges=true",
+            "ProtectSystem=strict",
+            "PrivateTmp=true",
+            "PrivateDevices=true",
+            "PHASE1_SAFE_MODE=1",
+            "PHASE1_ALLOW_HOST_TOOLS=0",
+            "ReadWritePaths=/var/lib/phase1 /run/phase1",
+        ],
+    );
+}
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains_all(text: &str, needles: &[&str]) {
+    for needle in needles {
+        assert!(text.contains(needle), "missing {needle:?}");
+    }
+}
+
+fn assert_not_contains_any(text: &str, needles: &[&str]) {
+    for needle in needles {
+        assert!(!text.contains(needle), "unexpected unsafe pattern {needle:?}");
+    }
+}


### PR DESCRIPTION
## Summary

Adds the initial Base1 secure host foundation for Phase1 hardware deployments. Base1 is intended to run below Phase1 on Raspberry Pi and ThinkPad X200-class systems so the host remains protected, recoverable, and operational even if Phase1 is damaged or reset.

## Security direction

Base1 starts with conservative, OpenBSD-inspired discipline without claiming OpenBSD-level maturity yet:

- Treat Phase1 as a contained/untrusted workload.
- Keep host boot, packages, services, firewall policy, logs, recovery paths, and secrets outside Phase1 control.
- Keep Phase1 safe mode on and host tools disabled by default.
- Require explicit future maintenance mode for host-changing actions.
- Start with non-destructive preflight tooling rather than a risky installer.

## Changes

- Adds `base1/README.md` overview.
- Adds `base1/SECURITY_MODEL.md` threat model and host boundary.
- Adds `base1/HARDWARE_TARGETS.md` for Raspberry Pi and X200 requirements.
- Adds `base1/PHASE1_COMPATIBILITY.md` compatibility contract and environment variables.
- Adds `base1/ROADMAP.md` staged roadmap from foundation through audit maturity.
- Adds `base1/config/base1-secure-profile.toml` secure-default machine-readable profile.
- Adds `scripts/base1-preflight.sh` read-only host readiness checker.
- Adds `scripts/base1-phase1-run.sh` hardened launcher wrapper that refuses root by default.
- Adds `base1/systemd/phase1-base1.service` hardened service template.
- Adds `tests/base1_foundation.rs` so the foundation files and security defaults are validated by CI.
- Updates the main README with Base1 links and status.

## Validation

Not run locally in this environment. Expected CI gate:

```bash
cargo fmt --all -- --check
cargo check --all-targets
cargo clippy --all-targets -- -D warnings
cargo test --all-targets
cargo audit
cargo deny check
```

## Notes

This PR intentionally avoids destructive install behavior. It establishes the Base1 architecture, compatibility contract, safety defaults, and first non-destructive operator tooling so Raspberry Pi and X200 support can be built with security boundaries from the beginning.