### PR TITLE
Harden logging and workflow pinning for CodeQL alerts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,9 +19,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+        shell: bash
+        run: |
+          set -euo pipefail
+          rustup toolchain install stable --profile minimal --component rustfmt
+          rustup default stable
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/src/history.rs
+++ b/src/history.rs
@@ -115,10 +115,11 @@ pub fn run(shell: &mut Phase1Shell, store: &HistoryStore, args: &[String]) -> St
 }
 
 pub fn push_bounded(history: &mut VecDeque<String>, line: &str) {
-    if line.trim().is_empty() {
+    let sanitized = sanitize_line(line);
+    if sanitized.trim().is_empty() {
         return;
     }
-    history.push_back(line.to_string());
+    history.push_back(sanitized);
     while history.len() > HISTORY_LIMIT {
         history.pop_front();
     }
@@ -126,7 +127,7 @@ pub fn push_bounded(history: &mut VecDeque<String>, line: &str) {
 
 pub fn status(shell: &Phase1Shell, store: &HistoryStore) -> String {
     format!(
-        "history entries     : {}\npersistent history  : {}\nhistory file        : {}\nprivacy             : persisted history is sanitized; password/token/secret-like commands are redacted\n",
+        "history entries     : {}\npersistent history  : {}\nhistory file        : {}\nprivacy             : in-memory and persisted history are sanitized; password/token/secret-like commands are redacted\n",
         shell.history.len(),
         if matches!(store, HistoryStore::Disk(_)) { "on" } else { "off" },
         store.describe()
@@ -239,6 +240,16 @@ mod tests {
         }
         assert_eq!(history.len(), HISTORY_LIMIT);
         assert_eq!(history.front().map(String::as_str), Some("cmd-3"));
+    }
+
+    #[test]
+    fn bounded_history_redacts_sensitive_entries_before_storage() {
+        let mut history = VecDeque::new();
+        push_bounded(&mut history, "wifi-connect home password123");
+        assert_eq!(
+            history.front().map(String::as_str),
+            Some("[redacted-sensitive-command]")
+        );
     }
 
     #[test]

--- a/src/ops_log.rs
+++ b/src/ops_log.rs
@@ -38,10 +38,10 @@ pub fn log_error(kind: &str, detail: &str) {
 }
 
 pub fn log_command(command: &str) {
-    let trimmed = command.trim();
-    if !trimmed.is_empty() {
-        let _ = append("command", trimmed);
+    if command.trim().is_empty() {
+        return;
     }
+    let _ = append("command", &command_summary(command));
 }
 
 pub fn run(args: &[String]) -> String {
@@ -97,7 +97,7 @@ fn status() -> String {
         .map(|meta| format!("{} bytes", meta.len()))
         .unwrap_or_else(|_| "none".to_string());
     format!(
-        "phase1 ops log\npath       : {LOG_PATH}\nsize       : {size} bytes\nrotation   : {ROTATED_LOG_PATH} ({rotated})\ncommands   : opslog tail | opslog clear | opslog path\nprivacy    : credential-like strings are redacted before write\n"
+        "phase1 ops log\npath       : {LOG_PATH}\nsize       : {size} bytes\nrotation   : {ROTATED_LOG_PATH} ({rotated})\ncommands   : opslog tail | opslog clear | opslog path\nprivacy    : commands are recorded as structured summaries and credential-like strings are redacted before write\n"
     )
 }
 
@@ -127,7 +127,7 @@ fn clear() -> io::Result<()> {
 }
 
 fn help() -> String {
-    "usage: opslog [status|tail [n]|path|clear]\n\nThe ops log records boot selections, shell commands, guarded local operations, and panic summaries in phase1.log. It is local-only and redacts common credential-like values.\n".to_string()
+    "usage: opslog [status|tail [n]|path|clear]\n\nThe ops log records boot selections, structured shell command summaries, guarded local operations, and panic summaries in phase1.log. It is local-only and redacts common credential-like values.\n".to_string()
 }
 
 fn timestamp() -> String {
@@ -136,6 +136,48 @@ fn timestamp() -> String {
         .unwrap_or_default()
         .as_secs();
     format!("unix:{now}")
+}
+
+fn command_summary(command: &str) -> String {
+    let trimmed = command.trim();
+    if contains_sensitive_marker(trimmed) {
+        return "name=[redacted] argc=0 sensitive=true".to_string();
+    }
+
+    let parts = trimmed.split_whitespace().collect::<Vec<_>>();
+    let name = parts.first().copied().unwrap_or("unknown");
+    format!(
+        "name={} argc={} sensitive=false",
+        sanitize_token(name),
+        parts.len().saturating_sub(1)
+    )
+}
+
+fn contains_sensitive_marker(raw: &str) -> bool {
+    let lower = raw.to_ascii_lowercase();
+    [
+        "password",
+        "passwd",
+        "secret",
+        "token",
+        "api_key",
+        "apikey",
+        "access_token",
+        "refresh_token",
+        "client_secret",
+        "private_key",
+        "authorization:",
+        "bearer ",
+        "cookie",
+        "github_pat_",
+        "ghp_",
+        "gho_",
+        "ghu_",
+        "ghs_",
+        "ghr_",
+    ]
+    .iter()
+    .any(|marker| lower.contains(marker))
 }
 
 fn sanitize(raw: &str) -> String {
@@ -153,6 +195,10 @@ fn sanitize_token(token: &str) -> String {
         || lower.contains("token=")
         || lower.contains("api_key=")
         || lower.contains("apikey=")
+        || lower.contains("access_token=")
+        || lower.contains("refresh_token=")
+        || lower.contains("client_secret=")
+        || lower.contains("private_key=")
     {
         return "[redacted-secret]".to_string();
     }
@@ -177,7 +223,7 @@ fn sanitize_token(token: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{run, sanitize_token};
+    use super::{command_summary, run, sanitize_token};
 
     #[test]
     fn redacts_secret_like_tokens() {
@@ -186,6 +232,18 @@ mod tests {
         assert_eq!(
             sanitize_token("https://user:pass@example.com/repo.git"),
             "https://[redacted-credential]@example.com/repo.git"
+        );
+    }
+
+    #[test]
+    fn command_summary_does_not_store_raw_sensitive_commands() {
+        assert_eq!(
+            command_summary("wifi-connect home password123"),
+            "name=[redacted] argc=0 sensitive=true"
+        );
+        assert_eq!(
+            command_summary("echo hello world"),
+            "name=echo argc=2 sensitive=false"
         );
     }
 

--- a/terminal/README.md
+++ b/terminal/README.md
@@ -4,7 +4,7 @@ This directory contains the lightweight Phase1 Terminal wrapper.
 
 The first implementation is deliberately small and current-master friendly:
 
-- `bin/phase1-terminal` delegates to `../../start_phase1`.
+- `bin/phase1-terminal` delegates to ../../start_phase1.
 - It keeps safe defaults and does not create a new trust path.
 - It provides discovery commands for doctor, Gina, Base1, quality checks, and self-test.
 

--- a/tests/ai_gina_current.rs
+++ b/tests/ai_gina_current.rs
@@ -9,13 +9,18 @@ fn gina_ai_and_assistant_manifests_are_offline_and_safe() {
     for plugin in ["gina", "ai", "assistant"] {
         let manifest = fs::read_to_string(format!("plugins/{plugin}.wasi"))
             .unwrap_or_else(|err| panic!("missing {plugin} manifest: {err}"));
-        assert!(manifest.contains("ai.offline"), "{plugin} should be offline");
+        assert!(
+            manifest.contains("ai.offline"),
+            "{plugin} should be offline"
+        );
         assert!(
             manifest.contains("no host") || manifest.contains("host shell blocked"),
             "{plugin} should describe host blocking"
         );
         assert!(
-            manifest.contains("credential") || manifest.contains("no provider") || manifest.contains("no external"),
+            manifest.contains("credential")
+                || manifest.contains("no provider")
+                || manifest.contains("no external"),
             "{plugin} should describe credential/provider safety"
         );
     }


### PR DESCRIPTION
## Summary

Follow-up hardening for the CodeQL alerts visible in Security and quality.

## Changes

- Replaces the mutable `dtolnay/rust-toolchain@stable` workflow action with direct `rustup` installation in `.github/workflows/rust.yml`.
- Changes in-memory history storage to sanitize sensitive commands before keeping them in `shell.history`.
- Changes ops logging to record structured command summaries instead of raw shell commands.
- Expands tests for sensitive command redaction.

## Why

The visible alerts include cleartext logging of sensitive information and an unpinned mutable workflow action. This PR reduces the data retained in logs/history and removes the unpinned Rust toolchain action path.

## Expected validation

- `cargo test --workspace --all-targets`
- `cargo fmt --all -- --check`
- GitHub CodeQL rescan closes or refreshes the reported logging/pinning alerts after merge.