### PR TITLE
Fix CodeQL Rust build mode

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
           - language: javascript-typescript
             build-mode: none
           - language: rust
-            build-mode: manual
+            build-mode: none
 
     steps:
       - name: Checkout repository
@@ -42,13 +42,6 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: +security-extended,security-and-quality
-
-      - name: Build Rust for CodeQL
-        if: matrix.language == 'rust'
-        shell: bash
-        run: |
-          set -euo pipefail
-          cargo check --all-targets
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

Fixes the failing CodeQL Rust analysis configuration shown in Security and quality.

## Problem

The current workflow config sets Rust to `build-mode: manual`, but the CodeQL Rust extractor reports that Rust does not support manual build mode and asks for `none` instead.

## Changes

- Changes the Rust CodeQL matrix entry from `manual` to `none`.
- Removes the Rust-only manual `cargo check --all-targets` step from the CodeQL workflow.
- Keeps default-deny permissions, read-only checkout access, extended query packs, and separate analysis categories.

## Validation

Expected GitHub Actions validation:

- CodeQL Advanced / Analyze (rust) initializes successfully.
- CodeQL Advanced / Analyze (actions) remains green.
- CodeQL Advanced / Analyze (javascript-typescript) remains green.
