### PR TITLE
Configure Dependabot and workflow token permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,56 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options: 
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
+
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # Rust workspace dependencies in Cargo.toml / Cargo.lock.
+  - package-ecosystem: "cargo"
+    directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "rust"
+      - "security"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      rust-patch-and-minor:
+        applies-to: "version-updates"
+        update-types:
+          - "patch"
+          - "minor"
+      rust-security:
+        applies-to: "security-updates"
+    ignore:
+      # Keep major Rust dependency upgrades explicit so they can receive manual review.
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  # GitHub Actions used by CI/security workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
+      timezone: "America/Chicago"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+      - "security"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      github-actions:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: "security-updates"

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -7,6 +7,9 @@ on:
     branches: ["*"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: rust-ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/tests/github_security.rs
+++ b/tests/github_security.rs
@@ -1,0 +1,41 @@
+use std::fs;
+
+#[test]
+fn dependabot_config_targets_required_ecosystems() {
+    let content = fs::read_to_string(".github/dependabot.yml").expect("read dependabot config");
+    assert!(content.contains("version: 2"));
+    assert!(content.contains("package-ecosystem: \"cargo\""));
+    assert!(content.contains("package-ecosystem: \"github-actions\""));
+    assert!(content.contains("open-pull-requests-limit"));
+    assert!(content.contains("rust-patch-and-minor"));
+    assert!(content.contains("github-actions-security"));
+}
+
+#[test]
+fn workflows_have_explicit_permissions_blocks() {
+    for workflow in [
+        ".github/workflows/rust.yml",
+        ".github/workflows/rust-ci.yml",
+        ".github/workflows/security.yml",
+        ".github/workflows/quality.yml",
+    ] {
+        let content = fs::read_to_string(workflow).expect("read workflow file");
+        assert!(
+            content.contains("permissions:"),
+            "workflow is missing explicit permissions block: {workflow}"
+        );
+        assert!(
+            content.contains("contents: read"),
+            "workflow is missing read-only contents permission: {workflow}"
+        );
+    }
+}
+
+#[test]
+fn codeql_workflow_keeps_required_security_permissions() {
+    let content = fs::read_to_string(".github/workflows/codeql.yml").expect("read CodeQL workflow");
+    assert!(content.contains("permissions:"));
+    assert!(content.contains("security-events: write"));
+    assert!(content.contains("contents: read"));
+    assert!(content.contains("actions: read"));
+}


### PR DESCRIPTION
## Summary

Configures Dependabot properly and tightens GitHub workflow permissions.

## What changed

- Replaces the placeholder `.github/dependabot.yml` with a real configuration.
- Enables Dependabot for:
  - Rust/Cargo dependencies
  - GitHub Actions dependencies
- Adds grouped updates for patch/minor Rust dependencies and GitHub Actions updates.
- Keeps Rust semver-major dependency updates ignored for manual review.
- Adds labels and commit-message prefixes for dependency PRs.
- Adds explicit least-privilege token permissions to `.github/workflows/rust-ci.yml`:

```yaml
permissions:
  contents: read
```

- Adds `tests/github_security.rs` to make sure Dependabot and workflow permission settings remain present.

## Security notes

Existing workflows already had appropriate explicit permissions in:

- `.github/workflows/rust.yml`
- `.github/workflows/security.yml`
- `.github/workflows/quality.yml`
- `.github/workflows/codeql.yml`

This PR fixes the remaining Rust CI workflow and protects the configuration with tests.

## Validation

Expected checks:

```bash
cargo test --test github_security
cargo test --all-targets
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
```
