### PR TITLE
Fix website desktop performance, mobile readability, and creator labeling

### DIFF
--- a/button-fix.css
+++ b/button-fix.css
@@ -52,9 +52,32 @@
   transform: translateY(1px) scale(0.99);
 }
 
-/* Founder-card cleanup: the page should present one clear Founder Profile label, not duplicate role labels. */
-.profile-label {
+/* Creator-section cleanup: present one clear creator story, not stacked labels. */
+.profile-label,
+.founder-copy > .eyebrow {
   display: none !important;
+}
+
+.founder-copy h2 {
+  color: var(--text) !important;
+  background: none !important;
+  -webkit-background-clip: initial !important;
+  background-clip: initial !important;
+  animation: none !important;
+}
+
+.founder-copy h2::before {
+  content: "Created by Chase Bryan";
+  display: block;
+  margin: 0 0 12px;
+  color: var(--cyan);
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  line-height: 1.4;
+  text-transform: uppercase;
+  text-shadow: 0 0 18px rgba(35, 247, 255, 0.5);
 }
 
 /* Phase1 visual identity: the prompt cursor is intentionally blinking pink/magenta. */
@@ -65,6 +88,87 @@
   animation: blink 0.9s steps(2, start) infinite !important;
 }
 
-.founder-copy > .eyebrow::after {
-  content: "";
+/* Mobile readability: keep the design, but stop headings from fragmenting. */
+@media (max-width: 860px) {
+  h1,
+  .section-heading h2,
+  .founder-copy h2,
+  .support-card h2 {
+    overflow-wrap: normal !important;
+    word-break: normal !important;
+    hyphens: none !important;
+    text-wrap: balance;
+  }
+
+  h1 {
+    font-size: clamp(2.05rem, 11vw, 3.35rem) !important;
+    line-height: 1.02 !important;
+    letter-spacing: -0.045em !important;
+  }
+
+  .section-heading h2,
+  .support-card h2 {
+    font-size: clamp(1.8rem, 8vw, 2.7rem) !important;
+    line-height: 1.08 !important;
+    letter-spacing: -0.035em !important;
+  }
+
+  .founder-copy h2 {
+    font-size: clamp(1.7rem, 7.4vw, 2.45rem) !important;
+    line-height: 1.1 !important;
+    letter-spacing: -0.025em !important;
+  }
+
+  .eyebrow,
+  .card-kicker,
+  .timeline-status,
+  .founder-copy h2::before {
+    letter-spacing: 0.12em !important;
+  }
+
+  .hero-text,
+  .section-heading p,
+  .feature-card p,
+  .roadmap p,
+  .founder p,
+  .support-card p,
+  .footer p {
+    font-size: 0.98rem;
+    line-height: 1.62 !important;
+  }
+
+  .feature-card,
+  .bryforge-card,
+  .support-card,
+  .timeline li {
+    padding: 18px !important;
+  }
+}
+
+@media (max-width: 420px) {
+  .site-shell {
+    width: min(100% - 16px, 720px) !important;
+  }
+
+  .hero {
+    padding: 20px !important;
+  }
+
+  h1 {
+    font-size: clamp(1.9rem, 10vw, 2.7rem) !important;
+    letter-spacing: -0.032em !important;
+  }
+
+  .section-heading h2,
+  .support-card h2 {
+    font-size: clamp(1.55rem, 7.5vw, 2.2rem) !important;
+  }
+
+  .founder-copy h2 {
+    font-size: clamp(1.45rem, 7vw, 2.05rem) !important;
+  }
+
+  .hero-actions {
+    gap: 10px !important;
+  }
 }

--- a/button-fix.css
+++ b/button-fix.css
@@ -52,7 +52,7 @@
   transform: translateY(1px) scale(0.99);
 }
 
-/* Creator-section cleanup: present one clear creator story, not stacked labels. */
+/* Founder-section cleanup: present one clear Founder profile label, not stacked role labels. */
 .profile-label,
 .founder-copy > .eyebrow {
   display: none !important;
@@ -67,7 +67,7 @@
 }
 
 .founder-copy h2::before {
-  content: "Created by Chase Bryan";
+  content: "Founder profile";
   display: block;
   margin: 0 0 12px;
   color: var(--cyan);

--- a/site.js
+++ b/site.js
@@ -7,9 +7,11 @@ let height = 0;
 let stars = [];
 let comets = [];
 let animationFrame = 0;
+let resizeTimer = 0;
+let running = false;
 
 function resize() {
-  const ratio = Math.min(window.devicePixelRatio || 1, 2);
+  const ratio = Math.min(window.devicePixelRatio || 1, width >= 1200 ? 1.5 : 2);
   width = window.innerWidth;
   height = window.innerHeight;
   canvas.width = Math.floor(width * ratio);
@@ -18,10 +20,17 @@ function resize() {
   canvas.style.height = `${height}px`;
   ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
 
-  const density = prefersReducedMotion ? 12000 : 6200;
-  const starCount = Math.min(prefersReducedMotion ? 90 : 220, Math.floor((width * height) / density));
+  const desktop = width >= 1024;
+  const density = prefersReducedMotion ? 16000 : desktop ? 8800 : 6800;
+  const cap = prefersReducedMotion ? 80 : desktop ? 180 : 210;
+  const starCount = Math.min(cap, Math.floor((width * height) / density));
   stars = Array.from({ length: starCount }, () => makeStar(true));
-  comets = Array.from({ length: prefersReducedMotion ? 0 : 3 }, (_, idx) => makeComet(idx));
+  comets = Array.from({ length: prefersReducedMotion ? 0 : desktop ? 2 : 3 }, (_, idx) => makeComet(idx));
+}
+
+function scheduleResize() {
+  window.clearTimeout(resizeTimer);
+  resizeTimer = window.setTimeout(resize, 120);
 }
 
 function makeStar(randomizeY = false) {
@@ -113,6 +122,8 @@ function drawComet(comet) {
 }
 
 function frame(time) {
+  if (!running) return;
+
   ctx.clearRect(0, 0, width, height);
   drawNebula(time);
 
@@ -127,6 +138,25 @@ function frame(time) {
   }
 
   animationFrame = requestAnimationFrame(frame);
+}
+
+function startAnimation() {
+  if (running) return;
+  running = true;
+  animationFrame = requestAnimationFrame(frame);
+}
+
+function stopAnimation() {
+  running = false;
+  cancelAnimationFrame(animationFrame);
+}
+
+function handleVisibilityChange() {
+  if (document.hidden) {
+    stopAnimation();
+  } else {
+    startAnimation();
+  }
 }
 
 function setupNavigation() {
@@ -263,6 +293,7 @@ resize();
 setupNavigation();
 setupReveals();
 setupTerminalDemo();
-animationFrame = requestAnimationFrame(frame);
-window.addEventListener("resize", resize, { passive: true });
-window.addEventListener("pagehide", () => cancelAnimationFrame(animationFrame));
+startAnimation();
+window.addEventListener("resize", scheduleResize, { passive: true });
+document.addEventListener("visibilitychange", handleVisibilityChange);
+window.addEventListener("pagehide", stopAnimation);

--- a/tests/website_phase_b.rs
+++ b/tests/website_phase_b.rs
@@ -90,7 +90,7 @@ fn website_mobile_fix_prevents_fragmented_headings_and_duplicate_creator_labels(
 }
 
 #[test]
-fn site_js_implements_canvas_terminal_and_progressive_enhancement() {
+fn site_js_implements_canvas_terminal_progressive_enhancement_and_performance_guards() {
     let js = read("site.js");
     assert_contains_all(
         &js,
@@ -104,6 +104,12 @@ fn site_js_implements_canvas_terminal_and_progressive_enhancement() {
             "setupReveals",
             "IntersectionObserver",
             "prefers-reduced-motion: reduce",
+            "scheduleResize",
+            "handleVisibilityChange",
+            "document.hidden",
+            "startAnimation",
+            "stopAnimation",
+            "desktop ? 180 : 210",
         ],
     );
 }

--- a/tests/website_phase_b.rs
+++ b/tests/website_phase_b.rs
@@ -76,8 +76,8 @@ fn website_mobile_fix_prevents_fragmented_headings_and_duplicate_creator_labels(
     assert_contains_all(
         &fix_css,
         &[
-            "Creator-section cleanup",
-            "Created by Chase Bryan",
+            "Founder-section cleanup",
+            "Founder profile",
             ".profile-label,",
             ".founder-copy > .eyebrow",
             "overflow-wrap: normal",
@@ -86,7 +86,15 @@ fn website_mobile_fix_prevents_fragmented_headings_and_duplicate_creator_labels(
             "Mobile readability",
         ],
     );
-    assert_not_contains_any(&fix_css, &["Builder profile", "builder profile"]);
+    assert_not_contains_any(
+        &fix_css,
+        &[
+            "Builder profile",
+            "builder profile",
+            "Created by Chase Bryan",
+            "Creator-section cleanup",
+        ],
+    );
 }
 
 #[test]
@@ -128,7 +136,7 @@ fn assert_not_contains_any(text: &str, needles: &[&str]) {
     for needle in needles {
         assert!(
             !text.contains(needle),
-            "unexpected external dependency {needle:?}"
+            "unexpected text or dependency {needle:?}"
         );
     }
 }

--- a/tests/website_phase_b.rs
+++ b/tests/website_phase_b.rs
@@ -71,6 +71,25 @@ fn styles_cover_terminal_roadmap_mobile_and_reveal_states() {
 }
 
 #[test]
+fn website_mobile_fix_prevents_fragmented_headings_and_duplicate_creator_labels() {
+    let fix_css = read("button-fix.css");
+    assert_contains_all(
+        &fix_css,
+        &[
+            "Creator-section cleanup",
+            "Created by Chase Bryan",
+            ".profile-label,",
+            ".founder-copy > .eyebrow",
+            "overflow-wrap: normal",
+            "word-break: normal",
+            "text-wrap: balance",
+            "Mobile readability",
+        ],
+    );
+    assert_not_contains_any(&fix_css, &["Builder profile", "builder profile"]);
+}
+
+#[test]
 fn site_js_implements_canvas_terminal_and_progressive_enhancement() {
     let js = read("site.js");
     assert_contains_all(


### PR DESCRIPTION
## Summary

Fixes the website issues visible in the mobile screenshot and improves desktop browsing performance without changing the intended neon/cyberpunk color palette.

## Changes

- Keeps the cyan/neon look intact.
- Removes redundant creator-section labels by hiding the small profile label and replacing the repeated generated label with one clear `Founder profile` label.
- Ensures the section does not show illogical stacked labels like founder profile / builder profile.
- Adds mobile typography overrides so hero, section, sponsor, and creator headings do not fragment awkwardly on narrow screens.
- Tightens mobile spacing for feature, support, and roadmap cards.
- Improves desktop animation performance by capping desktop canvas detail, reducing comet count on large screens, debouncing resize work, and pausing animation when the tab is hidden.
- Keeps reduced-motion behavior intact.
- Adds regression tests for the Founder profile label, duplicate-label cleanup, mobile readability rules, and browser performance guards.

## Validation

Not run locally in this environment. Expected CI gate:

```bash
cargo fmt --all -- --check
cargo check --all-targets
cargo clippy --all-targets -- -D warnings
cargo test --all-targets
cargo audit
cargo deny check
```