### PR TITLE
Fix live Founder profile label cache issue

### DIFF
--- a/button-fix.css
+++ b/button-fix.css
@@ -52,10 +52,13 @@
   transform: translateY(1px) scale(0.99);
 }
 
-/* Founder-section cleanup: present one clear Founder profile label, not stacked role labels. */
-.profile-label,
-.founder-copy > .eyebrow {
+/* Founder-section cleanup: keep the real Founder profile label and prevent generated duplicates. */
+.profile-label {
   display: none !important;
+}
+
+.founder-copy > .eyebrow {
+  display: block !important;
 }
 
 .founder-copy h2 {
@@ -67,17 +70,8 @@
 }
 
 .founder-copy h2::before {
-  content: "Founder profile";
-  display: block;
-  margin: 0 0 12px;
-  color: var(--cyan);
-  font-family: var(--mono);
-  font-size: 0.78rem;
-  font-weight: 900;
-  letter-spacing: 0.18em;
-  line-height: 1.4;
-  text-transform: uppercase;
-  text-shadow: 0 0 18px rgba(35, 247, 255, 0.5);
+  content: none !important;
+  display: none !important;
 }
 
 /* Phase1 visual identity: the prompt cursor is intentionally blinking pink/magenta. */

--- a/index.html
+++ b/index.html
@@ -88,8 +88,8 @@
     ]
   }
   </script>
-  <link rel="stylesheet" href="./styles.css">
-  <link rel="stylesheet" href="./button-fix.css">
+  <link rel="stylesheet" href="./styles.css?v=4.0.0-stable-2">
+  <link rel="stylesheet" href="./button-fix.css?v=4.0.0-founder-profile-2">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
@@ -143,7 +143,7 @@
             <div><strong>Rust</strong><span>core language</span></div>
             <div><strong>GPL-3.0</strong><span>open source</span></div>
             <div><strong>Safe mode</strong><span>default posture</span></div>
-            <div><strong>v4 edge</strong><span>active build</span></div>
+            <div><strong>v4 stable</strong><span>current build</span></div>
           </div>
         </div>
 
@@ -363,7 +363,7 @@
     </footer>
   </header>
 
-  <script src="./button-fix.js"></script>
-  <script src="./site.js"></script>
+  <script src="./button-fix.js?v=4.0.0-stable-2"></script>
+  <script src="./site.js?v=4.0.0-stable-2"></script>
 </body>
 </html>

--- a/tests/website_phase_b.rs
+++ b/tests/website_phase_b.rs
@@ -38,9 +38,17 @@ fn homepage_preserves_project_identity_and_metadata() {
 }
 
 #[test]
-fn homepage_keeps_static_offline_friendly_dependency_posture() {
+fn homepage_keeps_static_offline_friendly_dependency_posture_and_cache_busts_assets() {
     let html = read("index.html");
-    assert_contains_all(&html, &["./styles.css", "./site.js", "./button-fix.css"]);
+    assert_contains_all(
+        &html,
+        &[
+            "./styles.css?v=4.0.0-stable-2",
+            "./button-fix.css?v=4.0.0-founder-profile-2",
+            "./button-fix.js?v=4.0.0-stable-2",
+            "./site.js?v=4.0.0-stable-2",
+        ],
+    );
     assert_not_contains_any(
         &html,
         &[
@@ -77,9 +85,11 @@ fn website_mobile_fix_prevents_fragmented_headings_and_duplicate_creator_labels(
         &fix_css,
         &[
             "Founder-section cleanup",
-            "Founder profile",
-            ".profile-label,",
+            "keep the real Founder profile label",
+            ".profile-label",
             ".founder-copy > .eyebrow",
+            "content: none !important",
+            "display: none !important",
             "overflow-wrap: normal",
             "word-break: normal",
             "text-wrap: balance",
@@ -93,6 +103,7 @@ fn website_mobile_fix_prevents_fragmented_headings_and_duplicate_creator_labels(
             "builder profile",
             "Created by Chase Bryan",
             "Creator-section cleanup",
+            "content: \"Founder profile\"",
         ],
     );
 }


### PR DESCRIPTION
## Summary

The live site was still showing a stale generated `Builder profile` label because the browser was loading an older cached `button-fix.css`.

## Fix

- Removes the generated founder heading label entirely by disabling `.founder-copy h2::before`.
- Keeps the real HTML `Founder profile` eyebrow visible.
- Keeps the avatar name label hidden so the section has one clear label only.
- Adds cache-busted asset URLs for `styles.css`, `button-fix.css`, `button-fix.js`, and `site.js`.
- Updates the hero metric from `v4 edge` to `v4 stable`.
- Adds regression tests so generated labels and stale asset URLs do not come back.

## Expected result

The founder section should show only:

```text
FOUNDER PROFILE
Chase Bryan, computer scientist and phase1 creator.
```

It should no longer show `Builder profile`.