### PR TITLE
Prepare website roadmap and company page direction

### DIFF
--- a/WIKI_ROADMAP.md
+++ b/WIKI_ROADMAP.md
@@ -1,105 +1,239 @@
-# Phase1 Website + Wiki Roadmap
+# phase1 Website + Wiki Roadmap
 
-This roadmap turns GitHub Pages into the main public home for Phase1 and gradually brings the existing in-system wiki into the website.
+This roadmap turns GitHub Pages into the main public home for phase1 and Bryforge.
+
+Detailed implementation plans:
+
+- [`docs/website/NEXT_ROADMAP_IMPLEMENTATION.md`](docs/website/NEXT_ROADMAP_IMPLEMENTATION.md)
+- [`docs/website/PROJECT_AND_COMPANY_PAGES.md`](docs/website/PROJECT_AND_COMPANY_PAGES.md)
 
 ## Goal
 
-Make `https://bryforge.github.io/phase1/` the main Phase1 homepage:
+Make `https://bryforge.github.io/phase1/` the public front door for:
 
-- minimalist dark-space rainbow landing page
-- Phase1 logo and operator-console identity
-- founder profile for Chase Bryan
-- Bryforge startup software development company profile
-- sponsor section with Buy Me a Coffee support link
-- direct links to GitHub, install steps, docs, and releases
-- web version of the Phase1 wiki
-- command index and tutorial hub
+1. phase1, the Rust virtual OS console and advanced operator kernel.
+2. Bryforge, the startup software development company behind phase1.
+3. Chase Bryan, founder, computer scientist, and developer.
+
+The site should help visitors understand the project, try it quickly, read the docs, follow the roadmap, and support the work.
+
+## Current stable baseline
+
+| Track | Status |
+| --- | --- |
+| Stable release | `v4.0.0` |
+| Previous stable | `v3.10.9` |
+| Compatibility base | `v3.6.0` |
+| Website state | Phase A complete, Phase B started |
+| Base1 state | secure host foundation added |
+
+## Clear separation of pages
+
+The next website implementation should separate product and company messaging.
+
+| Page | Purpose |
+| --- | --- |
+| `index.html` | dramatic homepage and routing surface |
+| `project.html` | phase1 product page |
+| `company.html` | Bryforge company page |
+| `roadmap.html` | full public roadmap |
+| `support.html` | support and sponsorship page |
+| `wiki/index.html` | docs hub |
 
 ## Phase A — Launch homepage
 
-Status: started.
+Status: complete.
 
-- Add animated GitHub Pages homepage
-- Use a dark space canvas background with live stars/comets
-- Use moving rainbow gradients, orbital rings, and neon glass panels
-- Use the Phase1 logo on the homepage
-- Add Chase Bryan founder/computer scientist section
-- Add Bryforge startup software development company section
-- Add Buy Me a Coffee sponsor call-to-action
-- Link the website from the root `README.md`
-- Add a GitHub Pages deploy workflow
+Delivered:
 
-## Phase B — Bring existing wiki content into the site
+- animated GitHub Pages homepage
+- dark space canvas background
+- rainbow gradients, orbital rings, and neon glass panels
+- phase1 logo on homepage
+- founder profile for Chase Bryan
+- Bryforge startup software company teaser
+- Buy Me a Coffee sponsor call-to-action
+- GitHub, docs, and wiki links
+- SEO and social metadata
+- interactive browser terminal demo
+- mobile readability fixes
+- desktop animation performance guards
+- stable v4.0.0 release metadata
+- single logical Founder profile label
 
-Convert the current `docs/wiki/` content into web pages.
+## Phase B — Product and company page foundation
 
-Initial pages:
+Status: next implementation.
 
-- Quick Start
-- Boot Profiles
-- Command Map
-- Files and VFS
-- Browser and Network Safety
-- Language Runtime Support
-- Updates
-- Troubleshooting
-- Tutorials
-- Sponsorship and Bryforge
+Purpose:
 
-Recommended layout:
+Build the first deeper public pages so the site is no longer only a homepage.
+
+### PR B1: phase1 project page
+
+Add:
+
+```text
+project.html
+```
+
+Page sections:
+
+- phase1 product hero
+- system map
+- safety model
+- quick start
+- stable release status
+- Base1 bridge
+- contribution path
+
+Definition of done:
+
+- linked from homepage nav/footer
+- explains phase1 clearly without overclaiming
+- includes clone/run command
+- includes safe mode and host trust explanation
+- links to Base1 docs
+- includes tests
+
+### PR B2: Bryforge company page
+
+Add:
+
+```text
+company.html
+```
+
+Page sections:
+
+- Bryforge company hero
+- founder statement
+- what Bryforge builds
+- company principles
+- flagship project: phase1
+- support/contact CTAs
+
+Definition of done:
+
+- linked from homepage nav/footer
+- clearly separates Bryforge from phase1
+- avoids duplicate founder/builder labels
+- includes tests
+
+### PR B3: Roadmap page
+
+Add:
+
+```text
+roadmap.html
+```
+
+Page lanes:
+
+- website and docs
+- phase1 product/runtime
+- Base1 secure host foundation
+- Bryforge company development
+
+Definition of done:
+
+- linked from homepage roadmap preview
+- shows stable v4.0.0 status
+- shows Phase A through Phase E website direction
+- shows product/Base1/company lanes
+- includes tests
+
+## Phase C — Docs hub and navigation
+
+Add a real docs surface under `wiki/`.
+
+Recommended pages:
 
 ```text
 wiki/
   index.html
   quick-start.html
-  boot.html
   commands.html
-  files.html
-  browser.html
-  lang.html
-  updates.html
-  trouble.html
+  security.html
+  base1.html
+  releases.html
   tutorials.html
-  sponsor.html
-  bryforge.html
 ```
 
-## Phase C — Add docs navigation
+Features:
 
-- Add persistent docs sidebar
-- Add mobile docs drawer
-- Add page-local table of contents
-- Add previous/next links
-- Add keyboard-friendly search
-- Add command metadata cards for every Phase1 command
-- Add support links in the docs footer
+- docs cards
+- mobile docs drawer
+- page-local table of contents
+- previous/next links
+- keyboard-friendly search later
+- command metadata cards later
 
-## Phase D — Add visual demos
+## Phase D — Visual demos and release storytelling
 
-- Add screenshots or terminal captures
-- Add animated command previews
-- Add boot-profile selector preview
-- Add storage/Git/Rust workflow preview
-- Add safe-mode vs trusted-host explanation
-- Add founder/build-log updates for major milestones
+Add richer proof and demo material.
 
-## Phase E — Make the website the public front door
+- screenshots or terminal captures
+- animated command previews
+- boot-profile selector preview
+- storage/Git/Rust workflow preview
+- safe-mode versus trusted-host explanation
+- release notes and migration guides
+- stable/edge version cards if edge resumes after v4 stable
 
-- Keep README focused on quick start and link to the website for full docs
-- Add release notes and migration guides
-- Add stable/edge version cards
-- Add contributor guide
-- Add roadmap and quality score sections
-- Add links to security policy and audit notes
-- Keep the sponsor and Bryforge company sections visible from the homepage
+## Phase E — Full public front door
+
+Make the website the primary public destination.
+
+- keep README quick and practical
+- keep full docs on the website
+- add contributor guide
+- add quality score section
+- add security policy and audit notes links
+- keep support and Bryforge company sections visible
+- add future Bryforge product portfolio when ready
 
 ## Design principles
 
-- Dark background first
-- Rainbow motion, but accessible reduced-motion support
-- Fast static files only
-- No external JavaScript dependencies
-- Mobile-first layout
-- GitHub Pages compatible
-- Docs should be readable even if animations are disabled
-- Sponsor content should support the project without distracting from technical docs
+- Dark background first.
+- Neon/rainbow identity, but readable before flashy.
+- Mobile-first layout.
+- Static files only.
+- No external JavaScript dependencies.
+- No tracking scripts.
+- Reduced-motion support.
+- Docs must be readable without animation.
+- Company pages should feel calmer than the homepage.
+- Avoid duplicate labels such as `Founder profile` plus `Builder profile`.
+- Keep product, company, and founder identities distinct.
+
+## Quality gate
+
+Every website implementation PR should run:
+
+```bash
+cargo fmt --all -- --check
+cargo check --all-targets
+cargo clippy --all-targets -- -D warnings
+cargo test --all-targets
+cargo audit
+cargo deny check
+```
+
+Every website implementation PR should add or update tests for:
+
+- required page exists
+- homepage/footer links exist
+- no external CDN dependency
+- stable release metadata stays current
+- founder labels stay logical
+- lowercase `phase1` product naming is preserved
+- Bryforge company page remains distinct from phase1 product page
+
+## Immediate next action
+
+Start with **PR B1: phase1 project page**.
+
+Reason:
+
+The product page clarifies what phase1 is before the company page expands Bryforge. After that, build the company page so Bryforge has a professional identity separate from the phase1 technical pitch.

--- a/docs/website/NEXT_ROADMAP_IMPLEMENTATION.md
+++ b/docs/website/NEXT_ROADMAP_IMPLEMENTATION.md
@@ -1,0 +1,249 @@
+# Next Website Roadmap Implementation
+
+Status: prepared for the next design pass after the v4.0.0 stable release.
+
+This document defines the next practical website implementation direction for `https://bryforge.github.io/phase1/`.
+
+## Objective
+
+Turn the website from a strong landing page into a structured public front door for phase1 and Bryforge.
+
+The next implementation should separate three visitor needs:
+
+1. Understand what phase1 is.
+2. Learn how to run, use, and trust phase1.
+3. Understand Bryforge as the builder behind phase1 and future products.
+
+## Current foundation
+
+The current site already has:
+
+- Neo Tokyo / cyberpunk visual identity.
+- phase1 hero section.
+- interactive browser terminal demo.
+- feature cards.
+- founder profile.
+- Bryforge company block.
+- sponsor section.
+- website roadmap timeline.
+- static/offline-friendly asset posture.
+- mobile readability and desktop animation performance guards.
+- stable v4.0.0 release metadata.
+
+## Next implementation theme
+
+Use a two-track site model:
+
+```text
+phase1 product track
+Bryforge company track
+```
+
+The product track should answer:
+
+- What is phase1?
+- Why is it useful?
+- How do I install it?
+- How do I use it?
+- What is safe by default?
+- What is simulated versus host-backed?
+- What is Base1 and how does it protect the host?
+- What is the roadmap?
+
+The company track should answer:
+
+- What is Bryforge?
+- Who is Chase Bryan?
+- What does Bryforge build?
+- What principles guide the company?
+- How can people support or contact the project?
+
+## Recommended information architecture
+
+```text
+/
+  index.html                 homepage: product overview + founder + company teaser
+  project.html               phase1 product page
+  company.html               Bryforge company page
+  roadmap.html               visual roadmap and release direction
+  support.html               sponsor/support page
+
+/wiki/
+  index.html                 docs hub
+  quick-start.html           install and first run
+  commands.html              command map
+  security.html              security model and safe-mode behavior
+  base1.html                 Base1 secure-host overview
+  releases.html              v4 stable, previous stable, validation gate
+  tutorials.html             guided learning paths
+```
+
+## Page priority
+
+### Priority 1: Project page
+
+Build `project.html` first.
+
+Purpose:
+
+- Explain phase1 as a Rust virtual OS console.
+- Show the feature stack without overwhelming new users.
+- Explain safe mode, host trust, VFS, audit log, browser, wiki, and runtime roadmap.
+- Link to GitHub quick start and docs.
+
+Sections:
+
+1. Product hero: `phase1 // Rust virtual OS console`.
+2. Operator promise: secure, private, powerful, open.
+3. System map: kernel, VFS, process table, audit log, guarded browser, wiki, runtime support.
+4. Safety model: safe by default, explicit host trust, no secrets required.
+5. Quick start: clone, run, first commands.
+6. Base1 connection: secure host foundation for Raspberry Pi and ThinkPad X200.
+7. Roadmap preview: stable v4.0.0 now, next docs/runtime/Base1 milestones.
+8. Calls to action: Star GitHub, open docs, support Bryforge.
+
+### Priority 2: Company page
+
+Build `company.html` second.
+
+Purpose:
+
+- Make Bryforge feel real, focused, and trustworthy.
+- Keep founder messaging clear without repeating the founder card in awkward ways.
+- Present Bryforge as the company behind phase1 and future software products.
+
+Sections:
+
+1. Company hero: `Bryforge // software forged for builders`.
+2. Founder statement: Chase Bryan, computer scientist and developer.
+3. Mission: secure, polished, developer-first software.
+4. Current flagship: phase1.
+5. Future direction: Base1, dev tools, secure systems, automation, custom software products.
+6. Principles: security, usefulness, transparency, speed, craftsmanship.
+7. Support/contact CTA: GitHub, Buy Me a Coffee, project repository.
+
+### Priority 3: Roadmap page
+
+Build `roadmap.html` third.
+
+Purpose:
+
+- Turn the current timeline into a full public roadmap.
+- Give contributors and supporters a clear view of what comes next.
+
+Sections:
+
+1. Stable release status.
+2. Website roadmap: Phase A through Phase E.
+3. Product roadmap: terminal UX, docs/wiki, Git/storage, runtime support, Base1.
+4. Security roadmap: audit posture, dependency policy, safe host bridge, Base1 hardening.
+5. Contributor path: good first issues, docs tasks, test tasks, screenshots.
+
+## Visual direction
+
+Keep the existing cyberpunk look, but make page-level navigation calmer than the homepage.
+
+Rules:
+
+- Homepage can be dramatic.
+- Docs and company pages should be calmer, readable, and faster.
+- Use the same dark glass/neon language, but reduce motion density on text-heavy pages.
+- Avoid duplicate labels such as founder profile plus builder profile.
+- Use one page title, one section label, and one clear user action per block.
+
+## Component direction
+
+Reuse these components:
+
+- `glass-panel`
+- `section-heading`
+- `feature-card`
+- `timeline`
+- `button`
+- `terminal`
+- `metric-strip`
+
+Add these components next:
+
+```text
+.page-hero
+.page-nav
+.proof-grid
+.system-map
+.principle-card
+.release-card
+.cta-band
+.docs-shell
+.docs-sidebar
+.docs-card
+```
+
+## Performance requirements
+
+All new pages must preserve the current static/security posture:
+
+- no external JavaScript dependencies
+- no CDN framework dependency
+- no tracking scripts
+- no heavy third-party fonts
+- reduced-motion support
+- readable without canvas animation
+- GitHub Pages compatible
+- mobile-first layout
+- desktop animation should pause when hidden
+
+## Quality gate
+
+Every implementation PR should include tests that assert:
+
+- the new page exists
+- the page links from the homepage or footer
+- phase1 naming remains lowercase where product name is official
+- Bryforge page has company wording
+- founder section has one logical label only
+- no stale `Builder profile` label
+- no external CDN dependency
+- stable release metadata remains v4.0.0
+
+Suggested command gate:
+
+```bash
+cargo fmt --all -- --check
+cargo check --all-targets
+cargo clippy --all-targets -- -D warnings
+cargo test --all-targets
+cargo audit
+cargo deny check
+```
+
+## Recommended PR sequence
+
+### PR A: Project page foundation
+
+- Add `project.html`.
+- Add homepage/footer link to `project.html`.
+- Add tests.
+
+### PR B: Company page foundation
+
+- Add `company.html`.
+- Move/expand Bryforge messaging into company page.
+- Keep homepage company block as a teaser only.
+- Add tests.
+
+### PR C: Roadmap page foundation
+
+- Add `roadmap.html`.
+- Convert current roadmap timeline into a full page.
+- Add product/company roadmap split.
+- Add tests.
+
+### PR D: Wiki hub expansion
+
+- Add or improve `wiki/index.html`.
+- Add docs cards for Quick Start, Security, Base1, Releases, Tutorials.
+- Add tests.
+
+## Decision
+
+The next implementation should start with `project.html`, because it clarifies the product before expanding the company story. The company page should follow immediately after so Bryforge has a professional public identity separate from the phase1 technical pitch.

--- a/docs/website/PROJECT_AND_COMPANY_PAGES.md
+++ b/docs/website/PROJECT_AND_COMPANY_PAGES.md
@@ -38,7 +38,7 @@ Homepage sections should stay concise:
 7. Support CTA.
 8. Footer navigation.
 
-Avoid repeating the same role label twice. For example, do not show both `Founder profile` and `Builder profile` in the founder card.
+Avoid duplicate labels such as founder profile plus builder profile. Do not show both `Founder profile` and `Builder profile` in the founder card.
 
 ## phase1 project page
 

--- a/docs/website/PROJECT_AND_COMPANY_PAGES.md
+++ b/docs/website/PROJECT_AND_COMPANY_PAGES.md
@@ -1,0 +1,386 @@
+# Project and Company Pages Direction Plan
+
+This document defines the direction for the next phase1 project pages and Bryforge company pages.
+
+## Core distinction
+
+Do not let the website confuse these two identities:
+
+| Identity | Meaning | Primary page |
+| --- | --- | --- |
+| phase1 | The Rust virtual OS console and advanced operator kernel | `project.html` |
+| Bryforge | The startup software development company behind phase1 | `company.html` |
+| Chase Bryan | Founder, computer scientist, and developer | founder section + company page |
+
+The homepage should introduce all three, but each deeper page should have one clear focus.
+
+## Homepage role
+
+The homepage should remain a dramatic front door.
+
+It should answer quickly:
+
+- What is phase1?
+- Why should I care?
+- How do I try it?
+- Who built it?
+- What is Bryforge?
+- Where do I go next?
+
+Homepage sections should stay concise:
+
+1. Hero.
+2. Terminal demo.
+3. Feature cards.
+4. Roadmap preview.
+5. Founder profile.
+6. Bryforge teaser.
+7. Support CTA.
+8. Footer navigation.
+
+Avoid repeating the same role label twice. For example, do not show both `Founder profile` and `Builder profile` in the founder card.
+
+## phase1 project page
+
+Filename:
+
+```text
+project.html
+```
+
+Primary message:
+
+```text
+phase1 is a Rust-built virtual OS console for operators who want control.
+```
+
+Audience:
+
+- developers
+- cybersecurity learners
+- OS/systems learners
+- contributors
+- supporters who want to understand the product
+
+Page sections:
+
+### 1. Product hero
+
+Recommended copy:
+
+```text
+phase1 // Rust virtual OS console
+A terminal-first advanced operator kernel with a simulated kernel, VFS, process table, audit log, guarded browser, in-system wiki, and safe-by-default shell.
+```
+
+Primary CTA:
+
+```text
+Clone and run
+```
+
+Secondary CTA:
+
+```text
+Open docs
+```
+
+### 2. System map
+
+Show the system as a clear layered map:
+
+```text
+operator shell
+command metadata
+safe mode + host trust gates
+virtual filesystem
+process table + audit log
+guarded browser + network inspection
+language/runtime roadmap
+Base1 secure host foundation
+```
+
+### 3. Security model
+
+Explain:
+
+- safe mode is default
+- host-backed tools are explicit
+- no secrets are needed for normal use
+- audit records explain actions
+- Base1 protects the host below phase1
+
+### 4. Quick start
+
+Use one short block:
+
+```bash
+git clone https://github.com/Bryforge/phase1.git
+cd phase1
+cargo run
+```
+
+Then show first commands:
+
+```text
+help
+version
+security
+wiki
+sysinfo
+roadmap
+```
+
+### 5. Stable release status
+
+Show:
+
+```text
+Stable: v4.0.0
+Previous stable: v3.10.9
+Compatibility base: v3.6.0
+```
+
+### 6. Base1 bridge
+
+Explain Base1 as:
+
+```text
+Base1 is the secure hardware host foundation planned for Raspberry Pi and ThinkPad X200-class systems. Its job is to keep the host bootable, recoverable, and protected even if phase1 is damaged, reset, or removed.
+```
+
+### 7. Contribution path
+
+Show simple paths:
+
+- try the system
+- improve docs
+- test commands
+- review security model
+- contribute examples
+- support the roadmap
+
+## Bryforge company page
+
+Filename:
+
+```text
+company.html
+```
+
+Primary message:
+
+```text
+Bryforge is a startup software development company building secure, polished, developer-first systems and tools.
+```
+
+Audience:
+
+- potential clients
+- contributors
+- sponsors
+- recruiters/collaborators
+- people who want to know what Bryforge is
+
+Page sections:
+
+### 1. Company hero
+
+Recommended copy:
+
+```text
+Bryforge // software forged for builders
+A startup software development company founded by Chase Bryan, focused on secure systems, terminal-first tools, developer products, automation, and practical software that gives people more control.
+```
+
+### 2. Founder statement
+
+Keep wording direct:
+
+```text
+Founded by Chase Bryan, a computer scientist and developer building phase1 as Bryforge's flagship research-and-build project.
+```
+
+Do not use multiple competing labels. One section label is enough:
+
+```text
+Founder profile
+```
+
+### 3. What Bryforge builds
+
+Current flagship:
+
+- phase1
+- Base1 foundation
+
+Future categories:
+
+- secure developer tools
+- terminal-first applications
+- automation systems
+- systems education tools
+- custom software products
+
+### 4. Principles
+
+Recommended company principles:
+
+| Principle | Meaning |
+| --- | --- |
+| Security first | Software should avoid unnecessary trust and secrets |
+| Operator control | Users should understand what the system is doing |
+| Craftsmanship | Interfaces should feel polished, not thrown together |
+| Open learning | Documentation should teach, not obscure |
+| Practical ambition | Build bold systems in realistic, testable steps |
+
+### 5. Support and contact
+
+Use CTAs:
+
+- View phase1 on GitHub
+- Support on Buy Me a Coffee
+- Follow the roadmap
+
+## Roadmap page
+
+Filename:
+
+```text
+roadmap.html
+```
+
+Purpose:
+
+The roadmap page should show the full public direction of phase1 and Bryforge.
+
+Separate it into four lanes:
+
+1. Website and docs.
+2. phase1 product/runtime.
+3. Base1 secure host foundation.
+4. Bryforge company development.
+
+### Website/docs lane
+
+- Phase A: homepage launched
+- Phase B: wiki/docs hub
+- Phase C: docs navigation/search
+- Phase D: visual demos/releases
+- Phase E: public front door
+
+### phase1 product lane
+
+- v4.0.0 stable baseline
+- terminal UX improvements
+- storage/Git tooling
+- language/runtime support
+- security/audit improvements
+- examples and tutorials
+
+### Base1 lane
+
+- read-only preflight
+- host profile hardening
+- Raspberry Pi support
+- X200 support
+- recovery workflow
+- installer only after repeated safety checks
+
+### Bryforge lane
+
+- company page
+- support page
+- project portfolio
+- service/product direction
+- public credibility assets
+
+## Support page
+
+Filename:
+
+```text
+support.html
+```
+
+Purpose:
+
+Make sponsorship clear without overwhelming technical docs.
+
+Sections:
+
+1. Why support phase1.
+2. What support funds.
+3. Current roadmap priorities.
+4. Buy Me a Coffee CTA.
+5. GitHub star/watch/fork CTA.
+
+## Copy rules
+
+Use lowercase `phase1` as the product name in most UI text.
+
+Use `Bryforge` for the company.
+
+Use `Chase Bryan` for the founder.
+
+Avoid vague claims like:
+
+- revolutionary
+- unbreakable
+- military grade
+- impossible to compromise
+
+Prefer grounded claims:
+
+- safe-by-default
+- guarded host tools
+- simulated kernel
+- auditable behavior
+- tested release gate
+- static/offline-friendly website
+
+## Design rules
+
+- Keep neon, glass, space, and terminal identity.
+- Use less animation on docs/company pages than the homepage.
+- Avoid cramped mobile cards.
+- Avoid huge text that breaks words awkwardly.
+- Keep CTAs visible but not spammy.
+- Use one role label per person/company section.
+- Keep founder content professional and not repetitive.
+
+## Implementation checklist
+
+For each new page:
+
+- Add semantic HTML.
+- Add homepage/footer navigation.
+- Add mobile-responsive layout.
+- Add reduced-motion-safe effects only.
+- Add tests for required text and links.
+- Verify no external CDN dependencies.
+- Verify stable release metadata is consistent.
+- Verify no `Builder profile` label appears.
+
+## Recommended next issue list
+
+1. Create `project.html` phase1 product page.
+2. Create `company.html` Bryforge company page.
+3. Create `roadmap.html` full roadmap page.
+4. Create `support.html` support page.
+5. Expand `wiki/index.html` into a docs hub.
+6. Add visual command/system map components.
+7. Add screenshots/terminal captures after the layout is stable.
+
+## Definition of done for the next design implementation
+
+The next design implementation is complete when:
+
+- homepage links to product/company/roadmap pages
+- `project.html` clearly explains phase1
+- `company.html` clearly explains Bryforge
+- roadmap direction is visible and not buried in README text
+- mobile view is readable
+- desktop animation remains smooth
+- tests pass
+- no duplicate founder/builder labels appear

--- a/tests/website_direction_plan.rs
+++ b/tests/website_direction_plan.rs
@@ -1,0 +1,81 @@
+use std::fs;
+
+#[test]
+fn roadmap_points_to_next_design_implementation_docs() {
+    let roadmap = read("WIKI_ROADMAP.md");
+    assert_contains_all(
+        &roadmap,
+        &[
+            "docs/website/NEXT_ROADMAP_IMPLEMENTATION.md",
+            "docs/website/PROJECT_AND_COMPANY_PAGES.md",
+            "project.html",
+            "company.html",
+            "roadmap.html",
+            "support.html",
+            "Phase B — Product and company page foundation",
+            "Start with **PR B1: phase1 project page**",
+        ],
+    );
+}
+
+#[test]
+fn next_roadmap_implementation_has_clear_pr_sequence() {
+    let plan = read("docs/website/NEXT_ROADMAP_IMPLEMENTATION.md");
+    assert_contains_all(
+        &plan,
+        &[
+            "phase1 product track",
+            "Bryforge company track",
+            "PR A: Project page foundation",
+            "PR B: Company page foundation",
+            "PR C: Roadmap page foundation",
+            "PR D: Wiki hub expansion",
+            "The next implementation should start with `project.html`",
+        ],
+    );
+}
+
+#[test]
+fn project_and_company_pages_stay_distinct() {
+    let plan = read("docs/website/PROJECT_AND_COMPANY_PAGES.md");
+    assert_contains_all(
+        &plan,
+        &[
+            "phase1 | The Rust virtual OS console",
+            "Bryforge | The startup software development company behind phase1",
+            "Chase Bryan | Founder, computer scientist, and developer",
+            "project.html",
+            "company.html",
+            "Do not use multiple competing labels",
+            "Avoid duplicate labels such as founder profile plus builder profile",
+            "no `Builder profile` label appears",
+        ],
+    );
+}
+
+#[test]
+fn direction_plan_preserves_static_security_posture() {
+    for path in [
+        "WIKI_ROADMAP.md",
+        "docs/website/NEXT_ROADMAP_IMPLEMENTATION.md",
+        "docs/website/PROJECT_AND_COMPANY_PAGES.md",
+    ] {
+        let text = read(path);
+        assert!(
+            text.contains("No external JavaScript dependencies")
+                || text.contains("no external CDN dependency")
+                || text.contains("no external CDN dependencies"),
+            "{path} should preserve the static/offline-friendly dependency posture"
+        );
+    }
+}
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains_all(text: &str, needles: &[&str]) {
+    for needle in needles {
+        assert!(text.contains(needle), "missing {needle:?}");
+    }
+}


### PR DESCRIPTION
## Summary

Prepares the next roadmap/design implementation direction for the phase1 website and Bryforge company pages.

## Adds

- `docs/website/NEXT_ROADMAP_IMPLEMENTATION.md`
  - defines the next implementation theme,
  - separates the phase1 product track from the Bryforge company track,
  - recommends page architecture,
  - prioritizes project/company/roadmap/support/docs pages,
  - defines performance, quality, and PR sequencing requirements.

- `docs/website/PROJECT_AND_COMPANY_PAGES.md`
  - clearly separates phase1, Bryforge, and Chase Bryan identities,
  - defines `project.html` direction,
  - defines `company.html` direction,
  - defines roadmap/support page direction,
  - documents copy and design rules,
  - explicitly prevents duplicate labels like Founder profile plus Builder profile.

- `WIKI_ROADMAP.md`
  - updates the public roadmap around the v4.0.0 stable baseline,
  - defines Phase B as product/company page foundation,
  - sets the immediate next action as `PR B1: phase1 project page`.

- `tests/website_direction_plan.rs`
  - protects the direction docs and project/company split from accidental drift.

## Clear next implementation sequence

1. Build `project.html` for the phase1 product page.
2. Build `company.html` for the Bryforge company page.
3. Build `roadmap.html` for the full roadmap.
4. Build `support.html` for sponsorship/support.
5. Expand `wiki/index.html` into a real docs hub.

## Validation

Not run locally in this environment. Expected CI gate:

```bash
cargo fmt --all -- --check
cargo check --all-targets
cargo clippy --all-targets -- -D warnings
cargo test --all-targets
cargo audit
cargo deny check
```