### PR TITLE
Add inline Founder profile guard

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,20 @@
   </script>
   <link rel="stylesheet" href="./styles.css?v=4.0.0-stable-2">
   <link rel="stylesheet" href="./button-fix.css?v=4.0.0-founder-profile-2">
+  <style id="founder-profile-inline-guard">
+    #founder .profile-label {
+      display: none !important;
+    }
+
+    #founder .founder-copy > .eyebrow {
+      display: block !important;
+    }
+
+    #founder .founder-copy h2::before {
+      content: none !important;
+      display: none !important;
+    }
+  </style>
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>

--- a/tests/website_phase_b.rs
+++ b/tests/website_phase_b.rs
@@ -62,6 +62,22 @@ fn homepage_keeps_static_offline_friendly_dependency_posture_and_cache_busts_ass
 }
 
 #[test]
+fn homepage_has_inline_founder_profile_guard() {
+    let html = read("index.html");
+    assert_contains_all(
+        &html,
+        &[
+            "founder-profile-inline-guard",
+            "#founder .profile-label",
+            "#founder .founder-copy > .eyebrow",
+            "#founder .founder-copy h2::before",
+            "content: none !important",
+            "display: none !important",
+        ],
+    );
+}
+
+#[test]
 fn styles_cover_terminal_roadmap_mobile_and_reveal_states() {
     let css = read("styles.css");
     assert_contains_all(


### PR DESCRIPTION
## Summary

Adds a direct inline guard in `index.html` so the founder section cannot show the stale generated `Builder profile` line even if an old stylesheet is cached by Safari or GitHub Pages.

## Fix

- Keeps the real HTML label: `founder profile`.
- Hides the avatar/name helper label.
- Forces `#founder .founder-copy h2::before` to `content: none` and `display: none` directly in the page head.
- Adds a regression test requiring the inline guard.

## Expected result

The founder card should show only:

```text
FOUNDER PROFILE
Chase Bryan, computer scientist and phase1 creator.
```

It should not show `BUILDER PROFILE`.