### PR TITLE
Add Phase1 Terminal for Linux and macOS

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --all-targets -- -D warnings
 
+      - name: Validate Phase1 Terminal scripts
+        run: sh scripts/test-phase1-terminal.sh
+
       - name: Run tests
         run: cargo test --all-targets
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -7,6 +7,9 @@ on:
     branches: ["*"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: rust-ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
   ·
   <a href="base1/README.md">Base1 secure host foundation</a>
   ·
+  <a href="QUALITY.md">Quality system</a>
+  ·
   <a href="TERMINAL.md">Phase1 Terminal</a>
 </p>
 
@@ -45,6 +47,8 @@ It uses a dark live-space background, moving rainbow visuals, the Phase1 neon lo
 | Previous stable | `v3.10.9` | Previous stable reference line |
 | Compatibility base | `v3.6.0` | Historical comparison base |
 | Base1 | `foundation` | Secure host design for Raspberry Pi and X200 targets |
+| Quality | `managed` | Scorecard, gates, scripts, and CI workflow |
+| Phase1 Terminal | `advanced` | Linux/macOS launcher, profiles, colors, diagnostics, tests |
 
 The package version is the booted Phase1 version. Boot, ready line, `/proc/version`, dashboard, audit boot record, `/home/readme.txt`, and shutdown dynamically reflect `CARGO_PKG_VERSION`.
 
@@ -71,7 +75,7 @@ roadmap
 
 ## Phase1 Terminal
 
-Phase1 Terminal is the dedicated launcher/profile layer for Linux and macOS. It installs the `phase1-terminal` command, loads Phase1-specific defaults, discovers the Phase1 checkout or binary, and can add native Linux/macOS launch integrations.
+Phase1 Terminal is the dedicated launcher/profile/color layer for Linux and macOS. It installs the `phase1-terminal` command, loads Phase1-specific defaults, discovers the Phase1 checkout or binary, previews palettes, exports color/theme settings, and can add native Linux/macOS launch integrations.
 
 Install on Linux:
 
@@ -88,11 +92,37 @@ sh scripts/install-phase1-terminal-macos.sh
 Then run:
 
 ```bash
-phase1-terminal doctor
+phase1-terminal doctor --verbose
+phase1-terminal theme preview all
+phase1-terminal selftest
 phase1-terminal
 ```
 
-Full guide: [`TERMINAL.md`](TERMINAL.md).
+Full guide: [`TERMINAL.md`](TERMINAL.md). Test cases: [`TERMINAL_TEST_CASES.md`](TERMINAL_TEST_CASES.md).
+
+## Quality management
+
+Phase1 includes a repeatable quality management system with policy, scorecard, validation scripts, CI checks, and tests.
+
+Start here:
+
+- [`QUALITY.md`](QUALITY.md) - quality policy, gates, score model, and ownership areas.
+- [`QUALITY_SCORECARD.md`](QUALITY_SCORECARD.md) - score interpretation and scoring areas.
+- [`scripts/quality-score.sh`](scripts/quality-score.sh) - deterministic repository health score.
+- [`scripts/quality-check.sh`](scripts/quality-check.sh) - quick/full quality gates.
+
+Run:
+
+```bash
+sh scripts/quality-score.sh
+sh scripts/quality-check.sh quick
+```
+
+Before release:
+
+```bash
+sh scripts/quality-check.sh full
+```
 
 ## Base1 secure host foundation
 
@@ -160,8 +190,10 @@ Use `:help` inside `avim` for movement, edit, search, save, and quit commands.
 - Improve Linux color fallback for older systems such as ThinkPad X200 running Trisquel.
 - Improve Raspberry Pi 5 default OS text and color compatibility.
 - Add Base1 compatibility around secure Raspberry Pi and X200 host profiles.
+- Add Phase1 Terminal as the Linux/macOS launcher, profile, color, diagnostics, and test layer.
 - Improve the public website with clearer creator labeling, mobile readability, and desktop animation performance guards.
 - Harden `phase1-storage` output redaction for common secret and URL-credential patterns.
+- Manage quality through repeatable scripts, scorecards, tests, and CI.
 
 ## Run checks
 
@@ -175,6 +207,12 @@ cargo install cargo-deny --locked
 Then run the full quality gate:
 
 ```bash
+sh scripts/quality-check.sh full
+```
+
+The Rust-specific gate remains:
+
+```bash
 cargo fmt --all -- --check
 cargo check --all-targets
 cargo clippy --all-targets -- -D warnings
@@ -183,9 +221,9 @@ cargo audit
 cargo deny check
 ```
 
-`cargo test --all-targets` includes unit tests plus scripted smoke tests for the main Phase1 shell, the guarded `phase1-storage` helper, the website, release metadata, and the Base1 secure host foundation files.
+`cargo test --all-targets` includes unit tests plus scripted smoke tests for the main Phase1 shell, the guarded `phase1-storage` helper, the website, release metadata, quality system files, Phase1 Terminal, and the Base1 secure host foundation files.
 
-CI runs the same quality gate on pull requests, `master`, `main`, `release/**`, and manual dispatch. It also installs and runs RustSec advisory checks and dependency policy validation.
+CI runs Rust validation, security validation, CodeQL, and the quality management workflow on pull requests and branch pushes.
 
 ## Enable Python, browser, network inspection, and runtimes
 
@@ -218,6 +256,8 @@ The public website/wiki roadmap lives in [`WIKI_ROADMAP.md`](WIKI_ROADMAP.md).
 Phase1 is an educational simulator. It should never need your GitHub password, personal access token, SSH private key, browser cookies, Apple ID, email password, or recovery codes.
 
 Host-backed commands are explicit and guarded. Runtime files such as `phase1.state`, `phase1.history`, and `phase1.log` are local operational artifacts.
+
+Phase1 Terminal preserves safe defaults, uses allowlisted config mutation, and supports mono color fallback.
 
 Base1 is a secure host foundation, not a destructive installer. Its first tooling is intentionally read-only and compatibility-focused. Base1 security claims should remain conservative until backed by repeatable builds, audits, and hardware validation.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
   <a href="WIKI_ROADMAP.md">Website + wiki roadmap</a>
   ·
   <a href="base1/README.md">Base1 secure host foundation</a>
+  ·
+  <a href="TERMINAL.md">Phase1 Terminal</a>
 </p>
 
 ![Stable](https://img.shields.io/badge/stable-v4.0.0-39ff88) ![Previous Stable](https://img.shields.io/badge/previous%20stable-v3.10.9-7f8cff) ![Rust](https://img.shields.io/badge/language-Rust-ff8a00) ![Security](https://img.shields.io/badge/default-safe%20mode%20on-39ff88) ![Base1](https://img.shields.io/badge/base1-secure%20host%20foundation-8a5cff)
@@ -66,6 +68,31 @@ security
 sysinfo
 roadmap
 ```
+
+## Phase1 Terminal
+
+Phase1 Terminal is the dedicated launcher/profile layer for Linux and macOS. It installs the `phase1-terminal` command, loads Phase1-specific defaults, discovers the Phase1 checkout or binary, and can add native Linux/macOS launch integrations.
+
+Install on Linux:
+
+```bash
+sh scripts/install-phase1-terminal-linux.sh
+```
+
+Install on macOS:
+
+```bash
+sh scripts/install-phase1-terminal-macos.sh
+```
+
+Then run:
+
+```bash
+phase1-terminal doctor
+phase1-terminal
+```
+
+Full guide: [`TERMINAL.md`](TERMINAL.md).
 
 ## Base1 secure host foundation
 

--- a/TERMINAL.md
+++ b/TERMINAL.md
@@ -10,6 +10,8 @@ phase1-terminal
 
 A shorter `terminal` alias can also be installed when safe.
 
+Roadmap: [`TERMINAL_ROADMAP.md`](TERMINAL_ROADMAP.md).
+
 ## Name
 
 The project name is **Phase1 Terminal**. The command is `phase1-terminal` because `terminal` can conflict with existing system tools, shell aliases, or user scripts. The installer can create `terminal` as an alias only when requested or when no existing command is found.
@@ -154,6 +156,12 @@ If no built binary exists, Phase1 Terminal falls back to:
 ```bash
 cargo run --
 ```
+
+## Roadmap
+
+The terminal roadmap covers installer hardening, profile UX, session management, Gina-aware workflows, packaging, and future native terminal exploration.
+
+Read: [`TERMINAL_ROADMAP.md`](TERMINAL_ROADMAP.md).
 
 ## Safety
 

--- a/TERMINAL.md
+++ b/TERMINAL.md
@@ -1,0 +1,167 @@
+# Phase1 Terminal
+
+Phase1 Terminal is the dedicated terminal launcher and profile layer for Phase1 on Linux and macOS.
+
+The installed command is:
+
+```bash
+phase1-terminal
+```
+
+A shorter `terminal` alias can also be installed when safe.
+
+## Name
+
+The project name is **Phase1 Terminal**. The command is `phase1-terminal` because `terminal` can conflict with existing system tools, shell aliases, or user scripts. The installer can create `terminal` as an alias only when requested or when no existing command is found.
+
+## What it does
+
+Phase1 Terminal is not a full graphical terminal emulator. It is a Phase1-specific terminal launcher that:
+
+- loads a Phase1 terminal configuration file
+- sets Phase1-friendly environment defaults
+- locates a Phase1 checkout or installed binary
+- prefers an existing built binary
+- falls back to `cargo run`
+- sets the terminal title to `Phase1 Terminal`
+- provides `doctor` and `env` diagnostics
+- installs Linux and macOS launch integrations
+
+## Install on Linux
+
+From the Phase1 repository root:
+
+```bash
+sh scripts/install-phase1-terminal-linux.sh
+```
+
+Then ensure `~/.local/bin` is in your PATH:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Run:
+
+```bash
+phase1-terminal doctor
+phase1-terminal
+```
+
+The Linux installer also adds:
+
+```text
+~/.local/share/applications/phase1-terminal.desktop
+```
+
+## Install on macOS
+
+From the Phase1 repository root:
+
+```bash
+sh scripts/install-phase1-terminal-macos.sh
+```
+
+Then ensure `~/.local/bin` is in your PATH:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Run:
+
+```bash
+phase1-terminal doctor
+phase1-terminal
+```
+
+The macOS installer also creates a clickable launcher:
+
+```text
+~/Desktop/Phase1 Terminal.command
+```
+
+Optional Terminal.app profile:
+
+```text
+terminal/macos/Phase1-Terminal.terminal
+```
+
+Open that file in Terminal.app to import the profile.
+
+## Manual install
+
+```bash
+sh scripts/install-phase1-terminal.sh
+```
+
+Options:
+
+```bash
+sh scripts/install-phase1-terminal.sh --prefix "$HOME/.local"
+sh scripts/install-phase1-terminal.sh --alias
+sh scripts/install-phase1-terminal.sh --no-alias
+sh scripts/install-phase1-terminal.sh --phase1-home "$PWD"
+```
+
+## Configuration
+
+Default config file:
+
+```text
+~/.config/phase1/terminal.env
+```
+
+Example:
+
+```sh
+PHASE1_HOME="$HOME/phase1"
+PHASE1_TERMINAL_TITLE="Phase1 Terminal"
+PHASE1_THEME="cyber"
+PHASE1_SAFE_MODE="1"
+PHASE1_MOBILE_MODE="0"
+PHASE1_DEVICE_MODE="desktop"
+PHASE1_ASCII="0"
+```
+
+To use a custom config file:
+
+```bash
+PHASE1_TERMINAL_CONFIG=/path/to/terminal.env phase1-terminal
+```
+
+## Commands
+
+```bash
+phase1-terminal          # launch Phase1
+phase1-terminal run      # launch Phase1
+phase1-terminal doctor   # check environment and Phase1 discovery
+phase1-terminal env      # print effective Phase1 Terminal environment
+phase1-terminal help     # show help
+```
+
+## Recommended build flow
+
+For the fastest launch, build Phase1 once:
+
+```bash
+cargo build --release
+phase1-terminal
+```
+
+If no built binary exists, Phase1 Terminal falls back to:
+
+```bash
+cargo run --
+```
+
+## Safety
+
+Phase1 Terminal preserves Phase1 safe defaults:
+
+- `PHASE1_SAFE_MODE=1`
+- `PHASE1_DEVICE_MODE=desktop`
+- no host-tool trust is enabled by the launcher
+- no host network mutation is enabled by the launcher
+
+Host-capable Phase1 modes must still be explicitly enabled through Phase1's normal boot/profile controls.

--- a/TERMINAL.md
+++ b/TERMINAL.md
@@ -18,7 +18,7 @@ The project name is **Phase1 Terminal**. The command is `phase1-terminal` becaus
 
 ## What it does
 
-Phase1 Terminal is not a full graphical terminal emulator. It is a Phase1-specific terminal launcher that:
+Phase1 Terminal is not a full graphical terminal emulator. It is a Phase1-specific terminal management layer that:
 
 - loads a Phase1 terminal configuration file
 - sets Phase1-friendly environment defaults
@@ -26,8 +26,12 @@ Phase1 Terminal is not a full graphical terminal emulator. It is a Phase1-specif
 - prefers an existing built binary
 - falls back to `cargo run`
 - sets the terminal title to `Phase1 Terminal`
-- provides `doctor` and `env` diagnostics
+- provides text and JSON diagnostics
+- manages safe profiles and config presets
+- provides build/check/log helpers
+- exposes Gina/security launch shortcuts
 - installs Linux and macOS launch integrations
+- supports dry-run install and reversible uninstall
 
 ## Install on Linux
 
@@ -46,7 +50,7 @@ export PATH="$HOME/.local/bin:$PATH"
 Run:
 
 ```bash
-phase1-terminal doctor
+phase1-terminal doctor --verbose
 phase1-terminal
 ```
 
@@ -73,7 +77,7 @@ export PATH="$HOME/.local/bin:$PATH"
 Run:
 
 ```bash
-phase1-terminal doctor
+phase1-terminal doctor --verbose
 phase1-terminal
 ```
 
@@ -104,7 +108,24 @@ sh scripts/install-phase1-terminal.sh --prefix "$HOME/.local"
 sh scripts/install-phase1-terminal.sh --alias
 sh scripts/install-phase1-terminal.sh --no-alias
 sh scripts/install-phase1-terminal.sh --phase1-home "$PWD"
+sh scripts/install-phase1-terminal.sh --dry-run
 ```
+
+## Uninstall
+
+```bash
+sh scripts/uninstall-phase1-terminal.sh
+```
+
+Options:
+
+```bash
+sh scripts/uninstall-phase1-terminal.sh --dry-run
+sh scripts/uninstall-phase1-terminal.sh --remove-config
+sh scripts/uninstall-phase1-terminal.sh --prefix "$HOME/.local"
+```
+
+By default, uninstall keeps `~/.config/phase1/terminal.env` so user config is not deleted accidentally.
 
 ## Configuration
 
@@ -119,11 +140,13 @@ Example:
 ```sh
 PHASE1_HOME="$HOME/phase1"
 PHASE1_TERMINAL_TITLE="Phase1 Terminal"
+PHASE1_TERMINAL_PROFILE="default"
 PHASE1_THEME="cyber"
 PHASE1_SAFE_MODE="1"
 PHASE1_MOBILE_MODE="0"
 PHASE1_DEVICE_MODE="desktop"
 PHASE1_ASCII="0"
+PHASE1_TERMINAL_HINTS="1"
 ```
 
 To use a custom config file:
@@ -132,14 +155,53 @@ To use a custom config file:
 PHASE1_TERMINAL_CONFIG=/path/to/terminal.env phase1-terminal
 ```
 
+Config commands:
+
+```bash
+phase1-terminal config show
+phase1-terminal config set PHASE1_THEME=matrix
+phase1-terminal config set PHASE1_HOME="$PWD"
+phase1-terminal config reset
+```
+
+Only allowlisted config keys can be changed through `config set`.
+
+## Profiles
+
+```bash
+phase1-terminal profile list
+phase1-terminal profile show
+phase1-terminal profile apply cyber
+phase1-terminal profile apply matrix
+phase1-terminal profile apply amber
+phase1-terminal profile apply mono
+phase1-terminal profile apply safe
+phase1-terminal profile apply developer
+phase1-terminal profile apply base1
+```
+
+Profiles are safe by default. They change launch defaults such as theme, ASCII mode, and device mode. They do not enable host trust, host networking, or external AI providers.
+
 ## Commands
 
 ```bash
-phase1-terminal          # launch Phase1
-phase1-terminal run      # launch Phase1
-phase1-terminal doctor   # check environment and Phase1 discovery
-phase1-terminal env      # print effective Phase1 Terminal environment
-phase1-terminal help     # show help
+phase1-terminal                 # launch Phase1
+phase1-terminal run             # launch Phase1
+phase1-terminal safe            # launch with safe profile defaults
+phase1-terminal dev             # launch with developer-friendly safe defaults
+phase1-terminal demo            # launch with demo title/theme defaults
+phase1-terminal base1           # launch with Base1-focused safe defaults
+phase1-terminal gina            # launch Phase1 with Gina hint
+phase1-terminal security        # launch Phase1 with Gina security hint
+phase1-terminal build           # cargo build --release in Phase1 home
+phase1-terminal check           # fmt/check/test in Phase1 home
+phase1-terminal logs            # tail local Phase1 runtime files
+phase1-terminal doctor          # check environment and discovery
+phase1-terminal doctor --verbose
+phase1-terminal doctor --json
+phase1-terminal env             # print effective environment
+phase1-terminal version         # print launcher version
+phase1-terminal help            # show help
 ```
 
 ## Recommended build flow
@@ -157,11 +219,36 @@ If no built binary exists, Phase1 Terminal falls back to:
 cargo run --
 ```
 
+## Gina workflow
+
+Gina stays offline and sandboxed by default. Phase1 Terminal makes her easier to discover:
+
+```bash
+phase1-terminal gina
+phase1-terminal security
+```
+
+Inside Phase1, use:
+
+```text
+gina security
+gina optimize
+gina consistency
+```
+
 ## Roadmap
 
 The terminal roadmap covers installer hardening, profile UX, session management, Gina-aware workflows, packaging, and future native terminal exploration.
 
 Read: [`TERMINAL_ROADMAP.md`](TERMINAL_ROADMAP.md).
+
+## Validation
+
+```bash
+sh scripts/test-phase1-terminal.sh
+```
+
+CI validates shell syntax, launcher help/version/env/doctor output, profile listing, install dry-run, uninstall dry-run, and required Linux/macOS assets.
 
 ## Safety
 
@@ -171,5 +258,8 @@ Phase1 Terminal preserves Phase1 safe defaults:
 - `PHASE1_DEVICE_MODE=desktop`
 - no host-tool trust is enabled by the launcher
 - no host network mutation is enabled by the launcher
+- no external AI provider is enabled by the launcher
+- config changes are allowlisted
+- uninstall keeps user config unless `--remove-config` is explicit
 
 Host-capable Phase1 modes must still be explicitly enabled through Phase1's normal boot/profile controls.

--- a/TERMINAL.md
+++ b/TERMINAL.md
@@ -10,7 +10,7 @@ phase1-terminal
 
 A shorter `terminal` alias can also be installed when safe.
 
-Roadmap: [`TERMINAL_ROADMAP.md`](TERMINAL_ROADMAP.md).
+Roadmap: [`TERMINAL_ROADMAP.md`](TERMINAL_ROADMAP.md). Test cases: [`TERMINAL_TEST_CASES.md`](TERMINAL_TEST_CASES.md).
 
 ## Name
 
@@ -18,96 +18,45 @@ The project name is **Phase1 Terminal**. The command is `phase1-terminal` becaus
 
 ## What it does
 
-Phase1 Terminal is not a full graphical terminal emulator. It is a Phase1-specific terminal management layer that:
+Phase1 Terminal is a Phase1-specific terminal management layer that:
 
-- loads a Phase1 terminal configuration file
-- sets Phase1-friendly environment defaults
-- locates a Phase1 checkout or installed binary
-- prefers an existing built binary
-- falls back to `cargo run`
-- sets the terminal title to `Phase1 Terminal`
-- provides text and JSON diagnostics
+- loads Phase1 terminal configuration
+- discovers a Phase1 checkout or binary
+- prefers built binaries and falls back to `cargo run`
+- detects terminal color capability
+- exports Phase1 color/theme environment values
+- previews palettes and theme swatches
 - manages safe profiles and config presets
+- provides diagnostics, self-tests, and benchmark smoke tests
 - provides build/check/log helpers
 - exposes Gina/security launch shortcuts
 - installs Linux and macOS launch integrations
 - supports dry-run install and reversible uninstall
 
-## Install on Linux
+## Install
 
-From the Phase1 repository root:
+Linux:
 
 ```bash
 sh scripts/install-phase1-terminal-linux.sh
-```
-
-Then ensure `~/.local/bin` is in your PATH:
-
-```bash
-export PATH="$HOME/.local/bin:$PATH"
-```
-
-Run:
-
-```bash
 phase1-terminal doctor --verbose
+phase1-terminal theme preview all
 phase1-terminal
 ```
 
-The Linux installer also adds:
-
-```text
-~/.local/share/applications/phase1-terminal.desktop
-```
-
-## Install on macOS
-
-From the Phase1 repository root:
+macOS:
 
 ```bash
 sh scripts/install-phase1-terminal-macos.sh
-```
-
-Then ensure `~/.local/bin` is in your PATH:
-
-```bash
-export PATH="$HOME/.local/bin:$PATH"
-```
-
-Run:
-
-```bash
 phase1-terminal doctor --verbose
+phase1-terminal theme preview all
 phase1-terminal
 ```
 
-The macOS installer also creates a clickable launcher:
-
-```text
-~/Desktop/Phase1 Terminal.command
-```
-
-Optional Terminal.app profile:
-
-```text
-terminal/macos/Phase1-Terminal.terminal
-```
-
-Open that file in Terminal.app to import the profile.
-
-## Manual install
+Generic:
 
 ```bash
 sh scripts/install-phase1-terminal.sh
-```
-
-Options:
-
-```bash
-sh scripts/install-phase1-terminal.sh --prefix "$HOME/.local"
-sh scripts/install-phase1-terminal.sh --alias
-sh scripts/install-phase1-terminal.sh --no-alias
-sh scripts/install-phase1-terminal.sh --phase1-home "$PWD"
 sh scripts/install-phase1-terminal.sh --dry-run
 ```
 
@@ -115,14 +64,8 @@ sh scripts/install-phase1-terminal.sh --dry-run
 
 ```bash
 sh scripts/uninstall-phase1-terminal.sh
-```
-
-Options:
-
-```bash
 sh scripts/uninstall-phase1-terminal.sh --dry-run
 sh scripts/uninstall-phase1-terminal.sh --remove-config
-sh scripts/uninstall-phase1-terminal.sh --prefix "$HOME/.local"
 ```
 
 By default, uninstall keeps `~/.config/phase1/terminal.env` so user config is not deleted accidentally.
@@ -142,17 +85,14 @@ PHASE1_HOME="$HOME/phase1"
 PHASE1_TERMINAL_TITLE="Phase1 Terminal"
 PHASE1_TERMINAL_PROFILE="default"
 PHASE1_THEME="cyber"
+PHASE1_COLOR_MODE="auto"
+PHASE1_TERMINAL_BANNER="1"
 PHASE1_SAFE_MODE="1"
 PHASE1_MOBILE_MODE="0"
 PHASE1_DEVICE_MODE="desktop"
 PHASE1_ASCII="0"
 PHASE1_TERMINAL_HINTS="1"
-```
-
-To use a custom config file:
-
-```bash
-PHASE1_TERMINAL_CONFIG=/path/to/terminal.env phase1-terminal
+PHASE1_TERMINAL_PERF_BUDGET_MS="500"
 ```
 
 Config commands:
@@ -160,11 +100,64 @@ Config commands:
 ```bash
 phase1-terminal config show
 phase1-terminal config set PHASE1_THEME=matrix
+phase1-terminal config set PHASE1_COLOR_MODE=truecolor
 phase1-terminal config set PHASE1_HOME="$PWD"
 phase1-terminal config reset
 ```
 
 Only allowlisted config keys can be changed through `config set`.
+
+## Color and themes
+
+Phase1 Terminal detects terminal color support and exports both configured and detected color mode for Phase1.
+
+Color modes:
+
+```text
+auto
+truecolor
+256
+ansi
+mono
+```
+
+Themes:
+
+```text
+cyber
+matrix
+amber
+mono
+safe
+developer
+base1
+ice
+synthwave
+crimson
+```
+
+Color commands:
+
+```bash
+phase1-terminal colors detect
+phase1-terminal colors swatches
+phase1-terminal theme list
+phase1-terminal theme preview cyber
+phase1-terminal theme preview matrix
+phase1-terminal theme preview all
+NO_COLOR=1 phase1-terminal theme preview all
+```
+
+Phase1 receives:
+
+```text
+PHASE1_THEME
+PHASE1_COLOR_MODE
+PHASE1_TERMINAL_DETECTED_COLOR_MODE
+PHASE1_TERMINAL_BANNER
+```
+
+This lets Phase1 be vivid where colors are available and readable where mono output is preferred.
 
 ## Profiles
 
@@ -178,9 +171,11 @@ phase1-terminal profile apply mono
 phase1-terminal profile apply safe
 phase1-terminal profile apply developer
 phase1-terminal profile apply base1
+phase1-terminal profile apply ice
+phase1-terminal profile apply crimson
 ```
 
-Profiles are safe by default. They change launch defaults such as theme, ASCII mode, and device mode. They do not enable host trust, host networking, or external AI providers.
+Profiles are safe by default. They change launch defaults such as theme, color mode, ASCII mode, and device mode.
 
 ## Commands
 
@@ -199,14 +194,18 @@ phase1-terminal logs            # tail local Phase1 runtime files
 phase1-terminal doctor          # check environment and discovery
 phase1-terminal doctor --verbose
 phase1-terminal doctor --json
-phase1-terminal env             # print effective environment
-phase1-terminal version         # print launcher version
-phase1-terminal help            # show help
+phase1-terminal colors detect
+phase1-terminal colors swatches
+phase1-terminal theme list
+phase1-terminal theme preview all
+phase1-terminal selftest
+phase1-terminal benchmark 25
+phase1-terminal env
+phase1-terminal version
+phase1-terminal help
 ```
 
 ## Recommended build flow
-
-For the fastest launch, build Phase1 once:
 
 ```bash
 cargo build --release
@@ -221,8 +220,6 @@ cargo run --
 
 ## Gina workflow
 
-Gina stays offline and sandboxed by default. Phase1 Terminal makes her easier to discover:
-
 ```bash
 phase1-terminal gina
 phase1-terminal security
@@ -236,6 +233,16 @@ gina optimize
 gina consistency
 ```
 
+## Quality and performance tests
+
+```bash
+sh scripts/test-phase1-terminal.sh
+phase1-terminal selftest
+phase1-terminal benchmark 25
+```
+
+Full test-case guide: [`TERMINAL_TEST_CASES.md`](TERMINAL_TEST_CASES.md).
+
 ## Roadmap
 
 The terminal roadmap covers installer hardening, profile UX, session management, Gina-aware workflows, packaging, and future native terminal exploration.
@@ -248,18 +255,8 @@ Read: [`TERMINAL_ROADMAP.md`](TERMINAL_ROADMAP.md).
 sh scripts/test-phase1-terminal.sh
 ```
 
-CI validates shell syntax, launcher help/version/env/doctor output, profile listing, install dry-run, uninstall dry-run, and required Linux/macOS assets.
+CI validates shell syntax, launcher help/version/env/doctor output, color detection, theme previews, profile listing, self-test, benchmark smoke, install dry-run, uninstall dry-run, and required Linux/macOS assets.
 
 ## Safety
 
-Phase1 Terminal preserves Phase1 safe defaults:
-
-- `PHASE1_SAFE_MODE=1`
-- `PHASE1_DEVICE_MODE=desktop`
-- no host-tool trust is enabled by the launcher
-- no host network mutation is enabled by the launcher
-- no external AI provider is enabled by the launcher
-- config changes are allowlisted
-- uninstall keeps user config unless `--remove-config` is explicit
-
-Host-capable Phase1 modes must still be explicitly enabled through Phase1's normal boot/profile controls.
+Phase1 Terminal preserves safe defaults, uses allowlisted config mutation, keeps user config unless `--remove-config` is explicit, and supports mono fallback through `NO_COLOR=1` or `PHASE1_COLOR_MODE=mono`.

--- a/TERMINAL_ROADMAP.md
+++ b/TERMINAL_ROADMAP.md
@@ -1,0 +1,225 @@
+# Phase1 Terminal Roadmap
+
+Phase1 Terminal is the dedicated Linux/macOS launcher, profile, and future terminal experience for Phase1.
+
+The initial implementation is intentionally conservative: it installs `phase1-terminal`, applies safe Phase1 defaults, discovers a Phase1 checkout or binary, and launches Phase1 through the best available path. This roadmap defines the path from launcher/profile layer to a more complete Phase1-native terminal experience.
+
+## Guiding principles
+
+- Keep Phase1 safe by default.
+- Preserve Linux and macOS support equally.
+- Do not enable host trust, host networking, or host mutation from the terminal launcher.
+- Prefer deterministic, testable shell scripts before larger native rewrites.
+- Make every installer reversible and inspectable.
+- Avoid clobbering user terminal settings.
+- Keep `phase1-terminal` as the primary command; only create `terminal` as a safe optional alias.
+
+## Current baseline
+
+Implemented in the first Phase1 Terminal PR:
+
+- `terminal/bin/phase1-terminal` launcher.
+- Generic installer: `scripts/install-phase1-terminal.sh`.
+- Linux installer wrapper: `scripts/install-phase1-terminal-linux.sh`.
+- Linux `.desktop` launcher support.
+- macOS installer wrapper: `scripts/install-phase1-terminal-macos.sh`.
+- macOS clickable `.command` launcher.
+- Optional Terminal.app profile file.
+- Config file: `~/.config/phase1/terminal.env`.
+- Diagnostic command: `phase1-terminal doctor`.
+- Environment dump command: `phase1-terminal env`.
+- CI syntax/asset validation through `scripts/test-phase1-terminal.sh`.
+
+## Phase 1 — Installer hardening
+
+Goal: make Phase1 Terminal installation reliable, reversible, and safe across common Linux/macOS environments.
+
+Planned work:
+
+- Add `scripts/uninstall-phase1-terminal.sh`.
+- Add `phase1-terminal doctor --verbose`.
+- Add `phase1-terminal doctor --json` for machine-readable checks.
+- Validate `PHASE1_HOME` points to a real Phase1 checkout or install root.
+- Detect missing Rust/Cargo and provide OS-specific install guidance without mutating the system.
+- Detect PATH problems and print shell-specific fixes for bash, zsh, fish, and POSIX sh.
+- Add installer dry-run mode.
+- Add installer idempotency tests.
+
+Acceptance checks:
+
+```bash
+sh scripts/test-phase1-terminal.sh
+sh scripts/install-phase1-terminal.sh --dry-run
+phase1-terminal doctor
+phase1-terminal env
+```
+
+## Phase 2 — Profile and UX polish
+
+Goal: make Phase1 Terminal feel like a dedicated Phase1 environment instead of a generic shell wrapper.
+
+Planned work:
+
+- Add generated terminal title and session banner.
+- Add config presets:
+  - `cyber`
+  - `matrix`
+  - `amber`
+  - `mono`
+  - `safe`
+  - `developer`
+- Add `phase1-terminal config show`.
+- Add `phase1-terminal config set KEY=VALUE` with safe allowlisted keys.
+- Add `phase1-terminal config reset`.
+- Add Linux desktop icon once a stable icon asset is selected.
+- Add macOS profile import instructions with screenshots or text walkthrough.
+- Add shell completion files for bash/zsh/fish.
+
+Acceptance checks:
+
+```bash
+phase1-terminal config show
+phase1-terminal config set PHASE1_THEME=cyber
+phase1-terminal config reset
+phase1-terminal doctor
+```
+
+## Phase 3 — Native Phase1 session management
+
+Goal: give Phase1 Terminal consistent launch modes for operators, developers, Base1 users, and demos.
+
+Planned work:
+
+- Add launch profiles:
+  - `phase1-terminal run`
+  - `phase1-terminal demo`
+  - `phase1-terminal dev`
+  - `phase1-terminal base1`
+  - `phase1-terminal safe`
+- Add `phase1-terminal build` wrapper for `cargo build --release`.
+- Add `phase1-terminal check` wrapper for Phase1 validation commands.
+- Add `phase1-terminal logs` for local Phase1 runtime logs.
+- Add graceful error messages when no binary and no Cargo are available.
+- Add support for launching a specific Phase1 binary path.
+
+Acceptance checks:
+
+```bash
+phase1-terminal safe
+phase1-terminal dev
+phase1-terminal build
+phase1-terminal check
+phase1-terminal logs
+```
+
+## Phase 4 — Gina-aware terminal workflows
+
+Goal: integrate Phase1 Terminal with Gina while preserving offline/sandboxed defaults.
+
+Planned work:
+
+- Add `phase1-terminal gina` to launch Phase1 directly into Gina guidance.
+- Add `phase1-terminal security` to launch Phase1 with a security-first command hint.
+- Add terminal doctor checks for Gina plugin presence.
+- Add optional post-launch hint: `Inside Phase1, try: gina security`.
+- Add documentation for using Gina from Phase1 Terminal.
+- Keep all Gina/provider-backed behavior policy-gated and disabled by default.
+
+Acceptance checks:
+
+```bash
+phase1-terminal doctor
+phase1-terminal gina
+phase1-terminal security
+```
+
+## Phase 5 — Packaging
+
+Goal: make Phase1 Terminal installable through common packaging flows without requiring users to manually copy scripts.
+
+Planned work:
+
+- Add release tarball layout.
+- Add `make install` equivalent or `cargo xtask terminal-package` once `xtask` is merged.
+- Add Homebrew formula draft for macOS.
+- Add Debian package draft for Linux.
+- Add AppImage or portable Linux archive exploration.
+- Add checksums for release artifacts.
+- Document upgrade and rollback path.
+
+Acceptance checks:
+
+```bash
+phase1-terminal --version
+phase1-terminal doctor
+phase1-terminal uninstall --dry-run
+```
+
+## Phase 6 — Native terminal application exploration
+
+Goal: decide whether Phase1 needs a real terminal emulator or should remain a launcher/profile layer.
+
+Exploration topics:
+
+- Rust-native TUI shell wrapper.
+- Dedicated Phase1 pseudo-terminal session manager.
+- GPU-accelerated desktop terminal emulator feasibility.
+- macOS app bundle feasibility.
+- Linux desktop app feasibility.
+- Accessibility and reduced-motion requirements.
+- Security implications of embedding PTY/session management.
+
+Decision gate:
+
+Only build a full native terminal emulator if it provides clear value beyond existing Linux/macOS terminals and does not weaken Phase1 safety guarantees.
+
+## Testing strategy
+
+Every terminal change should include at least one of:
+
+- shell syntax validation
+- installer dry-run validation
+- doctor output validation
+- config parser validation
+- docs update
+- CI workflow coverage
+
+Core validation command:
+
+```bash
+sh scripts/test-phase1-terminal.sh
+```
+
+Future validation commands:
+
+```bash
+phase1-terminal doctor --json
+phase1-terminal config show
+phase1-terminal uninstall --dry-run
+```
+
+## Security requirements
+
+Phase1 Terminal must never silently enable:
+
+- host trust
+- host shell mutation
+- host network mutation
+- external AI provider calls
+- credential storage
+- browser cookie access
+- unredacted history/log export
+
+Phase1 Terminal may guide the user to enable higher-trust Phase1 modes, but those modes must stay explicit and policy-controlled inside Phase1.
+
+## Success criteria
+
+Phase1 Terminal is successful when:
+
+- Linux and macOS users can install it with one command.
+- `phase1-terminal doctor` clearly diagnoses environment problems.
+- the launcher starts Phase1 consistently from source or binary installs.
+- safe defaults are preserved.
+- Gina security guidance is discoverable.
+- uninstall/upgrade paths are documented and tested.
+- CI catches script, asset, and documentation regressions.

--- a/TERMINAL_ROADMAP.md
+++ b/TERMINAL_ROADMAP.md
@@ -1,13 +1,14 @@
 # Phase1 Terminal Roadmap
 
-Phase1 Terminal is the dedicated Linux/macOS launcher, profile, config, and future terminal experience for Phase1.
+Phase1 Terminal is the dedicated Linux/macOS launcher, profile, config, color, quality, and future terminal experience for Phase1.
 
-The implementation has moved beyond a basic launcher. Phase1 Terminal now installs `phase1-terminal`, applies safe defaults, discovers a Phase1 checkout or binary, launches Phase1 through the best available path, manages allowlisted config, provides profiles, exposes doctor JSON, supports dry-run install/uninstall, and adds Gina-aware launch shortcuts. This roadmap defines the remaining path from management layer to a more complete Phase1-native terminal experience.
+The implementation has moved beyond a basic launcher. Phase1 Terminal now installs `phase1-terminal`, applies safe defaults, discovers a Phase1 checkout or binary, launches Phase1 through the best available path, manages allowlisted config, provides profiles, detects color capabilities, previews palettes, exposes doctor JSON, supports dry-run install/uninstall, runs self-tests and benchmark smoke tests, and adds Gina-aware launch shortcuts. This roadmap defines the remaining path from management layer to a more complete Phase1-native terminal experience.
 
 ## Guiding principles
 
 - Keep Phase1 safe by default.
 - Preserve Linux and macOS support equally.
+- Make Phase1 beautiful where color is available and readable where mono output is preferred.
 - Do not enable host trust, host networking, or host mutation from the terminal launcher.
 - Prefer deterministic, testable shell scripts before larger native rewrites.
 - Make every installer reversible and inspectable.
@@ -32,12 +33,17 @@ Implemented in the current Phase1 Terminal PR:
 - `phase1-terminal version`.
 - Allowlisted `phase1-terminal config show|set|reset`.
 - Safe profiles through `phase1-terminal profile list|show|apply`.
+- Advanced color commands: `colors detect`, `colors swatches`, `theme list`, `theme preview`.
+- Phase1 color environment export: `PHASE1_THEME`, `PHASE1_COLOR_MODE`, `PHASE1_TERMINAL_DETECTED_COLOR_MODE`, `PHASE1_TERMINAL_BANNER`.
 - Session modes: `run`, `safe`, `dev`, `demo`, `base1`.
 - Gina/security shortcuts: `gina`, `security`.
 - Management helpers: `build`, `check`, `logs`.
+- Quality command: `selftest`.
+- Performance command: `benchmark`.
 - Installer dry-run mode.
 - Uninstaller dry-run mode.
 - CI validation through `scripts/test-phase1-terminal.sh`.
+- Test plan: `TERMINAL_TEST_CASES.md`.
 
 ## Phase 1 — Installer hardening
 
@@ -72,16 +78,20 @@ phase1-terminal doctor --json
 phase1-terminal env
 ```
 
-## Phase 2 — Profile and UX polish
+## Phase 2 — Profile, color, and UX polish
 
 Goal: make Phase1 Terminal feel like a dedicated Phase1 environment instead of a generic shell wrapper.
 
-Status: partially implemented.
+Status: mostly implemented.
 
 Implemented:
 
 - generated terminal title.
 - profile system.
+- color capability detection.
+- mono fallback with `NO_COLOR=1` or `PHASE1_COLOR_MODE=mono`.
+- theme previews and swatches.
+- color/theme environment export into Phase1.
 - config presets through profile application:
   - `cyber`
   - `matrix`
@@ -90,6 +100,8 @@ Implemented:
   - `safe`
   - `developer`
   - `base1`
+  - `ice`
+  - `crimson`
 - `phase1-terminal config show`.
 - `phase1-terminal config set KEY=VALUE` with safe allowlisted keys.
 - `phase1-terminal config reset`.
@@ -99,12 +111,15 @@ Remaining work:
 - Add Linux desktop icon once a stable icon asset is selected.
 - Add macOS profile import instructions with screenshots or text walkthrough.
 - Add shell completion files for bash/zsh/fish.
-- Add first-run banner that can be disabled.
+- Add first-run banner rendering inside the launcher.
 - Add profile-specific docs examples.
 
 Acceptance checks:
 
 ```bash
+phase1-terminal colors detect
+phase1-terminal theme preview all
+NO_COLOR=1 phase1-terminal theme preview all
 phase1-terminal config show
 phase1-terminal config set PHASE1_THEME=cyber
 phase1-terminal config reset
@@ -149,7 +164,35 @@ phase1-terminal check
 phase1-terminal logs
 ```
 
-## Phase 4 — Gina-aware terminal workflows
+## Phase 4 — Quality and performance layer
+
+Goal: make Phase1 Terminal self-checking and performance-aware.
+
+Status: partially implemented.
+
+Implemented:
+
+- `phase1-terminal selftest`.
+- `phase1-terminal benchmark [iterations]`.
+- CI validation for self-test and benchmark smoke.
+- `TERMINAL_TEST_CASES.md` quality/performance test plan.
+
+Remaining work:
+
+- Add machine-readable benchmark JSON.
+- Add startup-path timing for source, debug binary, release binary, and PATH binary modes.
+- Add temporary-prefix install/uninstall tests.
+- Add benchmark thresholds once real device baselines exist.
+
+Acceptance checks:
+
+```bash
+phase1-terminal selftest
+phase1-terminal benchmark 25
+sh scripts/test-phase1-terminal.sh
+```
+
+## Phase 5 — Gina-aware terminal workflows
 
 Goal: integrate Phase1 Terminal with Gina while preserving offline/sandboxed defaults.
 
@@ -179,7 +222,7 @@ phase1-terminal gina
 phase1-terminal security
 ```
 
-## Phase 5 — Packaging
+## Phase 6 — Packaging
 
 Goal: make Phase1 Terminal installable through common packaging flows without requiring users to manually copy scripts.
 
@@ -203,7 +246,7 @@ phase1-terminal doctor
 sh scripts/uninstall-phase1-terminal.sh --dry-run
 ```
 
-## Phase 6 — Native terminal application exploration
+## Phase 7 — Native terminal application exploration
 
 Goal: decide whether Phase1 needs a real terminal emulator or should remain a launcher/profile layer.
 
@@ -231,8 +274,12 @@ Every terminal change should include at least one of:
 - installer dry-run validation
 - uninstaller dry-run validation
 - doctor output validation
+- color detection validation
+- theme preview validation
 - config parser validation
 - profile validation
+- self-test validation
+- benchmark smoke validation
 - docs update
 - CI workflow coverage
 
@@ -246,9 +293,10 @@ Future validation commands:
 
 ```bash
 phase1-terminal doctor --json
-phase1-terminal config show
-phase1-terminal profile list
-sh scripts/uninstall-phase1-terminal.sh --dry-run
+phase1-terminal colors detect
+phase1-terminal theme preview all
+phase1-terminal selftest
+phase1-terminal benchmark 25
 ```
 
 ## Security requirements
@@ -272,9 +320,11 @@ Phase1 Terminal is successful when:
 - Linux and macOS users can install it with one command.
 - `phase1-terminal doctor` clearly diagnoses environment problems.
 - `phase1-terminal doctor --json` supports machine-readable checks.
+- Phase1 receives color/theme settings reliably.
+- theme previews are beautiful on color terminals and readable in mono fallback.
 - the launcher starts Phase1 consistently from source or binary installs.
 - safe profiles are easy to apply.
 - safe defaults are preserved.
 - Gina security guidance is discoverable.
 - uninstall/upgrade paths are documented and tested.
-- CI catches script, asset, and documentation regressions.
+- CI catches script, color, asset, and documentation regressions.

--- a/TERMINAL_ROADMAP.md
+++ b/TERMINAL_ROADMAP.md
@@ -1,8 +1,8 @@
 # Phase1 Terminal Roadmap
 
-Phase1 Terminal is the dedicated Linux/macOS launcher, profile, and future terminal experience for Phase1.
+Phase1 Terminal is the dedicated Linux/macOS launcher, profile, config, and future terminal experience for Phase1.
 
-The initial implementation is intentionally conservative: it installs `phase1-terminal`, applies safe Phase1 defaults, discovers a Phase1 checkout or binary, and launches Phase1 through the best available path. This roadmap defines the path from launcher/profile layer to a more complete Phase1-native terminal experience.
+The implementation has moved beyond a basic launcher. Phase1 Terminal now installs `phase1-terminal`, applies safe defaults, discovers a Phase1 checkout or binary, launches Phase1 through the best available path, manages allowlisted config, provides profiles, exposes doctor JSON, supports dry-run install/uninstall, and adds Gina-aware launch shortcuts. This roadmap defines the remaining path from management layer to a more complete Phase1-native terminal experience.
 
 ## Guiding principles
 
@@ -16,41 +16,59 @@ The initial implementation is intentionally conservative: it installs `phase1-te
 
 ## Current baseline
 
-Implemented in the first Phase1 Terminal PR:
+Implemented in the current Phase1 Terminal PR:
 
-- `terminal/bin/phase1-terminal` launcher.
+- `terminal/bin/phase1-terminal` launcher and management command.
 - Generic installer: `scripts/install-phase1-terminal.sh`.
+- Reversible uninstaller: `scripts/uninstall-phase1-terminal.sh`.
 - Linux installer wrapper: `scripts/install-phase1-terminal-linux.sh`.
 - Linux `.desktop` launcher support.
 - macOS installer wrapper: `scripts/install-phase1-terminal-macos.sh`.
 - macOS clickable `.command` launcher.
 - Optional Terminal.app profile file.
 - Config file: `~/.config/phase1/terminal.env`.
-- Diagnostic command: `phase1-terminal doctor`.
-- Environment dump command: `phase1-terminal env`.
-- CI syntax/asset validation through `scripts/test-phase1-terminal.sh`.
+- `phase1-terminal doctor`, `doctor --verbose`, and `doctor --json`.
+- `phase1-terminal env`.
+- `phase1-terminal version`.
+- Allowlisted `phase1-terminal config show|set|reset`.
+- Safe profiles through `phase1-terminal profile list|show|apply`.
+- Session modes: `run`, `safe`, `dev`, `demo`, `base1`.
+- Gina/security shortcuts: `gina`, `security`.
+- Management helpers: `build`, `check`, `logs`.
+- Installer dry-run mode.
+- Uninstaller dry-run mode.
+- CI validation through `scripts/test-phase1-terminal.sh`.
 
 ## Phase 1 — Installer hardening
 
 Goal: make Phase1 Terminal installation reliable, reversible, and safe across common Linux/macOS environments.
 
-Planned work:
+Status: mostly implemented.
 
-- Add `scripts/uninstall-phase1-terminal.sh`.
-- Add `phase1-terminal doctor --verbose`.
-- Add `phase1-terminal doctor --json` for machine-readable checks.
-- Validate `PHASE1_HOME` points to a real Phase1 checkout or install root.
+Implemented:
+
+- `scripts/uninstall-phase1-terminal.sh`.
+- `phase1-terminal doctor --verbose`.
+- `phase1-terminal doctor --json`.
+- basic `PHASE1_HOME` validation.
+- installer dry-run mode.
+- uninstaller dry-run mode.
+- CI validation for dry-run install/uninstall.
+
+Remaining work:
+
 - Detect missing Rust/Cargo and provide OS-specific install guidance without mutating the system.
 - Detect PATH problems and print shell-specific fixes for bash, zsh, fish, and POSIX sh.
-- Add installer dry-run mode.
-- Add installer idempotency tests.
+- Add installer idempotency tests that use a temporary prefix.
+- Add checksum/manifest output for installed files.
 
 Acceptance checks:
 
 ```bash
 sh scripts/test-phase1-terminal.sh
 sh scripts/install-phase1-terminal.sh --dry-run
-phase1-terminal doctor
+sh scripts/uninstall-phase1-terminal.sh --dry-run
+phase1-terminal doctor --json
 phase1-terminal env
 ```
 
@@ -58,22 +76,31 @@ phase1-terminal env
 
 Goal: make Phase1 Terminal feel like a dedicated Phase1 environment instead of a generic shell wrapper.
 
-Planned work:
+Status: partially implemented.
 
-- Add generated terminal title and session banner.
-- Add config presets:
+Implemented:
+
+- generated terminal title.
+- profile system.
+- config presets through profile application:
   - `cyber`
   - `matrix`
   - `amber`
   - `mono`
   - `safe`
   - `developer`
-- Add `phase1-terminal config show`.
-- Add `phase1-terminal config set KEY=VALUE` with safe allowlisted keys.
-- Add `phase1-terminal config reset`.
+  - `base1`
+- `phase1-terminal config show`.
+- `phase1-terminal config set KEY=VALUE` with safe allowlisted keys.
+- `phase1-terminal config reset`.
+
+Remaining work:
+
 - Add Linux desktop icon once a stable icon asset is selected.
 - Add macOS profile import instructions with screenshots or text walkthrough.
 - Add shell completion files for bash/zsh/fish.
+- Add first-run banner that can be disabled.
+- Add profile-specific docs examples.
 
 Acceptance checks:
 
@@ -81,6 +108,8 @@ Acceptance checks:
 phase1-terminal config show
 phase1-terminal config set PHASE1_THEME=cyber
 phase1-terminal config reset
+phase1-terminal profile list
+phase1-terminal profile apply matrix
 phase1-terminal doctor
 ```
 
@@ -88,19 +117,27 @@ phase1-terminal doctor
 
 Goal: give Phase1 Terminal consistent launch modes for operators, developers, Base1 users, and demos.
 
-Planned work:
+Status: mostly implemented.
 
-- Add launch profiles:
-  - `phase1-terminal run`
-  - `phase1-terminal demo`
-  - `phase1-terminal dev`
-  - `phase1-terminal base1`
-  - `phase1-terminal safe`
-- Add `phase1-terminal build` wrapper for `cargo build --release`.
-- Add `phase1-terminal check` wrapper for Phase1 validation commands.
-- Add `phase1-terminal logs` for local Phase1 runtime logs.
-- Add graceful error messages when no binary and no Cargo are available.
-- Add support for launching a specific Phase1 binary path.
+Implemented:
+
+- `phase1-terminal run`.
+- `phase1-terminal demo`.
+- `phase1-terminal dev`.
+- `phase1-terminal base1`.
+- `phase1-terminal safe`.
+- `phase1-terminal build` wrapper for `cargo build --release`.
+- `phase1-terminal check` wrapper for validation commands.
+- `phase1-terminal logs` for local Phase1 runtime files.
+- graceful errors when no Phase1 home/binary and no Cargo are available.
+- support for source, release binary, debug binary, `bin/phase1`, local `./phase1`, and PATH binary discovery.
+
+Remaining work:
+
+- Add explicit `PHASE1_BINARY` config override.
+- Add `phase1-terminal check --quick`.
+- Add `phase1-terminal check --full`.
+- Add redacted log output mode.
 
 Acceptance checks:
 
@@ -116,19 +153,28 @@ phase1-terminal logs
 
 Goal: integrate Phase1 Terminal with Gina while preserving offline/sandboxed defaults.
 
-Planned work:
+Status: partially implemented.
 
-- Add `phase1-terminal gina` to launch Phase1 directly into Gina guidance.
-- Add `phase1-terminal security` to launch Phase1 with a security-first command hint.
-- Add terminal doctor checks for Gina plugin presence.
-- Add optional post-launch hint: `Inside Phase1, try: gina security`.
-- Add documentation for using Gina from Phase1 Terminal.
-- Keep all Gina/provider-backed behavior policy-gated and disabled by default.
+Implemented:
+
+- `phase1-terminal gina` launches Phase1 with Gina guidance.
+- `phase1-terminal security` launches Phase1 with a security-first Gina hint.
+- verbose doctor checks for Gina plugin presence.
+- post-launch hint: `Inside Phase1, try: gina security`.
+- documentation for using Gina from Phase1 Terminal.
+- no Gina/provider-backed behavior is enabled by the terminal.
+
+Remaining work:
+
+- Add `phase1-terminal gina --status` that reports Gina availability without launching Phase1.
+- Add `phase1-terminal gina --doctor`.
+- Add terminal-to-Gina roadmap cross-reference output.
+- Add tests that simulate Gina plugin presence with a temporary Phase1 home.
 
 Acceptance checks:
 
 ```bash
-phase1-terminal doctor
+phase1-terminal doctor --verbose
 phase1-terminal gina
 phase1-terminal security
 ```
@@ -136,6 +182,8 @@ phase1-terminal security
 ## Phase 5 — Packaging
 
 Goal: make Phase1 Terminal installable through common packaging flows without requiring users to manually copy scripts.
+
+Status: planned.
 
 Planned work:
 
@@ -152,12 +200,14 @@ Acceptance checks:
 ```bash
 phase1-terminal --version
 phase1-terminal doctor
-phase1-terminal uninstall --dry-run
+sh scripts/uninstall-phase1-terminal.sh --dry-run
 ```
 
 ## Phase 6 — Native terminal application exploration
 
 Goal: decide whether Phase1 needs a real terminal emulator or should remain a launcher/profile layer.
+
+Status: research only.
 
 Exploration topics:
 
@@ -179,8 +229,10 @@ Every terminal change should include at least one of:
 
 - shell syntax validation
 - installer dry-run validation
+- uninstaller dry-run validation
 - doctor output validation
 - config parser validation
+- profile validation
 - docs update
 - CI workflow coverage
 
@@ -195,7 +247,8 @@ Future validation commands:
 ```bash
 phase1-terminal doctor --json
 phase1-terminal config show
-phase1-terminal uninstall --dry-run
+phase1-terminal profile list
+sh scripts/uninstall-phase1-terminal.sh --dry-run
 ```
 
 ## Security requirements
@@ -218,7 +271,9 @@ Phase1 Terminal is successful when:
 
 - Linux and macOS users can install it with one command.
 - `phase1-terminal doctor` clearly diagnoses environment problems.
+- `phase1-terminal doctor --json` supports machine-readable checks.
 - the launcher starts Phase1 consistently from source or binary installs.
+- safe profiles are easy to apply.
 - safe defaults are preserved.
 - Gina security guidance is discoverable.
 - uninstall/upgrade paths are documented and tested.

--- a/TERMINAL_TEST_CASES.md
+++ b/TERMINAL_TEST_CASES.md
@@ -1,0 +1,276 @@
+# Phase1 Terminal Test Cases
+
+This document defines quality, color, safety, and performance test cases for Phase1 Terminal.
+
+The goal is to keep Phase1 beautiful, reliable, fast, and safe across Linux and macOS terminal environments.
+
+## Core validation command
+
+```bash
+sh scripts/test-phase1-terminal.sh
+```
+
+This is the CI-backed terminal validation entry point.
+
+## Test matrix
+
+| Area | Command | Expected result |
+| --- | --- | --- |
+| Syntax | `sh -n terminal/bin/phase1-terminal` | no syntax errors |
+| Syntax | `sh -n scripts/install-phase1-terminal.sh` | no syntax errors |
+| Syntax | `sh -n scripts/uninstall-phase1-terminal.sh` | no syntax errors |
+| Help | `phase1-terminal help` | lists run/config/profile/colors/theme/selftest/benchmark commands |
+| Version | `phase1-terminal version` | prints `phase1-terminal <version>` |
+| Env | `phase1-terminal env` | includes terminal, theme, color, safety values |
+| Doctor | `phase1-terminal doctor` | prints text diagnostics |
+| Doctor JSON | `phase1-terminal doctor --json` | includes version, theme, detected color mode |
+| Color detect | `phase1-terminal colors detect` | reports configured and detected color support |
+| Color swatches | `phase1-terminal colors swatches` | prints all theme swatches or text fallback |
+| Theme list | `phase1-terminal theme list` | lists supported themes |
+| Theme preview | `phase1-terminal theme preview matrix` | previews matrix palette |
+| Profiles | `phase1-terminal profile list` | lists all profiles |
+| Self-test | `phase1-terminal selftest` | returns `selftest: passed` |
+| Benchmark | `phase1-terminal benchmark 2` | returns `status    : completed` |
+| Installer dry-run | `sh scripts/install-phase1-terminal.sh --dry-run` | prints planned writes and exits successfully |
+| Uninstaller dry-run | `sh scripts/uninstall-phase1-terminal.sh --dry-run` | prints planned removals and exits successfully |
+
+## Color quality tests
+
+### CQ-1: Auto color detection
+
+Command:
+
+```bash
+phase1-terminal colors detect
+```
+
+Expected:
+
+- reports configured color mode
+- reports detected color mode
+- includes `TERM`
+- includes `COLORTERM`
+- includes `tput colors`
+- does not fail when `tput` is missing or unavailable
+
+### CQ-2: No-color compatibility
+
+Command:
+
+```bash
+NO_COLOR=1 phase1-terminal colors detect
+```
+
+Expected:
+
+- detected color mode is `mono`
+- command exits successfully
+- output remains readable without ANSI styling
+
+### CQ-3: Theme swatch fallback
+
+Command:
+
+```bash
+NO_COLOR=1 phase1-terminal theme preview all
+```
+
+Expected:
+
+- all themes are still listed
+- output uses text fallback instead of relying on color blocks
+
+### CQ-4: Truecolor environment pass-through
+
+Command:
+
+```bash
+PHASE1_COLOR_MODE=truecolor phase1-terminal env
+```
+
+Expected:
+
+- includes `PHASE1_COLOR_MODE=truecolor`
+- includes detected color mode data
+- does not enable unsafe host behavior
+
+### CQ-5: Phase1 beauty themes
+
+Command:
+
+```bash
+phase1-terminal theme preview all
+```
+
+Expected themes:
+
+- `cyber`
+- `matrix`
+- `amber`
+- `mono`
+- `safe`
+- `developer`
+- `base1`
+- `ice`
+- `synthwave`
+- `crimson`
+
+## Performance tests
+
+### PERF-1: Terminal command self-test
+
+Command:
+
+```bash
+phase1-terminal selftest
+```
+
+Expected:
+
+- completes quickly
+- reports color detection status
+- verifies doctor JSON includes color fields
+- verifies theme preview works
+- returns success
+
+### PERF-2: Lightweight benchmark
+
+Command:
+
+```bash
+phase1-terminal benchmark 25
+```
+
+Expected:
+
+- runs repeated detection/doctor/theme operations
+- prints iterations
+- prints elapsed seconds
+- prints configured budget
+- exits successfully
+
+### PERF-3: CI benchmark smoke
+
+Command:
+
+```bash
+phase1-terminal benchmark 2
+```
+
+Expected:
+
+- stable under CI
+- no dependence on interactive terminal capabilities
+- exits successfully
+
+## Safety tests
+
+### SAFE-1: Defaults remain safe
+
+Command:
+
+```bash
+phase1-terminal env
+```
+
+Expected:
+
+- `PHASE1_SAFE_MODE=1`
+- `PHASE1_DEVICE_MODE=desktop`
+- no host trust environment variable is set
+- no external AI provider is set
+
+### SAFE-2: Profiles do not enable host trust
+
+Command:
+
+```bash
+phase1-terminal profile apply developer
+phase1-terminal config show
+```
+
+Expected:
+
+- developer profile may change theme
+- safe mode remains enabled
+- no host network mutation is enabled
+- no external AI provider is enabled
+
+### SAFE-3: Config keys are allowlisted
+
+Command:
+
+```bash
+phase1-terminal config set UNSAFE_KEY=1
+```
+
+Expected:
+
+- command fails
+- unsupported key is rejected
+- config file is not expanded with arbitrary keys
+
+## Installer tests
+
+### INSTALL-1: Dry-run install
+
+Command:
+
+```bash
+sh scripts/install-phase1-terminal.sh --dry-run --no-alias
+```
+
+Expected:
+
+- does not write files
+- prints install target
+- prints config target
+- prints color/theme defaults
+
+### INSTALL-2: Dry-run uninstall
+
+Command:
+
+```bash
+sh scripts/uninstall-phase1-terminal.sh --dry-run
+```
+
+Expected:
+
+- does not delete files
+- prints planned removals
+- keeps config unless `--remove-config` is explicit
+
+## Manual visual tests
+
+These are not required in CI but should be checked before major releases:
+
+```bash
+phase1-terminal theme preview all
+phase1-terminal profile apply cyber
+phase1-terminal profile apply matrix
+phase1-terminal profile apply amber
+phase1-terminal profile apply ice
+phase1-terminal profile apply crimson
+phase1-terminal doctor --verbose
+phase1-terminal gina
+```
+
+Visual pass criteria:
+
+- theme previews are readable
+- colors are vivid where terminal support exists
+- mono fallback remains legible
+- no unreadable low-contrast combination becomes the default
+- Phase1 launch receives theme/color environment values
+
+## Regression checklist
+
+Before merging terminal changes, confirm:
+
+- `sh scripts/test-phase1-terminal.sh` passes
+- Rust CI passes terminal validation
+- security workflow passes
+- README/TERMINAL docs list new commands
+- roadmap reflects implemented features
+- terminal does not enable host trust, network mutation, or external AI providers

--- a/scripts/install-phase1-terminal-linux.sh
+++ b/scripts/install-phase1-terminal-linux.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+set -eu
+
+PREFIX="${PREFIX:-$HOME/.local}"
+DESKTOP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+
+sh scripts/install-phase1-terminal.sh --prefix "$PREFIX" "$@"
+
+mkdir -p "$DESKTOP_DIR"
+cp terminal/linux/phase1-terminal.desktop "$DESKTOP_DIR/phase1-terminal.desktop"
+chmod 0644 "$DESKTOP_DIR/phase1-terminal.desktop"
+
+if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database "$DESKTOP_DIR" >/dev/null 2>&1 || true
+fi
+
+cat <<EOF
+Linux desktop launcher installed:
+  $DESKTOP_DIR/phase1-terminal.desktop
+EOF

--- a/scripts/install-phase1-terminal-linux.sh
+++ b/scripts/install-phase1-terminal-linux.sh
@@ -7,7 +7,17 @@ DESKTOP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/applications"
 sh scripts/install-phase1-terminal.sh --prefix "$PREFIX" "$@"
 
 mkdir -p "$DESKTOP_DIR"
-cp terminal/linux/phase1-terminal.desktop "$DESKTOP_DIR/phase1-terminal.desktop"
+cat > "$DESKTOP_DIR/phase1-terminal.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=Phase1 Terminal
+Comment=Launch the Phase1 terminal-first computing environment
+Exec=$PREFIX/bin/phase1-terminal
+Terminal=true
+Categories=Development;System;TerminalEmulator;
+Keywords=phase1;terminal;rust;os;shell;
+StartupNotify=false
+EOF
 chmod 0644 "$DESKTOP_DIR/phase1-terminal.desktop"
 
 if command -v update-desktop-database >/dev/null 2>&1; then

--- a/scripts/install-phase1-terminal-macos.sh
+++ b/scripts/install-phase1-terminal-macos.sh
@@ -4,19 +4,20 @@ set -eu
 PREFIX="${PREFIX:-$HOME/.local}"
 APP_SUPPORT="$HOME/Library/Application Support/Phase1"
 COMMAND_FILE="$HOME/Desktop/Phase1 Terminal.command"
+INSTALLED_LAUNCHER="$PREFIX/bin/phase1-terminal"
 
 sh scripts/install-phase1-terminal.sh --prefix "$PREFIX" --no-alias "$@"
 
 mkdir -p "$APP_SUPPORT"
-cat > "$APP_SUPPORT/Phase1 Terminal.command" <<'EOF'
+cat > "$APP_SUPPORT/Phase1 Terminal.command" <<EOF
 #!/usr/bin/env sh
+if [ -x "$INSTALLED_LAUNCHER" ]; then
+    exec "$INSTALLED_LAUNCHER"
+fi
 if command -v phase1-terminal >/dev/null 2>&1; then
     exec phase1-terminal
 fi
-if [ -x "$HOME/.local/bin/phase1-terminal" ]; then
-    exec "$HOME/.local/bin/phase1-terminal"
-fi
-echo "phase1-terminal was not found. Add ~/.local/bin to PATH or reinstall Phase1 Terminal."
+echo "phase1-terminal was not found. Reinstall Phase1 Terminal or add the install bin directory to PATH."
 read -r _
 EOF
 chmod 0755 "$APP_SUPPORT/Phase1 Terminal.command"

--- a/scripts/install-phase1-terminal-macos.sh
+++ b/scripts/install-phase1-terminal-macos.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+set -eu
+
+PREFIX="${PREFIX:-$HOME/.local}"
+APP_SUPPORT="$HOME/Library/Application Support/Phase1"
+COMMAND_FILE="$HOME/Desktop/Phase1 Terminal.command"
+
+sh scripts/install-phase1-terminal.sh --prefix "$PREFIX" --no-alias "$@"
+
+mkdir -p "$APP_SUPPORT"
+cat > "$APP_SUPPORT/Phase1 Terminal.command" <<'EOF'
+#!/usr/bin/env sh
+if command -v phase1-terminal >/dev/null 2>&1; then
+    exec phase1-terminal
+fi
+if [ -x "$HOME/.local/bin/phase1-terminal" ]; then
+    exec "$HOME/.local/bin/phase1-terminal"
+fi
+echo "phase1-terminal was not found. Add ~/.local/bin to PATH or reinstall Phase1 Terminal."
+read -r _
+EOF
+chmod 0755 "$APP_SUPPORT/Phase1 Terminal.command"
+cp "$APP_SUPPORT/Phase1 Terminal.command" "$COMMAND_FILE"
+chmod 0755 "$COMMAND_FILE"
+
+cat <<EOF
+macOS launcher installed.
+
+Clickable launcher:
+  $COMMAND_FILE
+
+Support copy:
+  $APP_SUPPORT/Phase1 Terminal.command
+
+Optional: import terminal/macos/Phase1-Terminal.terminal into Terminal.app profiles.
+EOF

--- a/scripts/install-phase1-terminal.sh
+++ b/scripts/install-phase1-terminal.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env sh
+set -eu
+
+PREFIX="${PREFIX:-$HOME/.local}"
+CREATE_ALIAS="${CREATE_ALIAS:-auto}"
+PHASE1_HOME_VALUE="${PHASE1_HOME:-$(pwd)}"
+BIN_DIR="$PREFIX/bin"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/phase1"
+CONFIG_FILE="$CONFIG_DIR/terminal.env"
+LAUNCHER_SOURCE="terminal/bin/phase1-terminal"
+LAUNCHER_TARGET="$BIN_DIR/phase1-terminal"
+ALIAS_TARGET="$BIN_DIR/terminal"
+
+usage() {
+    cat <<'EOF'
+Install Phase1 Terminal
+
+Usage:
+  sh scripts/install-phase1-terminal.sh [options]
+
+Options:
+  --prefix PATH       Install prefix. Default: $HOME/.local
+  --alias             Also create a terminal alias/symlink.
+  --no-alias          Do not create a terminal alias/symlink.
+  --phase1-home PATH  Set PHASE1_HOME in generated config.
+  -h, --help          Show help.
+
+Environment:
+  PREFIX              Install prefix override.
+  CREATE_ALIAS        auto, yes, or no. Default: auto.
+  PHASE1_HOME         Phase1 repository/install path.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --prefix)
+            PREFIX="$2"
+            BIN_DIR="$PREFIX/bin"
+            LAUNCHER_TARGET="$BIN_DIR/phase1-terminal"
+            ALIAS_TARGET="$BIN_DIR/terminal"
+            shift 2
+            ;;
+        --alias)
+            CREATE_ALIAS="yes"
+            shift
+            ;;
+        --no-alias)
+            CREATE_ALIAS="no"
+            shift
+            ;;
+        --phase1-home)
+            PHASE1_HOME_VALUE="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ ! -f "$LAUNCHER_SOURCE" ]; then
+    echo "installer must be run from the Phase1 repository root" >&2
+    exit 1
+fi
+
+mkdir -p "$BIN_DIR" "$CONFIG_DIR"
+cp "$LAUNCHER_SOURCE" "$LAUNCHER_TARGET"
+chmod 0755 "$LAUNCHER_TARGET"
+
+cat > "$CONFIG_FILE" <<EOF
+# Phase1 Terminal config
+PHASE1_HOME="$PHASE1_HOME_VALUE"
+PHASE1_TERMINAL_TITLE="Phase1 Terminal"
+PHASE1_THEME="cyber"
+PHASE1_SAFE_MODE="1"
+PHASE1_MOBILE_MODE="0"
+PHASE1_DEVICE_MODE="desktop"
+PHASE1_ASCII="0"
+EOF
+
+case "$CREATE_ALIAS" in
+    yes)
+        ln -sf "$LAUNCHER_TARGET" "$ALIAS_TARGET"
+        alias_status="created"
+        ;;
+    no)
+        alias_status="skipped"
+        ;;
+    auto)
+        if command -v terminal >/dev/null 2>&1; then
+            alias_status="skipped; terminal command already exists"
+        else
+            ln -sf "$LAUNCHER_TARGET" "$ALIAS_TARGET"
+            alias_status="created"
+        fi
+        ;;
+    *)
+        echo "CREATE_ALIAS must be auto, yes, or no" >&2
+        exit 1
+        ;;
+esac
+
+case ":$PATH:" in
+    *":$BIN_DIR:"*) path_hint="already in PATH" ;;
+    *) path_hint="add $BIN_DIR to PATH" ;;
+esac
+
+cat <<EOF
+Phase1 Terminal installed.
+
+Command : $LAUNCHER_TARGET
+Alias   : $alias_status
+Config  : $CONFIG_FILE
+PATH    : $path_hint
+
+Try:
+  phase1-terminal doctor
+  phase1-terminal
+EOF

--- a/scripts/install-phase1-terminal.sh
+++ b/scripts/install-phase1-terminal.sh
@@ -3,6 +3,7 @@ set -eu
 
 PREFIX="${PREFIX:-$HOME/.local}"
 CREATE_ALIAS="${CREATE_ALIAS:-auto}"
+DRY_RUN="0"
 PHASE1_HOME_VALUE="${PHASE1_HOME:-$(pwd)}"
 BIN_DIR="$PREFIX/bin"
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/phase1"
@@ -23,6 +24,7 @@ Options:
   --alias             Also create a terminal alias/symlink.
   --no-alias          Do not create a terminal alias/symlink.
   --phase1-home PATH  Set PHASE1_HOME in generated config.
+  --dry-run           Print planned actions without writing files.
   -h, --help          Show help.
 
 Environment:
@@ -32,13 +34,25 @@ Environment:
 EOF
 }
 
+refresh_paths() {
+    BIN_DIR="$PREFIX/bin"
+    LAUNCHER_TARGET="$BIN_DIR/phase1-terminal"
+    ALIAS_TARGET="$BIN_DIR/terminal"
+}
+
+say_do() {
+    if [ "$DRY_RUN" = "1" ]; then
+        echo "dry-run: $*"
+    else
+        "$@"
+    fi
+}
+
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --prefix)
             PREFIX="$2"
-            BIN_DIR="$PREFIX/bin"
-            LAUNCHER_TARGET="$BIN_DIR/phase1-terminal"
-            ALIAS_TARGET="$BIN_DIR/terminal"
+            refresh_paths
             shift 2
             ;;
         --alias)
@@ -52,6 +66,10 @@ while [ "$#" -gt 0 ]; do
         --phase1-home)
             PHASE1_HOME_VALUE="$2"
             shift 2
+            ;;
+        --dry-run)
+            DRY_RUN="1"
+            shift
             ;;
         -h|--help)
             usage
@@ -70,6 +88,28 @@ if [ ! -f "$LAUNCHER_SOURCE" ]; then
     exit 1
 fi
 
+case "$PHASE1_HOME_VALUE" in
+    "") PHASE1_HOME_VALUE="$(pwd)" ;;
+esac
+
+if [ ! -f "$PHASE1_HOME_VALUE/Cargo.toml" ] && [ ! -x "$PHASE1_HOME_VALUE/phase1" ] && [ ! -x "$PHASE1_HOME_VALUE/bin/phase1" ]; then
+    echo "warning: PHASE1_HOME does not look like a Phase1 source or install root: $PHASE1_HOME_VALUE" >&2
+fi
+
+if [ "$DRY_RUN" = "1" ]; then
+    cat <<EOF
+Phase1 Terminal install dry-run
+
+Would create : $BIN_DIR
+Would create : $CONFIG_DIR
+Would install: $LAUNCHER_SOURCE -> $LAUNCHER_TARGET
+Would config : $CONFIG_FILE
+Alias mode   : $CREATE_ALIAS
+Phase1 home  : $PHASE1_HOME_VALUE
+EOF
+    exit 0
+fi
+
 mkdir -p "$BIN_DIR" "$CONFIG_DIR"
 cp "$LAUNCHER_SOURCE" "$LAUNCHER_TARGET"
 chmod 0755 "$LAUNCHER_TARGET"
@@ -78,11 +118,13 @@ cat > "$CONFIG_FILE" <<EOF
 # Phase1 Terminal config
 PHASE1_HOME="$PHASE1_HOME_VALUE"
 PHASE1_TERMINAL_TITLE="Phase1 Terminal"
+PHASE1_TERMINAL_PROFILE="default"
 PHASE1_THEME="cyber"
 PHASE1_SAFE_MODE="1"
 PHASE1_MOBILE_MODE="0"
 PHASE1_DEVICE_MODE="desktop"
 PHASE1_ASCII="0"
+PHASE1_TERMINAL_HINTS="1"
 EOF
 
 case "$CREATE_ALIAS" in
@@ -121,6 +163,7 @@ Config  : $CONFIG_FILE
 PATH    : $path_hint
 
 Try:
-  phase1-terminal doctor
-  phase1-terminal
+  phase1-terminal doctor --verbose
+  phase1-terminal profile list
+  phase1-terminal gina
 EOF

--- a/scripts/install-phase1-terminal.sh
+++ b/scripts/install-phase1-terminal.sh
@@ -40,14 +40,6 @@ refresh_paths() {
     ALIAS_TARGET="$BIN_DIR/terminal"
 }
 
-say_do() {
-    if [ "$DRY_RUN" = "1" ]; then
-        echo "dry-run: $*"
-    else
-        "$@"
-    fi
-}
-
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --prefix)
@@ -106,6 +98,8 @@ Would install: $LAUNCHER_SOURCE -> $LAUNCHER_TARGET
 Would config : $CONFIG_FILE
 Alias mode   : $CREATE_ALIAS
 Phase1 home  : $PHASE1_HOME_VALUE
+Color mode   : auto
+Theme        : cyber
 EOF
     exit 0
 fi
@@ -120,11 +114,14 @@ PHASE1_HOME="$PHASE1_HOME_VALUE"
 PHASE1_TERMINAL_TITLE="Phase1 Terminal"
 PHASE1_TERMINAL_PROFILE="default"
 PHASE1_THEME="cyber"
+PHASE1_COLOR_MODE="auto"
+PHASE1_TERMINAL_BANNER="1"
 PHASE1_SAFE_MODE="1"
 PHASE1_MOBILE_MODE="0"
 PHASE1_DEVICE_MODE="desktop"
 PHASE1_ASCII="0"
 PHASE1_TERMINAL_HINTS="1"
+PHASE1_TERMINAL_PERF_BUDGET_MS="500"
 EOF
 
 case "$CREATE_ALIAS" in
@@ -164,6 +161,8 @@ PATH    : $path_hint
 
 Try:
   phase1-terminal doctor --verbose
-  phase1-terminal profile list
+  phase1-terminal colors detect
+  phase1-terminal theme preview all
+  phase1-terminal selftest
   phase1-terminal gina
 EOF

--- a/scripts/test-phase1-terminal.sh
+++ b/scripts/test-phase1-terminal.sh
@@ -30,12 +30,32 @@ sh terminal/bin/phase1-terminal version | grep 'phase1-terminal '
 
 echo "phase1-terminal env"
 sh terminal/bin/phase1-terminal env | grep 'PHASE1_TERMINAL_VERSION='
+sh terminal/bin/phase1-terminal env | grep 'PHASE1_DETECTED_COLOR_MODE='
 
 echo "phase1-terminal doctor --json"
 sh terminal/bin/phase1-terminal doctor --json | grep '"version"'
+sh terminal/bin/phase1-terminal doctor --json | grep '"detected_color_mode"'
+
+echo "phase1-terminal colors detect"
+sh terminal/bin/phase1-terminal colors detect | grep 'detected'
+
+echo "phase1-terminal colors swatches"
+sh terminal/bin/phase1-terminal colors swatches | grep 'cyber'
+
+echo "phase1-terminal theme list"
+sh terminal/bin/phase1-terminal theme list | grep 'themes:'
+
+echo "phase1-terminal theme preview matrix"
+sh terminal/bin/phase1-terminal theme preview matrix | grep 'matrix'
 
 echo "phase1-terminal profile list"
 sh terminal/bin/phase1-terminal profile list | grep 'profiles:'
+
+echo "phase1-terminal selftest"
+sh terminal/bin/phase1-terminal selftest | grep 'selftest: passed'
+
+echo "phase1-terminal benchmark"
+sh terminal/bin/phase1-terminal benchmark 2 | grep 'status    : completed'
 
 echo "phase1-terminal install dry-run"
 sh scripts/install-phase1-terminal.sh --dry-run --no-alias >/dev/null

--- a/scripts/test-phase1-terminal.sh
+++ b/scripts/test-phase1-terminal.sh
@@ -5,7 +5,8 @@ for file in \
     terminal/bin/phase1-terminal \
     scripts/install-phase1-terminal.sh \
     scripts/install-phase1-terminal-linux.sh \
-    scripts/install-phase1-terminal-macos.sh
+    scripts/install-phase1-terminal-macos.sh \
+    scripts/uninstall-phase1-terminal.sh
  do
     echo "sh -n $file"
     sh -n "$file"
@@ -20,5 +21,26 @@ if [ ! -f terminal/macos/Phase1-Terminal.terminal ]; then
     echo "missing macOS Terminal profile" >&2
     exit 1
 fi
+
+echo "phase1-terminal help"
+terminal/bin/phase1-terminal help >/dev/null
+
+echo "phase1-terminal version"
+terminal/bin/phase1-terminal version | grep 'phase1-terminal '
+
+echo "phase1-terminal env"
+terminal/bin/phase1-terminal env | grep 'PHASE1_TERMINAL_VERSION='
+
+echo "phase1-terminal doctor --json"
+terminal/bin/phase1-terminal doctor --json | grep '"version"'
+
+echo "phase1-terminal profile list"
+terminal/bin/phase1-terminal profile list | grep 'profiles:'
+
+echo "phase1-terminal install dry-run"
+sh scripts/install-phase1-terminal.sh --dry-run --no-alias >/dev/null
+
+echo "phase1-terminal uninstall dry-run"
+sh scripts/uninstall-phase1-terminal.sh --dry-run >/dev/null
 
 echo "Phase1 Terminal scripts validated"

--- a/scripts/test-phase1-terminal.sh
+++ b/scripts/test-phase1-terminal.sh
@@ -23,19 +23,19 @@ if [ ! -f terminal/macos/Phase1-Terminal.terminal ]; then
 fi
 
 echo "phase1-terminal help"
-terminal/bin/phase1-terminal help >/dev/null
+sh terminal/bin/phase1-terminal help >/dev/null
 
 echo "phase1-terminal version"
-terminal/bin/phase1-terminal version | grep 'phase1-terminal '
+sh terminal/bin/phase1-terminal version | grep 'phase1-terminal '
 
 echo "phase1-terminal env"
-terminal/bin/phase1-terminal env | grep 'PHASE1_TERMINAL_VERSION='
+sh terminal/bin/phase1-terminal env | grep 'PHASE1_TERMINAL_VERSION='
 
 echo "phase1-terminal doctor --json"
-terminal/bin/phase1-terminal doctor --json | grep '"version"'
+sh terminal/bin/phase1-terminal doctor --json | grep '"version"'
 
 echo "phase1-terminal profile list"
-terminal/bin/phase1-terminal profile list | grep 'profiles:'
+sh terminal/bin/phase1-terminal profile list | grep 'profiles:'
 
 echo "phase1-terminal install dry-run"
 sh scripts/install-phase1-terminal.sh --dry-run --no-alias >/dev/null

--- a/scripts/test-phase1-terminal.sh
+++ b/scripts/test-phase1-terminal.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -eu
+
+for file in \
+    terminal/bin/phase1-terminal \
+    scripts/install-phase1-terminal.sh \
+    scripts/install-phase1-terminal-linux.sh \
+    scripts/install-phase1-terminal-macos.sh
+ do
+    echo "sh -n $file"
+    sh -n "$file"
+ done
+
+if [ ! -f terminal/linux/phase1-terminal.desktop ]; then
+    echo "missing Linux desktop entry" >&2
+    exit 1
+fi
+
+if [ ! -f terminal/macos/Phase1-Terminal.terminal ]; then
+    echo "missing macOS Terminal profile" >&2
+    exit 1
+fi
+
+echo "Phase1 Terminal scripts validated"

--- a/scripts/uninstall-phase1-terminal.sh
+++ b/scripts/uninstall-phase1-terminal.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env sh
+set -eu
+
+PREFIX="${PREFIX:-$HOME/.local}"
+DRY_RUN="0"
+REMOVE_CONFIG="0"
+BIN_DIR="$PREFIX/bin"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/phase1"
+CONFIG_FILE="$CONFIG_DIR/terminal.env"
+DESKTOP_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/applications/phase1-terminal.desktop"
+MACOS_SUPPORT="$HOME/Library/Application Support/Phase1/Phase1 Terminal.command"
+MACOS_DESKTOP="$HOME/Desktop/Phase1 Terminal.command"
+LAUNCHER_TARGET="$BIN_DIR/phase1-terminal"
+ALIAS_TARGET="$BIN_DIR/terminal"
+
+usage() {
+    cat <<'EOF'
+Uninstall Phase1 Terminal
+
+Usage:
+  sh scripts/uninstall-phase1-terminal.sh [options]
+
+Options:
+  --prefix PATH       Install prefix. Default: $HOME/.local
+  --remove-config     Also remove ~/.config/phase1/terminal.env.
+  --dry-run           Print planned removals without deleting files.
+  -h, --help          Show help.
+EOF
+}
+
+refresh_paths() {
+    BIN_DIR="$PREFIX/bin"
+    LAUNCHER_TARGET="$BIN_DIR/phase1-terminal"
+    ALIAS_TARGET="$BIN_DIR/terminal"
+}
+
+remove_path() {
+    path="$1"
+    if [ -e "$path" ] || [ -L "$path" ]; then
+        if [ "$DRY_RUN" = "1" ]; then
+            echo "dry-run: remove $path"
+        else
+            rm -f "$path"
+            echo "removed: $path"
+        fi
+    fi
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --prefix)
+            PREFIX="$2"
+            refresh_paths
+            shift 2
+            ;;
+        --remove-config)
+            REMOVE_CONFIG="1"
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN="1"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+remove_path "$LAUNCHER_TARGET"
+
+if [ -L "$ALIAS_TARGET" ]; then
+    target=$(readlink "$ALIAS_TARGET" || true)
+    if [ "$target" = "$LAUNCHER_TARGET" ]; then
+        remove_path "$ALIAS_TARGET"
+    else
+        echo "skipped alias: $ALIAS_TARGET points to $target"
+    fi
+fi
+
+remove_path "$DESKTOP_FILE"
+remove_path "$MACOS_SUPPORT"
+remove_path "$MACOS_DESKTOP"
+
+if [ "$REMOVE_CONFIG" = "1" ]; then
+    remove_path "$CONFIG_FILE"
+else
+    echo "config kept: $CONFIG_FILE"
+fi
+
+if [ "$DRY_RUN" = "1" ]; then
+    echo "Phase1 Terminal uninstall dry-run complete."
+else
+    echo "Phase1 Terminal uninstall complete."
+fi

--- a/terminal/README.md
+++ b/terminal/README.md
@@ -1,10 +1,10 @@
 # Phase1 Terminal
 
-Phase1 Terminal is the dedicated launcher/profile/config/session layer for Phase1 on Linux and macOS.
+Phase1 Terminal is the dedicated launcher/profile/config/session/color layer for Phase1 on Linux and macOS.
 
-Use it when you want a consistent Phase1 entry point that configures the shell environment, discovers the Phase1 install path, launches the fastest available Phase1 binary, and provides safe management commands around the Phase1 terminal experience.
+Use it when you want a consistent Phase1 entry point that configures the shell environment, discovers the Phase1 install path, launches the fastest available Phase1 binary, detects terminal color support, previews beautiful Phase1 palettes, and provides safe management commands around the Phase1 terminal experience.
 
-Roadmap: [`../TERMINAL_ROADMAP.md`](../TERMINAL_ROADMAP.md).
+Roadmap: [`../TERMINAL_ROADMAP.md`](../TERMINAL_ROADMAP.md). Test cases: [`../TERMINAL_TEST_CASES.md`](../TERMINAL_TEST_CASES.md).
 
 ## Command
 
@@ -24,7 +24,7 @@ The project name is **Phase1 Terminal**. The installed command is `phase1-termin
 
 ```text
 terminal/
-├── bin/phase1-terminal              # launcher/config/session command
+├── bin/phase1-terminal              # launcher/config/session/color command
 ├── linux/phase1-terminal.desktop    # Linux desktop entry template
 └── macos/Phase1-Terminal.terminal   # optional Terminal.app profile
 ```
@@ -87,6 +87,8 @@ sh scripts/uninstall-phase1-terminal.sh --remove-config
 
 ```bash
 sh scripts/test-phase1-terminal.sh
+phase1-terminal selftest
+phase1-terminal benchmark 25
 ```
 
 ## Configure
@@ -104,6 +106,8 @@ PHASE1_HOME="$HOME/phase1"
 PHASE1_TERMINAL_TITLE="Phase1 Terminal"
 PHASE1_TERMINAL_PROFILE="default"
 PHASE1_THEME="cyber"
+PHASE1_COLOR_MODE="auto"
+PHASE1_TERMINAL_BANNER="1"
 PHASE1_SAFE_MODE="1"
 PHASE1_DEVICE_MODE="desktop"
 PHASE1_TERMINAL_HINTS="1"
@@ -114,7 +118,35 @@ Config commands:
 ```bash
 phase1-terminal config show
 phase1-terminal config set PHASE1_THEME=matrix
+phase1-terminal config set PHASE1_COLOR_MODE=truecolor
 phase1-terminal config reset
+```
+
+## Color and themes
+
+```bash
+phase1-terminal colors detect
+phase1-terminal colors swatches
+phase1-terminal theme list
+phase1-terminal theme preview cyber
+phase1-terminal theme preview matrix
+phase1-terminal theme preview all
+NO_COLOR=1 phase1-terminal theme preview all
+```
+
+Themes:
+
+```text
+cyber matrix amber mono safe developer base1 ice synthwave crimson
+```
+
+Phase1 Terminal exports color data to Phase1:
+
+```text
+PHASE1_THEME
+PHASE1_COLOR_MODE
+PHASE1_TERMINAL_DETECTED_COLOR_MODE
+PHASE1_TERMINAL_BANNER
 ```
 
 ## Profiles
@@ -127,6 +159,8 @@ phase1-terminal profile apply mono
 phase1-terminal profile apply safe
 phase1-terminal profile apply developer
 phase1-terminal profile apply base1
+phase1-terminal profile apply ice
+phase1-terminal profile apply crimson
 ```
 
 ## Session commands
@@ -151,6 +185,8 @@ phase1-terminal check
 phase1-terminal logs
 phase1-terminal env
 phase1-terminal version
+phase1-terminal selftest
+phase1-terminal benchmark 25
 ```
 
 ## Roadmap
@@ -161,6 +197,6 @@ Read: [`../TERMINAL_ROADMAP.md`](../TERMINAL_ROADMAP.md).
 
 ## Safety model
 
-Phase1 Terminal does not enable host-trust, host-network mutation, or external AI provider settings. It launches Phase1 with safe defaults and leaves higher-trust modes to Phase1's normal boot controls.
+Phase1 Terminal launches Phase1 with safe defaults, uses allowlisted config keys, supports mono fallback, and leaves higher-trust modes to Phase1's normal boot controls.
 
 See `TERMINAL.md` for full usage details.

--- a/terminal/README.md
+++ b/terminal/README.md
@@ -1,0 +1,87 @@
+# Phase1 Terminal
+
+Phase1 Terminal is the dedicated launcher/profile layer for Phase1 on Linux and macOS.
+
+Use it when you want a consistent Phase1 entry point that configures the shell environment, discovers the Phase1 install path, and launches the fastest available Phase1 binary.
+
+## Command
+
+```bash
+phase1-terminal
+```
+
+Optional alias:
+
+```bash
+terminal
+```
+
+The project name is **Phase1 Terminal**. The installed command is `phase1-terminal` to avoid clashing with existing system commands. The installer can create a `terminal` alias when safe.
+
+## Layout
+
+```text
+terminal/
+├── bin/phase1-terminal              # launcher command
+├── linux/phase1-terminal.desktop    # Linux desktop entry template
+└── macos/Phase1-Terminal.terminal   # optional Terminal.app profile
+```
+
+Installer scripts live in `scripts/`:
+
+```text
+scripts/install-phase1-terminal.sh
+scripts/install-phase1-terminal-linux.sh
+scripts/install-phase1-terminal-macos.sh
+scripts/test-phase1-terminal.sh
+```
+
+## Install
+
+Linux:
+
+```bash
+sh scripts/install-phase1-terminal-linux.sh
+```
+
+macOS:
+
+```bash
+sh scripts/install-phase1-terminal-macos.sh
+```
+
+Generic:
+
+```bash
+sh scripts/install-phase1-terminal.sh
+```
+
+## Validate
+
+```bash
+sh scripts/test-phase1-terminal.sh
+```
+
+## Configure
+
+Default config file:
+
+```text
+~/.config/phase1/terminal.env
+```
+
+Useful values:
+
+```sh
+PHASE1_HOME="$HOME/phase1"
+PHASE1_TERMINAL_TITLE="Phase1 Terminal"
+PHASE1_THEME="cyber"
+PHASE1_SAFE_MODE="1"
+PHASE1_DEVICE_MODE="desktop"
+```
+
+## Safety model
+
+Phase1 Terminal does not enable host-trust or host-network mutation settings. It launches Phase1 with safe defaults and leaves higher-trust modes to Phase1's normal boot controls.
+
+See `TERMINAL.md` for full usage details.

--- a/terminal/README.md
+++ b/terminal/README.md
@@ -1,8 +1,8 @@
 # Phase1 Terminal
 
-Phase1 Terminal is the dedicated launcher/profile layer for Phase1 on Linux and macOS.
+Phase1 Terminal is the dedicated launcher/profile/config/session layer for Phase1 on Linux and macOS.
 
-Use it when you want a consistent Phase1 entry point that configures the shell environment, discovers the Phase1 install path, and launches the fastest available Phase1 binary.
+Use it when you want a consistent Phase1 entry point that configures the shell environment, discovers the Phase1 install path, launches the fastest available Phase1 binary, and provides safe management commands around the Phase1 terminal experience.
 
 Roadmap: [`../TERMINAL_ROADMAP.md`](../TERMINAL_ROADMAP.md).
 
@@ -24,7 +24,7 @@ The project name is **Phase1 Terminal**. The installed command is `phase1-termin
 
 ```text
 terminal/
-├── bin/phase1-terminal              # launcher command
+├── bin/phase1-terminal              # launcher/config/session command
 ├── linux/phase1-terminal.desktop    # Linux desktop entry template
 └── macos/Phase1-Terminal.terminal   # optional Terminal.app profile
 ```
@@ -35,6 +35,7 @@ Installer scripts live in `scripts/`:
 scripts/install-phase1-terminal.sh
 scripts/install-phase1-terminal-linux.sh
 scripts/install-phase1-terminal-macos.sh
+scripts/uninstall-phase1-terminal.sh
 scripts/test-phase1-terminal.sh
 ```
 
@@ -58,6 +59,30 @@ Generic:
 sh scripts/install-phase1-terminal.sh
 ```
 
+Dry-run:
+
+```bash
+sh scripts/install-phase1-terminal.sh --dry-run
+```
+
+## Uninstall
+
+```bash
+sh scripts/uninstall-phase1-terminal.sh
+```
+
+Dry-run:
+
+```bash
+sh scripts/uninstall-phase1-terminal.sh --dry-run
+```
+
+Remove config explicitly:
+
+```bash
+sh scripts/uninstall-phase1-terminal.sh --remove-config
+```
+
 ## Validate
 
 ```bash
@@ -77,9 +102,55 @@ Useful values:
 ```sh
 PHASE1_HOME="$HOME/phase1"
 PHASE1_TERMINAL_TITLE="Phase1 Terminal"
+PHASE1_TERMINAL_PROFILE="default"
 PHASE1_THEME="cyber"
 PHASE1_SAFE_MODE="1"
 PHASE1_DEVICE_MODE="desktop"
+PHASE1_TERMINAL_HINTS="1"
+```
+
+Config commands:
+
+```bash
+phase1-terminal config show
+phase1-terminal config set PHASE1_THEME=matrix
+phase1-terminal config reset
+```
+
+## Profiles
+
+```bash
+phase1-terminal profile list
+phase1-terminal profile apply cyber
+phase1-terminal profile apply matrix
+phase1-terminal profile apply mono
+phase1-terminal profile apply safe
+phase1-terminal profile apply developer
+phase1-terminal profile apply base1
+```
+
+## Session commands
+
+```bash
+phase1-terminal run
+phase1-terminal safe
+phase1-terminal dev
+phase1-terminal demo
+phase1-terminal base1
+phase1-terminal gina
+phase1-terminal security
+```
+
+## Management commands
+
+```bash
+phase1-terminal doctor --verbose
+phase1-terminal doctor --json
+phase1-terminal build
+phase1-terminal check
+phase1-terminal logs
+phase1-terminal env
+phase1-terminal version
 ```
 
 ## Roadmap
@@ -90,6 +161,6 @@ Read: [`../TERMINAL_ROADMAP.md`](../TERMINAL_ROADMAP.md).
 
 ## Safety model
 
-Phase1 Terminal does not enable host-trust or host-network mutation settings. It launches Phase1 with safe defaults and leaves higher-trust modes to Phase1's normal boot controls.
+Phase1 Terminal does not enable host-trust, host-network mutation, or external AI provider settings. It launches Phase1 with safe defaults and leaves higher-trust modes to Phase1's normal boot controls.
 
 See `TERMINAL.md` for full usage details.

--- a/terminal/README.md
+++ b/terminal/README.md
@@ -4,6 +4,8 @@ Phase1 Terminal is the dedicated launcher/profile layer for Phase1 on Linux and 
 
 Use it when you want a consistent Phase1 entry point that configures the shell environment, discovers the Phase1 install path, and launches the fastest available Phase1 binary.
 
+Roadmap: [`../TERMINAL_ROADMAP.md`](../TERMINAL_ROADMAP.md).
+
 ## Command
 
 ```bash
@@ -79,6 +81,12 @@ PHASE1_THEME="cyber"
 PHASE1_SAFE_MODE="1"
 PHASE1_DEVICE_MODE="desktop"
 ```
+
+## Roadmap
+
+The Phase1 Terminal roadmap covers installer hardening, profile UX, session management, Gina-aware workflows, packaging, and native terminal exploration.
+
+Read: [`../TERMINAL_ROADMAP.md`](../TERMINAL_ROADMAP.md).
 
 ## Safety model
 

--- a/terminal/bin/phase1-terminal
+++ b/terminal/bin/phase1-terminal
@@ -2,7 +2,7 @@
 set -eu
 
 APP_NAME="Phase1 Terminal"
-VERSION="0.2.0"
+VERSION="0.3.0"
 CONFIG_FILE="${PHASE1_TERMINAL_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/phase1/terminal.env}"
 CONFIG_DIR=$(dirname "$CONFIG_FILE")
 
@@ -19,6 +19,12 @@ fi
 : "${PHASE1_ASCII:=0}"
 : "${PHASE1_TERMINAL_PROFILE:=default}"
 : "${PHASE1_TERMINAL_HINTS:=1}"
+: "${PHASE1_COLOR_MODE:=auto}"
+: "${PHASE1_TERMINAL_BANNER:=1}"
+: "${PHASE1_TERMINAL_PERF_BUDGET_MS:=500}"
+
+ESC=$(printf '\033')
+RESET="${ESC}[0m"
 
 print_help() {
     cat <<'EOF'
@@ -26,20 +32,18 @@ Phase1 Terminal
 
 Usage:
   phase1-terminal [run] [phase1 args...]
-  phase1-terminal safe
-  phase1-terminal dev
-  phase1-terminal demo
-  phase1-terminal base1
-  phase1-terminal gina
-  phase1-terminal security
-  phase1-terminal build
-  phase1-terminal check
-  phase1-terminal logs
+  phase1-terminal safe | dev | demo | base1
+  phase1-terminal gina | security
+  phase1-terminal build | check | logs
   phase1-terminal doctor [--verbose|--json]
+  phase1-terminal colors [detect|swatches]
+  phase1-terminal theme [list|preview NAME|preview all]
   phase1-terminal config show
   phase1-terminal config set KEY=VALUE
   phase1-terminal config reset
   phase1-terminal profile [list|show|apply NAME]
+  phase1-terminal selftest
+  phase1-terminal benchmark [iterations]
   phase1-terminal env
   phase1-terminal version
   phase1-terminal help
@@ -48,6 +52,7 @@ Environment:
   PHASE1_HOME              Path to the Phase1 repository or install root.
   PHASE1_TERMINAL_CONFIG   Optional config file path.
   PHASE1_THEME             Default terminal theme passed to Phase1.
+  PHASE1_COLOR_MODE        auto, truecolor, 256, ansi, or mono.
   PHASE1_SAFE_MODE         Defaults to 1.
   PHASE1_DEVICE_MODE       Defaults to desktop.
 
@@ -70,6 +75,164 @@ write_title() {
 
 json_escape() {
     printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+terminal_color_count() {
+    if command -v tput >/dev/null 2>&1; then
+        tput colors 2>/dev/null || printf '0\n'
+    else
+        printf '0\n'
+    fi
+}
+
+detect_color_mode() {
+    if [ "${NO_COLOR:-}" != "" ]; then
+        echo "mono"
+        return 0
+    fi
+
+    case "$PHASE1_COLOR_MODE" in
+        truecolor|24bit) echo "truecolor" ;;
+        256|256color) echo "256" ;;
+        ansi|8|16) echo "ansi" ;;
+        mono|none|off|0) echo "mono" ;;
+        auto|"")
+            case "${COLORTERM:-}" in
+                *truecolor*|*24bit*) echo "truecolor"; return 0 ;;
+            esac
+            colors=$(terminal_color_count)
+            case "$colors" in
+                ''|*[!0-9]*) colors=0 ;;
+            esac
+            if [ "$colors" -ge 256 ]; then
+                echo "256"
+            elif [ "$colors" -ge 8 ]; then
+                echo "ansi"
+            else
+                case "${TERM:-}" in
+                    xterm*|screen*|tmux*|vt100*|ansi*) echo "ansi" ;;
+                    *) echo "mono" ;;
+                esac
+            fi
+            ;;
+        *) echo "auto" ;;
+    esac
+}
+
+color_enabled() {
+    mode=$(detect_color_mode)
+    [ "$mode" != "mono" ]
+}
+
+fg256() {
+    if color_enabled; then
+        printf '%s' "${ESC}[38;5;$1m"
+    fi
+}
+
+bg256() {
+    if color_enabled; then
+        printf '%s' "${ESC}[48;5;$1m"
+    fi
+}
+
+bold() {
+    if color_enabled; then
+        printf '%s' "${ESC}[1m"
+    fi
+}
+
+reset_color() {
+    if color_enabled; then
+        printf '%s' "$RESET"
+    fi
+}
+
+theme_codes() {
+    case "$1" in
+        matrix) echo "46 82 40 118" ;;
+        amber|base1) echo "214 220 178 94" ;;
+        mono|safe) echo "250 245 240 238" ;;
+        ice) echo "81 117 159 195" ;;
+        synthwave|developer) echo "201 99 45 213" ;;
+        crimson) echo "196 160 88 52" ;;
+        cyber|default|*) echo "51 45 201 118" ;;
+    esac
+}
+
+theme_list() {
+    cat <<'EOF'
+themes:
+  cyber
+  matrix
+  amber
+  mono
+  safe
+  developer
+  base1
+  ice
+  synthwave
+  crimson
+EOF
+}
+
+print_swatch() {
+    theme="$1"
+    set -- $(theme_codes "$theme")
+    a="$1"; b="$2"; c="$3"; d="$4"
+    printf '%-10s ' "$theme"
+    if color_enabled; then
+        bg256 "$a"; printf '  '; reset_color
+        bg256 "$b"; printf '  '; reset_color
+        bg256 "$c"; printf '  '; reset_color
+        bg256 "$d"; printf '  '; reset_color
+        printf ' '
+        fg256 "$a"; printf 'Phase'; reset_color
+        fg256 "$b"; printf '1 '; reset_color
+        fg256 "$c"; printf 'Terminal'; reset_color
+    else
+        printf '[%s %s %s %s] Phase1 Terminal' "$a" "$b" "$c" "$d"
+    fi
+    printf '\n'
+}
+
+theme_preview() {
+    target="${1:-$PHASE1_THEME}"
+    if [ "$target" = "all" ]; then
+        for theme in cyber matrix amber mono safe developer base1 ice synthwave crimson; do
+            print_swatch "$theme"
+        done
+        return 0
+    fi
+    print_swatch "$target"
+    printf 'theme       : %s\n' "$target"
+    printf 'color mode  : %s\n' "$(detect_color_mode)"
+    printf 'phase1 env  : PHASE1_THEME=%s PHASE1_COLOR_MODE=%s\n' "$target" "$(detect_color_mode)"
+}
+
+colors_cmd() {
+    sub="${1:-detect}"
+    case "$sub" in
+        detect)
+            cat <<EOF
+Phase1 Terminal color detection
+configured : $PHASE1_COLOR_MODE
+detected   : $(detect_color_mode)
+TERM       : ${TERM:-}
+COLORTERM  : ${COLORTERM:-}
+NO_COLOR   : ${NO_COLOR:-}
+tput colors: $(terminal_color_count)
+theme      : $PHASE1_THEME
+EOF
+            ;;
+        swatches|preview)
+            theme_preview all
+            ;;
+        *)
+            echo "usage: phase1-terminal colors [detect|swatches]" >&2
+            exit 1
+            ;;
+    esac
 }
 
 find_phase1_home() {
@@ -127,11 +290,15 @@ PHASE1_TERMINAL_CONFIG=$CONFIG_FILE
 PHASE1_TERMINAL_PROFILE=$PHASE1_TERMINAL_PROFILE
 PHASE1_HOME=${PHASE1_HOME:-}
 PHASE1_THEME=$PHASE1_THEME
+PHASE1_COLOR_MODE=$PHASE1_COLOR_MODE
+PHASE1_DETECTED_COLOR_MODE=$(detect_color_mode)
+PHASE1_TERMINAL_BANNER=$PHASE1_TERMINAL_BANNER
 PHASE1_SAFE_MODE=$PHASE1_SAFE_MODE
 PHASE1_MOBILE_MODE=$PHASE1_MOBILE_MODE
 PHASE1_DEVICE_MODE=$PHASE1_DEVICE_MODE
 PHASE1_ASCII=$PHASE1_ASCII
 PHASE1_TERMINAL_HINTS=$PHASE1_TERMINAL_HINTS
+PHASE1_TERMINAL_PERF_BUDGET_MS=$PHASE1_TERMINAL_PERF_BUDGET_MS
 EOF
 }
 
@@ -147,11 +314,14 @@ PHASE1_HOME="${PHASE1_HOME:-}"
 PHASE1_TERMINAL_TITLE="$PHASE1_TERMINAL_TITLE"
 PHASE1_TERMINAL_PROFILE="$PHASE1_TERMINAL_PROFILE"
 PHASE1_THEME="$PHASE1_THEME"
+PHASE1_COLOR_MODE="$PHASE1_COLOR_MODE"
+PHASE1_TERMINAL_BANNER="$PHASE1_TERMINAL_BANNER"
 PHASE1_SAFE_MODE="$PHASE1_SAFE_MODE"
 PHASE1_MOBILE_MODE="$PHASE1_MOBILE_MODE"
 PHASE1_DEVICE_MODE="$PHASE1_DEVICE_MODE"
 PHASE1_ASCII="$PHASE1_ASCII"
 PHASE1_TERMINAL_HINTS="$PHASE1_TERMINAL_HINTS"
+PHASE1_TERMINAL_PERF_BUDGET_MS="$PHASE1_TERMINAL_PERF_BUDGET_MS"
 EOF
 }
 
@@ -167,7 +337,7 @@ config_show() {
 config_set() {
     pair="${1:-}"
     case "$pair" in
-        PHASE1_HOME=*|PHASE1_TERMINAL_TITLE=*|PHASE1_TERMINAL_PROFILE=*|PHASE1_THEME=*|PHASE1_SAFE_MODE=*|PHASE1_MOBILE_MODE=*|PHASE1_DEVICE_MODE=*|PHASE1_ASCII=*|PHASE1_TERMINAL_HINTS=*)
+        PHASE1_HOME=*|PHASE1_TERMINAL_TITLE=*|PHASE1_TERMINAL_PROFILE=*|PHASE1_THEME=*|PHASE1_COLOR_MODE=*|PHASE1_TERMINAL_BANNER=*|PHASE1_SAFE_MODE=*|PHASE1_MOBILE_MODE=*|PHASE1_DEVICE_MODE=*|PHASE1_ASCII=*|PHASE1_TERMINAL_HINTS=*|PHASE1_TERMINAL_PERF_BUDGET_MS=*)
             key=${pair%%=*}
             value=${pair#*=}
             case "$key" in
@@ -175,11 +345,14 @@ config_set() {
                 PHASE1_TERMINAL_TITLE) PHASE1_TERMINAL_TITLE=$value ;;
                 PHASE1_TERMINAL_PROFILE) PHASE1_TERMINAL_PROFILE=$value ;;
                 PHASE1_THEME) PHASE1_THEME=$value ;;
+                PHASE1_COLOR_MODE) PHASE1_COLOR_MODE=$value ;;
+                PHASE1_TERMINAL_BANNER) PHASE1_TERMINAL_BANNER=$value ;;
                 PHASE1_SAFE_MODE) PHASE1_SAFE_MODE=$value ;;
                 PHASE1_MOBILE_MODE) PHASE1_MOBILE_MODE=$value ;;
                 PHASE1_DEVICE_MODE) PHASE1_DEVICE_MODE=$value ;;
                 PHASE1_ASCII) PHASE1_ASCII=$value ;;
                 PHASE1_TERMINAL_HINTS) PHASE1_TERMINAL_HINTS=$value ;;
+                PHASE1_TERMINAL_PERF_BUDGET_MS) PHASE1_TERMINAL_PERF_BUDGET_MS=$value ;;
             esac
             write_config
             echo "config: set $key"
@@ -190,8 +363,9 @@ config_set() {
             ;;
         *)
             echo "config: unsupported key. Allowed keys:" >&2
-            echo "  PHASE1_HOME PHASE1_TERMINAL_TITLE PHASE1_TERMINAL_PROFILE PHASE1_THEME" >&2
-            echo "  PHASE1_SAFE_MODE PHASE1_MOBILE_MODE PHASE1_DEVICE_MODE PHASE1_ASCII PHASE1_TERMINAL_HINTS" >&2
+            echo "  PHASE1_HOME PHASE1_TERMINAL_TITLE PHASE1_TERMINAL_PROFILE PHASE1_THEME PHASE1_COLOR_MODE" >&2
+            echo "  PHASE1_TERMINAL_BANNER PHASE1_SAFE_MODE PHASE1_MOBILE_MODE PHASE1_DEVICE_MODE" >&2
+            echo "  PHASE1_ASCII PHASE1_TERMINAL_HINTS PHASE1_TERMINAL_PERF_BUDGET_MS" >&2
             exit 1
             ;;
     esac
@@ -201,11 +375,14 @@ config_reset() {
     PHASE1_TERMINAL_TITLE="$APP_NAME"
     PHASE1_TERMINAL_PROFILE="default"
     PHASE1_THEME="cyber"
+    PHASE1_COLOR_MODE="auto"
+    PHASE1_TERMINAL_BANNER="1"
     PHASE1_SAFE_MODE="1"
     PHASE1_MOBILE_MODE="0"
     PHASE1_DEVICE_MODE="desktop"
     PHASE1_ASCII="0"
     PHASE1_TERMINAL_HINTS="1"
+    PHASE1_TERMINAL_PERF_BUDGET_MS="500"
     write_config
     echo "config: reset $CONFIG_FILE"
 }
@@ -213,14 +390,16 @@ config_reset() {
 profile_list() {
     cat <<'EOF'
 profiles:
-  default    cyber theme, safe desktop defaults
+  default    cyber theme, auto color, safe desktop defaults
   cyber      neon/cyber Phase1 defaults
-  matrix     matrix theme with safe desktop defaults
-  amber      amber theme with safe desktop defaults
+  matrix     matrix green console palette
+  amber      warm amber hardware-console palette
   mono       ASCII/mono-friendly safe profile
   safe       conservative safe-mode profile
-  developer  developer-friendly theme, still safe by default
+  developer  synthwave developer-friendly safe profile
   base1      Base1-focused safe profile
+  ice        cool blue high-contrast palette
+  crimson    red defensive/security palette
 EOF
 }
 
@@ -228,19 +407,23 @@ apply_profile_vars() {
     name="$1"
     case "$name" in
         default|cyber)
-            PHASE1_TERMINAL_PROFILE="$name"; PHASE1_THEME="cyber"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="desktop" ;;
+            PHASE1_TERMINAL_PROFILE="$name"; PHASE1_THEME="cyber"; PHASE1_COLOR_MODE="auto"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="desktop" ;;
         matrix)
-            PHASE1_TERMINAL_PROFILE="matrix"; PHASE1_THEME="matrix"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="desktop" ;;
+            PHASE1_TERMINAL_PROFILE="matrix"; PHASE1_THEME="matrix"; PHASE1_COLOR_MODE="auto"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="desktop" ;;
         amber)
-            PHASE1_TERMINAL_PROFILE="amber"; PHASE1_THEME="amber"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="desktop" ;;
+            PHASE1_TERMINAL_PROFILE="amber"; PHASE1_THEME="amber"; PHASE1_COLOR_MODE="auto"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="desktop" ;;
         mono)
-            PHASE1_TERMINAL_PROFILE="mono"; PHASE1_THEME="mono"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="1"; PHASE1_DEVICE_MODE="desktop" ;;
+            PHASE1_TERMINAL_PROFILE="mono"; PHASE1_THEME="mono"; PHASE1_COLOR_MODE="mono"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="1"; PHASE1_DEVICE_MODE="desktop" ;;
         safe)
-            PHASE1_TERMINAL_PROFILE="safe"; PHASE1_THEME="cyber"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="desktop" ;;
+            PHASE1_TERMINAL_PROFILE="safe"; PHASE1_THEME="cyber"; PHASE1_COLOR_MODE="auto"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="desktop" ;;
         developer|dev)
-            PHASE1_TERMINAL_PROFILE="developer"; PHASE1_THEME="synthwave"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="desktop" ;;
+            PHASE1_TERMINAL_PROFILE="developer"; PHASE1_THEME="synthwave"; PHASE1_COLOR_MODE="auto"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="desktop" ;;
         base1)
-            PHASE1_TERMINAL_PROFILE="base1"; PHASE1_THEME="amber"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="base1" ;;
+            PHASE1_TERMINAL_PROFILE="base1"; PHASE1_THEME="amber"; PHASE1_COLOR_MODE="auto"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="base1" ;;
+        ice)
+            PHASE1_TERMINAL_PROFILE="ice"; PHASE1_THEME="ice"; PHASE1_COLOR_MODE="auto"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="desktop" ;;
+        crimson)
+            PHASE1_TERMINAL_PROFILE="crimson"; PHASE1_THEME="crimson"; PHASE1_COLOR_MODE="auto"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="desktop" ;;
         *)
             echo "profile: unknown profile '$name'" >&2
             profile_list >&2
@@ -273,6 +456,8 @@ doctor_text() {
     echo "system : $(uname -s 2>/dev/null || echo unknown)"
     echo "config : $CONFIG_FILE"
     echo "profile: $PHASE1_TERMINAL_PROFILE"
+    echo "theme  : $PHASE1_THEME"
+    echo "color  : $(detect_color_mode)"
 
     if phase1_home=$(find_phase1_home); then
         echo "home   : $phase1_home"
@@ -300,10 +485,13 @@ doctor_text() {
     fi
 
     if [ "$verbose" = "1" ]; then
-        echo "theme  : $PHASE1_THEME"
+        echo "term   : ${TERM:-}"
+        echo "colort : ${COLORTERM:-}"
+        echo "tput   : $(terminal_color_count)"
         echo "safe   : $PHASE1_SAFE_MODE"
         echo "device : $PHASE1_DEVICE_MODE"
         echo "ascii  : $PHASE1_ASCII"
+        echo "banner : $PHASE1_TERMINAL_BANNER"
         echo "hints  : $PHASE1_TERMINAL_HINTS"
         if phase1_home=$(find_phase1_home); then
             if [ -f "$phase1_home/plugins/gina.wasm" ] || [ -f "$phase1_home/plugins/gina.wasi" ]; then
@@ -328,6 +516,11 @@ doctor_json() {
     printf '  "version": "%s",\n' "$(json_escape "$VERSION")"
     printf '  "config": "%s",\n' "$(json_escape "$CONFIG_FILE")"
     printf '  "profile": "%s",\n' "$(json_escape "$PHASE1_TERMINAL_PROFILE")"
+    printf '  "theme": "%s",\n' "$(json_escape "$PHASE1_THEME")"
+    printf '  "configured_color_mode": "%s",\n' "$(json_escape "$PHASE1_COLOR_MODE")"
+    printf '  "detected_color_mode": "%s",\n' "$(json_escape "$(detect_color_mode)")"
+    printf '  "term": "%s",\n' "$(json_escape "${TERM:-}")"
+    printf '  "colorterm": "%s",\n' "$(json_escape "${COLORTERM:-}")"
     printf '  "home": "%s",\n' "$(json_escape "$home")"
     printf '  "binary": "%s",\n' "$(json_escape "$binary")"
     printf '  "cargo": "%s",\n' "$(json_escape "$cargo")"
@@ -343,6 +536,70 @@ doctor() {
         --verbose|-v|verbose) doctor_text 1 ;;
         *) doctor_text 0 ;;
     esac
+}
+
+now_s() {
+    date +%s 2>/dev/null || echo 0
+}
+
+selftest() {
+    failures=0
+    echo "Phase1 Terminal selftest"
+    for profile in cyber matrix amber mono safe developer base1 ice crimson; do
+        apply_profile_vars "$profile"
+        if [ "$PHASE1_TERMINAL_PROFILE" = "" ]; then
+            echo "fail: profile $profile"
+            failures=$((failures + 1))
+        fi
+    done
+    mode=$(detect_color_mode)
+    case "$mode" in
+        truecolor|256|ansi|mono|auto) echo "ok: color detection -> $mode" ;;
+        *) echo "fail: color detection -> $mode"; failures=$((failures + 1)) ;;
+    esac
+    if doctor_json | grep '"detected_color_mode"' >/dev/null 2>&1; then
+        echo "ok: doctor json includes color"
+    else
+        echo "fail: doctor json color"
+        failures=$((failures + 1))
+    fi
+    if theme_preview cyber >/dev/null 2>&1; then
+        echo "ok: theme preview"
+    else
+        echo "fail: theme preview"
+        failures=$((failures + 1))
+    fi
+    if [ "$failures" -eq 0 ]; then
+        echo "selftest: passed"
+        return 0
+    fi
+    echo "selftest: failed ($failures)"
+    return 1
+}
+
+benchmark() {
+    iterations="${1:-25}"
+    case "$iterations" in
+        ''|*[!0-9]*) iterations=25 ;;
+    esac
+    if [ "$iterations" -lt 1 ]; then
+        iterations=1
+    fi
+    start=$(now_s)
+    i=0
+    while [ "$i" -lt "$iterations" ]; do
+        detect_color_mode >/dev/null
+        doctor_json >/dev/null
+        theme_preview cyber >/dev/null
+        i=$((i + 1))
+    done
+    end=$(now_s)
+    elapsed=$((end - start))
+    echo "Phase1 Terminal benchmark"
+    echo "iterations: $iterations"
+    echo "elapsed_s : $elapsed"
+    echo "budget_ms : $PHASE1_TERMINAL_PERF_BUDGET_MS"
+    echo "status    : completed"
 }
 
 phase1_run_command() {
@@ -378,7 +635,10 @@ phase1_run_command() {
 
 run_phase1() {
     write_title
-    export PHASE1_THEME PHASE1_SAFE_MODE PHASE1_MOBILE_MODE PHASE1_DEVICE_MODE PHASE1_ASCII
+    detected_color=$(detect_color_mode)
+    export PHASE1_THEME PHASE1_COLOR_MODE PHASE1_TERMINAL_BANNER
+    export PHASE1_TERMINAL_DETECTED_COLOR_MODE="$detected_color"
+    export PHASE1_SAFE_MODE PHASE1_MOBILE_MODE PHASE1_DEVICE_MODE PHASE1_ASCII
     phase1_run_command "$@"
 }
 
@@ -485,6 +745,25 @@ case "$command_name" in
     doctor)
         shift || true
         doctor "${1:-}"
+        ;;
+    colors|color)
+        shift || true
+        colors_cmd "${1:-detect}"
+        ;;
+    theme)
+        shift || true
+        case "${1:-list}" in
+            list) theme_list ;;
+            preview) shift || true; theme_preview "${1:-$PHASE1_THEME}" ;;
+            *) echo "usage: phase1-terminal theme [list|preview NAME|preview all]" >&2; exit 1 ;;
+        esac
+        ;;
+    selftest)
+        selftest
+        ;;
+    benchmark|bench|perf)
+        shift || true
+        benchmark "${1:-25}"
         ;;
     env)
         print_env

--- a/terminal/bin/phase1-terminal
+++ b/terminal/bin/phase1-terminal
@@ -2,7 +2,9 @@
 set -eu
 
 APP_NAME="Phase1 Terminal"
+VERSION="0.2.0"
 CONFIG_FILE="${PHASE1_TERMINAL_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/phase1/terminal.env}"
+CONFIG_DIR=$(dirname "$CONFIG_FILE")
 
 if [ -f "$CONFIG_FILE" ]; then
     # shellcheck disable=SC1090
@@ -15,6 +17,8 @@ fi
 : "${PHASE1_MOBILE_MODE:=0}"
 : "${PHASE1_DEVICE_MODE:=desktop}"
 : "${PHASE1_ASCII:=0}"
+: "${PHASE1_TERMINAL_PROFILE:=default}"
+: "${PHASE1_TERMINAL_HINTS:=1}"
 
 print_help() {
     cat <<'EOF'
@@ -22,8 +26,22 @@ Phase1 Terminal
 
 Usage:
   phase1-terminal [run] [phase1 args...]
-  phase1-terminal doctor
+  phase1-terminal safe
+  phase1-terminal dev
+  phase1-terminal demo
+  phase1-terminal base1
+  phase1-terminal gina
+  phase1-terminal security
+  phase1-terminal build
+  phase1-terminal check
+  phase1-terminal logs
+  phase1-terminal doctor [--verbose|--json]
+  phase1-terminal config show
+  phase1-terminal config set KEY=VALUE
+  phase1-terminal config reset
+  phase1-terminal profile [list|show|apply NAME]
   phase1-terminal env
+  phase1-terminal version
   phase1-terminal help
 
 Environment:
@@ -36,7 +54,12 @@ Environment:
 Notes:
   The installed command is phase1-terminal.
   The installer creates a terminal alias only when it is safe or explicitly requested.
+  Phase1 Terminal never enables host trust, network mutation, or external AI providers.
 EOF
+}
+
+version() {
+    echo "phase1-terminal $VERSION"
 }
 
 write_title() {
@@ -45,10 +68,16 @@ write_title() {
     fi
 }
 
+json_escape() {
+    printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
 find_phase1_home() {
     if [ "${PHASE1_HOME:-}" != "" ]; then
-        printf '%s\n' "$PHASE1_HOME"
-        return 0
+        if [ -f "$PHASE1_HOME/Cargo.toml" ] || [ -x "$PHASE1_HOME/phase1" ] || [ -x "$PHASE1_HOME/bin/phase1" ]; then
+            printf '%s\n' "$PHASE1_HOME"
+            return 0
+        fi
     fi
 
     if [ -f "Cargo.toml" ] && [ -d "src" ]; then
@@ -61,34 +90,201 @@ find_phase1_home() {
             printf '%s\n' "$candidate"
             return 0
         fi
+        if [ -x "$candidate/phase1" ] || [ -x "$candidate/bin/phase1" ]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
     done
 
     return 1
 }
 
+phase1_binary_path() {
+    if phase1_home=$(find_phase1_home); then
+        for candidate in \
+            "$phase1_home/target/release/phase1" \
+            "$phase1_home/target/debug/phase1" \
+            "$phase1_home/bin/phase1" \
+            "$phase1_home/phase1"; do
+            if [ -x "$candidate" ]; then
+                printf '%s\n' "$candidate"
+                return 0
+            fi
+        done
+    fi
+    if command -v phase1 >/dev/null 2>&1; then
+        command -v phase1
+        return 0
+    fi
+    return 1
+}
+
 print_env() {
     cat <<EOF
+PHASE1_TERMINAL_VERSION=$VERSION
 PHASE1_TERMINAL_TITLE=$PHASE1_TERMINAL_TITLE
 PHASE1_TERMINAL_CONFIG=$CONFIG_FILE
+PHASE1_TERMINAL_PROFILE=$PHASE1_TERMINAL_PROFILE
 PHASE1_HOME=${PHASE1_HOME:-}
 PHASE1_THEME=$PHASE1_THEME
 PHASE1_SAFE_MODE=$PHASE1_SAFE_MODE
 PHASE1_MOBILE_MODE=$PHASE1_MOBILE_MODE
 PHASE1_DEVICE_MODE=$PHASE1_DEVICE_MODE
 PHASE1_ASCII=$PHASE1_ASCII
+PHASE1_TERMINAL_HINTS=$PHASE1_TERMINAL_HINTS
 EOF
 }
 
-doctor() {
+ensure_config_dir() {
+    mkdir -p "$CONFIG_DIR"
+}
+
+write_config() {
+    ensure_config_dir
+    cat > "$CONFIG_FILE" <<EOF
+# Phase1 Terminal config
+PHASE1_HOME="${PHASE1_HOME:-}"
+PHASE1_TERMINAL_TITLE="$PHASE1_TERMINAL_TITLE"
+PHASE1_TERMINAL_PROFILE="$PHASE1_TERMINAL_PROFILE"
+PHASE1_THEME="$PHASE1_THEME"
+PHASE1_SAFE_MODE="$PHASE1_SAFE_MODE"
+PHASE1_MOBILE_MODE="$PHASE1_MOBILE_MODE"
+PHASE1_DEVICE_MODE="$PHASE1_DEVICE_MODE"
+PHASE1_ASCII="$PHASE1_ASCII"
+PHASE1_TERMINAL_HINTS="$PHASE1_TERMINAL_HINTS"
+EOF
+}
+
+config_show() {
+    if [ -f "$CONFIG_FILE" ]; then
+        cat "$CONFIG_FILE"
+    else
+        echo "config: not found at $CONFIG_FILE"
+        echo "hint  : run phase1-terminal config reset"
+    fi
+}
+
+config_set() {
+    pair="${1:-}"
+    case "$pair" in
+        PHASE1_HOME=*|PHASE1_TERMINAL_TITLE=*|PHASE1_TERMINAL_PROFILE=*|PHASE1_THEME=*|PHASE1_SAFE_MODE=*|PHASE1_MOBILE_MODE=*|PHASE1_DEVICE_MODE=*|PHASE1_ASCII=*|PHASE1_TERMINAL_HINTS=*)
+            key=${pair%%=*}
+            value=${pair#*=}
+            case "$key" in
+                PHASE1_HOME) PHASE1_HOME=$value ;;
+                PHASE1_TERMINAL_TITLE) PHASE1_TERMINAL_TITLE=$value ;;
+                PHASE1_TERMINAL_PROFILE) PHASE1_TERMINAL_PROFILE=$value ;;
+                PHASE1_THEME) PHASE1_THEME=$value ;;
+                PHASE1_SAFE_MODE) PHASE1_SAFE_MODE=$value ;;
+                PHASE1_MOBILE_MODE) PHASE1_MOBILE_MODE=$value ;;
+                PHASE1_DEVICE_MODE) PHASE1_DEVICE_MODE=$value ;;
+                PHASE1_ASCII) PHASE1_ASCII=$value ;;
+                PHASE1_TERMINAL_HINTS) PHASE1_TERMINAL_HINTS=$value ;;
+            esac
+            write_config
+            echo "config: set $key"
+            ;;
+        "")
+            echo "usage: phase1-terminal config set KEY=VALUE" >&2
+            exit 1
+            ;;
+        *)
+            echo "config: unsupported key. Allowed keys:" >&2
+            echo "  PHASE1_HOME PHASE1_TERMINAL_TITLE PHASE1_TERMINAL_PROFILE PHASE1_THEME" >&2
+            echo "  PHASE1_SAFE_MODE PHASE1_MOBILE_MODE PHASE1_DEVICE_MODE PHASE1_ASCII PHASE1_TERMINAL_HINTS" >&2
+            exit 1
+            ;;
+    esac
+}
+
+config_reset() {
+    PHASE1_TERMINAL_TITLE="$APP_NAME"
+    PHASE1_TERMINAL_PROFILE="default"
+    PHASE1_THEME="cyber"
+    PHASE1_SAFE_MODE="1"
+    PHASE1_MOBILE_MODE="0"
+    PHASE1_DEVICE_MODE="desktop"
+    PHASE1_ASCII="0"
+    PHASE1_TERMINAL_HINTS="1"
+    write_config
+    echo "config: reset $CONFIG_FILE"
+}
+
+profile_list() {
+    cat <<'EOF'
+profiles:
+  default    cyber theme, safe desktop defaults
+  cyber      neon/cyber Phase1 defaults
+  matrix     matrix theme with safe desktop defaults
+  amber      amber theme with safe desktop defaults
+  mono       ASCII/mono-friendly safe profile
+  safe       conservative safe-mode profile
+  developer  developer-friendly theme, still safe by default
+  base1      Base1-focused safe profile
+EOF
+}
+
+apply_profile_vars() {
+    name="$1"
+    case "$name" in
+        default|cyber)
+            PHASE1_TERMINAL_PROFILE="$name"; PHASE1_THEME="cyber"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="desktop" ;;
+        matrix)
+            PHASE1_TERMINAL_PROFILE="matrix"; PHASE1_THEME="matrix"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="desktop" ;;
+        amber)
+            PHASE1_TERMINAL_PROFILE="amber"; PHASE1_THEME="amber"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="desktop" ;;
+        mono)
+            PHASE1_TERMINAL_PROFILE="mono"; PHASE1_THEME="mono"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="1"; PHASE1_DEVICE_MODE="desktop" ;;
+        safe)
+            PHASE1_TERMINAL_PROFILE="safe"; PHASE1_THEME="cyber"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="desktop" ;;
+        developer|dev)
+            PHASE1_TERMINAL_PROFILE="developer"; PHASE1_THEME="synthwave"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="desktop" ;;
+        base1)
+            PHASE1_TERMINAL_PROFILE="base1"; PHASE1_THEME="amber"; PHASE1_SAFE_MODE="1"; PHASE1_ASCII="0"; PHASE1_DEVICE_MODE="base1" ;;
+        *)
+            echo "profile: unknown profile '$name'" >&2
+            profile_list >&2
+            exit 1
+            ;;
+    esac
+}
+
+profile_cmd() {
+    sub="${1:-show}"
+    case "$sub" in
+        list) profile_list ;;
+        show) echo "$PHASE1_TERMINAL_PROFILE" ;;
+        apply)
+            apply_profile_vars "${2:-}"
+            write_config
+            echo "profile: applied $PHASE1_TERMINAL_PROFILE"
+            ;;
+        *)
+            echo "usage: phase1-terminal profile [list|show|apply NAME]" >&2
+            exit 1
+            ;;
+    esac
+}
+
+doctor_text() {
+    verbose="${1:-0}"
     echo "Phase1 Terminal doctor"
+    echo "version: $VERSION"
     echo "system : $(uname -s 2>/dev/null || echo unknown)"
     echo "config : $CONFIG_FILE"
+    echo "profile: $PHASE1_TERMINAL_PROFILE"
 
     if phase1_home=$(find_phase1_home); then
         echo "home   : $phase1_home"
     else
         echo "home   : not found"
         echo "hint   : set PHASE1_HOME to your Phase1 repository path"
+    fi
+
+    if bin=$(phase1_binary_path); then
+        echo "binary : $bin"
+    else
+        echo "binary : not built/found"
     fi
 
     if command -v cargo >/dev/null 2>&1; then
@@ -103,17 +299,53 @@ doctor() {
         echo "rustc  : missing"
     fi
 
-    if command -v phase1 >/dev/null 2>&1; then
-        echo "phase1 : $(command -v phase1)"
-    else
-        echo "phase1 : no global phase1 command found; repository launch will use cargo"
+    if [ "$verbose" = "1" ]; then
+        echo "theme  : $PHASE1_THEME"
+        echo "safe   : $PHASE1_SAFE_MODE"
+        echo "device : $PHASE1_DEVICE_MODE"
+        echo "ascii  : $PHASE1_ASCII"
+        echo "hints  : $PHASE1_TERMINAL_HINTS"
+        if phase1_home=$(find_phase1_home); then
+            if [ -f "$phase1_home/plugins/gina.wasm" ] || [ -f "$phase1_home/plugins/gina.wasi" ]; then
+                echo "gina   : plugin present"
+            else
+                echo "gina   : plugin not found in $phase1_home/plugins"
+            fi
+        fi
     fi
 }
 
-run_phase1() {
-    write_title
-    export PHASE1_THEME PHASE1_SAFE_MODE PHASE1_MOBILE_MODE PHASE1_DEVICE_MODE PHASE1_ASCII
+doctor_json() {
+    home=""
+    binary=""
+    cargo=""
+    rustc_value=""
+    if home_value=$(find_phase1_home); then home=$home_value; fi
+    if binary_value=$(phase1_binary_path); then binary=$binary_value; fi
+    if command -v cargo >/dev/null 2>&1; then cargo=$(command -v cargo); fi
+    if command -v rustc >/dev/null 2>&1; then rustc_value=$(rustc --version 2>/dev/null || true); fi
+    printf '{\n'
+    printf '  "version": "%s",\n' "$(json_escape "$VERSION")"
+    printf '  "config": "%s",\n' "$(json_escape "$CONFIG_FILE")"
+    printf '  "profile": "%s",\n' "$(json_escape "$PHASE1_TERMINAL_PROFILE")"
+    printf '  "home": "%s",\n' "$(json_escape "$home")"
+    printf '  "binary": "%s",\n' "$(json_escape "$binary")"
+    printf '  "cargo": "%s",\n' "$(json_escape "$cargo")"
+    printf '  "rustc": "%s",\n' "$(json_escape "$rustc_value")"
+    printf '  "safe_mode": "%s",\n' "$(json_escape "$PHASE1_SAFE_MODE")"
+    printf '  "device_mode": "%s"\n' "$(json_escape "$PHASE1_DEVICE_MODE")"
+    printf '}\n'
+}
 
+doctor() {
+    case "${1:-}" in
+        --json|json) doctor_json ;;
+        --verbose|-v|verbose) doctor_text 1 ;;
+        *) doctor_text 0 ;;
+    esac
+}
+
+phase1_run_command() {
     if phase1_home=$(find_phase1_home); then
         cd "$phase1_home"
     elif command -v phase1 >/dev/null 2>&1; then
@@ -127,16 +359,86 @@ run_phase1() {
     if [ -x "target/release/phase1" ]; then
         exec "target/release/phase1" "$@"
     fi
-
     if [ -x "target/debug/phase1" ]; then
         exec "target/debug/phase1" "$@"
     fi
-
+    if [ -x "bin/phase1" ]; then
+        exec "bin/phase1" "$@"
+    fi
+    if [ -x "./phase1" ]; then
+        exec "./phase1" "$@"
+    fi
     if command -v cargo >/dev/null 2>&1; then
         exec cargo run -- "$@"
     fi
 
     echo "phase1-terminal: cargo is required when no built phase1 binary is present." >&2
+    exit 1
+}
+
+run_phase1() {
+    write_title
+    export PHASE1_THEME PHASE1_SAFE_MODE PHASE1_MOBILE_MODE PHASE1_DEVICE_MODE PHASE1_ASCII
+    phase1_run_command "$@"
+}
+
+run_profile() {
+    apply_profile_vars "$1"
+    shift || true
+    run_phase1 "$@"
+}
+
+run_with_hint() {
+    hint="$1"
+    shift || true
+    if [ "$PHASE1_TERMINAL_HINTS" = "1" ]; then
+        echo "Phase1 Terminal hint: inside Phase1, try: $hint"
+    fi
+    run_phase1 "$@"
+}
+
+build_phase1() {
+    if phase1_home=$(find_phase1_home); then
+        cd "$phase1_home"
+    else
+        echo "build: Phase1 home not found" >&2
+        exit 1
+    fi
+    if command -v cargo >/dev/null 2>&1; then
+        exec cargo build --release
+    fi
+    echo "build: cargo not found" >&2
+    exit 1
+}
+
+check_phase1() {
+    if phase1_home=$(find_phase1_home); then
+        cd "$phase1_home"
+    else
+        echo "check: Phase1 home not found" >&2
+        exit 1
+    fi
+    if command -v cargo >/dev/null 2>&1; then
+        cargo fmt --all -- --check
+        cargo check --all-targets
+        cargo test --all-targets
+        exit 0
+    fi
+    echo "check: cargo not found" >&2
+    exit 1
+}
+
+logs_phase1() {
+    if phase1_home=$(find_phase1_home); then
+        for file in "$phase1_home/phase1.log" "$phase1_home/phase1.history" "$phase1_home/phase1.state"; do
+            if [ -f "$file" ]; then
+                echo "==> $file"
+                tail -n 40 "$file"
+            fi
+        done
+        return 0
+    fi
+    echo "logs: Phase1 home not found" >&2
     exit 1
 }
 
@@ -146,11 +448,62 @@ case "$command_name" in
         shift || true
         run_phase1 "$@"
         ;;
+    safe)
+        shift || true
+        run_profile safe "$@"
+        ;;
+    dev|developer)
+        shift || true
+        run_profile developer "$@"
+        ;;
+    demo)
+        shift || true
+        PHASE1_TERMINAL_TITLE="Phase1 Terminal Demo"
+        run_profile cyber "$@"
+        ;;
+    base1)
+        shift || true
+        run_profile base1 "$@"
+        ;;
+    gina)
+        shift || true
+        run_with_hint "gina security" "$@"
+        ;;
+    security)
+        shift || true
+        run_with_hint "gina security" "$@"
+        ;;
+    build)
+        build_phase1
+        ;;
+    check|validate)
+        check_phase1
+        ;;
+    logs)
+        logs_phase1
+        ;;
     doctor)
-        doctor
+        shift || true
+        doctor "${1:-}"
         ;;
     env)
         print_env
+        ;;
+    config)
+        shift || true
+        case "${1:-show}" in
+            show) config_show ;;
+            set) shift || true; config_set "${1:-}" ;;
+            reset) config_reset ;;
+            *) echo "usage: phase1-terminal config [show|set KEY=VALUE|reset]" >&2; exit 1 ;;
+        esac
+        ;;
+    profile)
+        shift || true
+        profile_cmd "$@"
+        ;;
+    version|--version|-V)
+        version
         ;;
     help|--help|-h)
         print_help

--- a/terminal/bin/phase1-terminal
+++ b/terminal/bin/phase1-terminal
@@ -1,0 +1,161 @@
+#!/usr/bin/env sh
+set -eu
+
+APP_NAME="Phase1 Terminal"
+CONFIG_FILE="${PHASE1_TERMINAL_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/phase1/terminal.env}"
+
+if [ -f "$CONFIG_FILE" ]; then
+    # shellcheck disable=SC1090
+    . "$CONFIG_FILE"
+fi
+
+: "${PHASE1_TERMINAL_TITLE:=$APP_NAME}"
+: "${PHASE1_THEME:=cyber}"
+: "${PHASE1_SAFE_MODE:=1}"
+: "${PHASE1_MOBILE_MODE:=0}"
+: "${PHASE1_DEVICE_MODE:=desktop}"
+: "${PHASE1_ASCII:=0}"
+
+print_help() {
+    cat <<'EOF'
+Phase1 Terminal
+
+Usage:
+  phase1-terminal [run] [phase1 args...]
+  phase1-terminal doctor
+  phase1-terminal env
+  phase1-terminal help
+
+Environment:
+  PHASE1_HOME              Path to the Phase1 repository or install root.
+  PHASE1_TERMINAL_CONFIG   Optional config file path.
+  PHASE1_THEME             Default terminal theme passed to Phase1.
+  PHASE1_SAFE_MODE         Defaults to 1.
+  PHASE1_DEVICE_MODE       Defaults to desktop.
+
+Notes:
+  The installed command is phase1-terminal.
+  The installer creates a terminal alias only when it is safe or explicitly requested.
+EOF
+}
+
+write_title() {
+    if [ -t 1 ]; then
+        printf '\033]0;%s\007' "$PHASE1_TERMINAL_TITLE"
+    fi
+}
+
+find_phase1_home() {
+    if [ "${PHASE1_HOME:-}" != "" ]; then
+        printf '%s\n' "$PHASE1_HOME"
+        return 0
+    fi
+
+    if [ -f "Cargo.toml" ] && [ -d "src" ]; then
+        pwd
+        return 0
+    fi
+
+    for candidate in "$HOME/phase1" "$HOME/Developer/phase1" "$HOME/projects/phase1" "$HOME/Projects/phase1" "/opt/phase1"; do
+        if [ -f "$candidate/Cargo.toml" ] && [ -d "$candidate/src" ]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+print_env() {
+    cat <<EOF
+PHASE1_TERMINAL_TITLE=$PHASE1_TERMINAL_TITLE
+PHASE1_TERMINAL_CONFIG=$CONFIG_FILE
+PHASE1_HOME=${PHASE1_HOME:-}
+PHASE1_THEME=$PHASE1_THEME
+PHASE1_SAFE_MODE=$PHASE1_SAFE_MODE
+PHASE1_MOBILE_MODE=$PHASE1_MOBILE_MODE
+PHASE1_DEVICE_MODE=$PHASE1_DEVICE_MODE
+PHASE1_ASCII=$PHASE1_ASCII
+EOF
+}
+
+doctor() {
+    echo "Phase1 Terminal doctor"
+    echo "system : $(uname -s 2>/dev/null || echo unknown)"
+    echo "config : $CONFIG_FILE"
+
+    if phase1_home=$(find_phase1_home); then
+        echo "home   : $phase1_home"
+    else
+        echo "home   : not found"
+        echo "hint   : set PHASE1_HOME to your Phase1 repository path"
+    fi
+
+    if command -v cargo >/dev/null 2>&1; then
+        echo "cargo  : $(command -v cargo)"
+    else
+        echo "cargo  : missing"
+    fi
+
+    if command -v rustc >/dev/null 2>&1; then
+        echo "rustc  : $(rustc --version 2>/dev/null || echo found)"
+    else
+        echo "rustc  : missing"
+    fi
+
+    if command -v phase1 >/dev/null 2>&1; then
+        echo "phase1 : $(command -v phase1)"
+    else
+        echo "phase1 : no global phase1 command found; repository launch will use cargo"
+    fi
+}
+
+run_phase1() {
+    write_title
+    export PHASE1_THEME PHASE1_SAFE_MODE PHASE1_MOBILE_MODE PHASE1_DEVICE_MODE PHASE1_ASCII
+
+    if phase1_home=$(find_phase1_home); then
+        cd "$phase1_home"
+    elif command -v phase1 >/dev/null 2>&1; then
+        exec phase1 "$@"
+    else
+        echo "phase1-terminal: could not find Phase1." >&2
+        echo "Set PHASE1_HOME or install the phase1 binary in PATH." >&2
+        exit 1
+    fi
+
+    if [ -x "target/release/phase1" ]; then
+        exec "target/release/phase1" "$@"
+    fi
+
+    if [ -x "target/debug/phase1" ]; then
+        exec "target/debug/phase1" "$@"
+    fi
+
+    if command -v cargo >/dev/null 2>&1; then
+        exec cargo run -- "$@"
+    fi
+
+    echo "phase1-terminal: cargo is required when no built phase1 binary is present." >&2
+    exit 1
+}
+
+command_name="${1:-run}"
+case "$command_name" in
+    run)
+        shift || true
+        run_phase1 "$@"
+        ;;
+    doctor)
+        doctor
+        ;;
+    env)
+        print_env
+        ;;
+    help|--help|-h)
+        print_help
+        ;;
+    *)
+        run_phase1 "$@"
+        ;;
+esac

--- a/terminal/linux/phase1-terminal.desktop
+++ b/terminal/linux/phase1-terminal.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Phase1 Terminal
+Comment=Launch the Phase1 terminal-first computing environment
+Exec=phase1-terminal
+Terminal=true
+Categories=Development;System;TerminalEmulator;
+Keywords=phase1;terminal;rust;os;shell;
+StartupNotify=false

--- a/terminal/macos/Phase1-Terminal.terminal
+++ b/terminal/macos/Phase1-Terminal.terminal
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Window Settings</key>
+  <array>
+    <dict>
+      <key>name</key>
+      <string>Phase1 Terminal</string>
+      <key>CommandString</key>
+      <string>phase1-terminal</string>
+      <key>RunCommandAsShell</key>
+      <false/>
+      <key>Font</key>
+      <data>
+      YnBsaXN0MDDUAQIDBAUGGBlYJHZlcnNpb25YJG9iamVjdHNaJGFyY2hpdmVy
+      VCR0b3ASAAGGoKQHCAcIClUkbnVsbNQKCwwNDg8QERJVTlNpemVWTlNOYW1lViRj
+      bGFzc0BmAAAAAAAAGEAqXU0ZTW9uby1SZWd1bGFy0hMUFRZaJGNsYXNzbmFtZVgk
+      Y2xhc3Nlc1ZOU0ZvbnSiFRdYTlNPYmplY3RfEA9OU0tleWVkQXJjaGl2ZXLRGhtU
+      cm9vdIABEAAIABEAGgAkACkAMgA3AD0AQwBKAFEAUwBVAFcAXABiAG0AfwCOAJAA
+      kgCUAKQArQC2AAAAAAAAAgEAAAAAAAAAHAAAAAAAAAAAAAAAAAAAAL8=
+      </data>
+      <key>ProfileCurrentVersion</key>
+      <real>2.07</real>
+      <key>type</key>
+      <string>Window Settings</string>
+    </dict>
+  </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Extremely upgrades **Phase1 Terminal** into a dedicated Linux/macOS launcher, config manager, profile manager, color/theme layer, session manager, diagnostics layer, quality/performance test harness, and safe Gina-aware entry point for Phase1.

The project name is **Phase1 Terminal**. The primary installed command is `phase1-terminal` to avoid clashing with existing system `terminal` commands. The installer can also create a shorter `terminal` alias when safe or explicitly requested.

## What changed

- Adds `terminal/bin/phase1-terminal` as a full launcher/config/session/color command.
- Adds Linux installer wrapper and `.desktop` integration.
- Adds macOS installer wrapper, clickable `.command` launcher, and Terminal.app profile.
- Adds generic installer script with configurable prefix, Phase1 home path, optional alias behavior, and `--dry-run`.
- Adds reversible uninstaller: `scripts/uninstall-phase1-terminal.sh`.
- Adds expanded config file support at `~/.config/phase1/terminal.env`.
- Adds allowlisted config management:
  - `phase1-terminal config show`
  - `phase1-terminal config set KEY=VALUE`
  - `phase1-terminal config reset`
- Adds advanced color support:
  - auto color detection
  - truecolor / 256-color / ANSI / mono modes
  - `NO_COLOR=1` fallback
  - `phase1-terminal colors detect`
  - `phase1-terminal colors swatches`
  - `phase1-terminal theme list`
  - `phase1-terminal theme preview NAME`
  - `phase1-terminal theme preview all`
- Exports color/theme state to Phase1:
  - `PHASE1_THEME`
  - `PHASE1_COLOR_MODE`
  - `PHASE1_TERMINAL_DETECTED_COLOR_MODE`
  - `PHASE1_TERMINAL_BANNER`
- Adds safe profile management:
  - `phase1-terminal profile list`
  - `phase1-terminal profile show`
  - `phase1-terminal profile apply cyber|matrix|amber|mono|safe|developer|base1|ice|crimson`
- Adds launch/session modes:
  - `phase1-terminal run`
  - `phase1-terminal safe`
  - `phase1-terminal dev`
  - `phase1-terminal demo`
  - `phase1-terminal base1`
- Adds Gina-aware shortcuts:
  - `phase1-terminal gina`
  - `phase1-terminal security`
- Adds management helpers:
  - `phase1-terminal build`
  - `phase1-terminal check`
  - `phase1-terminal logs`
- Adds diagnostics:
  - `phase1-terminal doctor`
  - `phase1-terminal doctor --verbose`
  - `phase1-terminal doctor --json`
  - `phase1-terminal env`
  - `phase1-terminal version`
- Adds quality/performance commands:
  - `phase1-terminal selftest`
  - `phase1-terminal benchmark [iterations]`
- Adds `TERMINAL.md`, `terminal/README.md`, `TERMINAL_ROADMAP.md`, and `TERMINAL_TEST_CASES.md`.
- Links Phase1 Terminal from the main README.
- Adds expanded CI validation through `scripts/test-phase1-terminal.sh`.
- Updates Rust CI to validate Phase1 Terminal scripts, color commands, theme previews, self-test, benchmark smoke, and command surfaces.

## Roadmap coverage

`TERMINAL_ROADMAP.md` now tracks implemented and remaining work across:

1. Installer hardening.
2. Profile, color, and UX polish.
3. Native Phase1 session management.
4. Quality and performance layer.
5. Gina-aware terminal workflows.
6. Packaging.
7. Future native terminal application exploration.

## Usage

Linux:

```bash
sh scripts/install-phase1-terminal-linux.sh
phase1-terminal doctor --verbose
phase1-terminal theme preview all
phase1-terminal
```

macOS:

```bash
sh scripts/install-phase1-terminal-macos.sh
phase1-terminal doctor --verbose
phase1-terminal theme preview all
phase1-terminal
```

Color/theme workflow:

```bash
phase1-terminal colors detect
phase1-terminal colors swatches
phase1-terminal theme preview all
NO_COLOR=1 phase1-terminal theme preview all
```

Profiles/config:

```bash
phase1-terminal profile list
phase1-terminal profile apply matrix
phase1-terminal config show
phase1-terminal config set PHASE1_COLOR_MODE=truecolor
phase1-terminal config set PHASE1_THEME=cyber
```

Quality/performance:

```bash
sh scripts/test-phase1-terminal.sh
phase1-terminal selftest
phase1-terminal benchmark 25
```

Gina/security workflow:

```bash
phase1-terminal gina
phase1-terminal security
```

Uninstall dry-run:

```bash
sh scripts/uninstall-phase1-terminal.sh --dry-run
```

## Design notes

Phase1 Terminal is intentionally still a launcher/profile/config/session/color layer, not a full graphical terminal emulator. It loads Phase1-specific defaults, detects terminal color support, finds the Phase1 checkout or installed binary, prefers built binaries, falls back to `cargo run`, and preserves safe defaults.

The roadmap explicitly defers a full native terminal emulator until there is clear value beyond existing Linux/macOS terminals and no weakening of Phase1 safety guarantees.

## Safety

The launcher keeps safe defaults:

- `PHASE1_SAFE_MODE=1`
- `PHASE1_DEVICE_MODE=desktop`
- no host-tool trust is enabled
- no host network mutation is enabled
- no external AI provider is enabled
- config mutation is allowlisted
- uninstall keeps user config unless `--remove-config` is explicit
- mono fallback is available through `NO_COLOR=1` or `PHASE1_COLOR_MODE=mono`

Higher-trust modes remain controlled by Phase1's normal boot/profile controls.

## Validation

Expected checks:

```bash
sh scripts/test-phase1-terminal.sh
cargo fmt --all -- --check
cargo check --all-targets
cargo clippy --all-targets -- -D warnings
cargo test --all-targets
```

CI validates shell syntax, required Linux/macOS assets, help/version/env/doctor output, color detection, theme previews, profile listing, self-test, benchmark smoke, install dry-run, uninstall dry-run, and the Rust quality gate.
