### PR TITLE
Prepare Phase1 v4.1.0 stable release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,4 +5,4 @@ version = 4
 
 [[package]]
 name = "phase1"
-version = "4.1.0-dev"
+version = "4.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phase1"
-version = "4.1.0-dev"
+version = "4.1.0"
 edition = "2021"
 default-run = "phase1"
 authors = ["Chase Bryan"]

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@
   ·
   <a href="QUALITY.md">Quality system</a>
   ·
-  <a href="RELEASE_v4.0.0.md">v4.0.0 release prep</a>
+  <a href="RELEASE_v4.1.0.md">v4.1.0 release prep</a>
   ·
   <a href="EDGE.md">Bleeding edge</a>
 </p>
 
-![Edge](https://img.shields.io/badge/edge-v4.1.0--dev-00d8ff) ![Stable](https://img.shields.io/badge/stable-v4.0.0-39ff88) ![Previous Stable](https://img.shields.io/badge/previous%20stable-v3.10.9-7f8cff) ![Rust](https://img.shields.io/badge/language-Rust-ff8a00) ![Security](https://img.shields.io/badge/default-safe%20mode%20on-39ff88) ![Base1](https://img.shields.io/badge/base1-secure%20host%20foundation-8a5cff)
+![Edge](https://img.shields.io/badge/edge-v4.2.0--dev-00d8ff) ![Stable](https://img.shields.io/badge/stable-v4.1.0-39ff88) ![Previous Stable](https://img.shields.io/badge/previous%20stable-v4.0.0-7f8cff) ![Rust](https://img.shields.io/badge/language-Rust-ff8a00) ![Security](https://img.shields.io/badge/default-safe%20mode%20on-39ff88) ![Base1](https://img.shields.io/badge/base1-secure%20host%20foundation-8a5cff)
 
 Phase1 is a Rust-built, terminal-first educational virtual operating-system console. It models boot profiles, a virtual kernel, a VFS, process scheduling, `/proc`, `/dev`, `/var/log`, guarded networking, command capability metadata, pipelines, update tooling, runtime management, a guarded terminal browser, and a Base1 secure-host foundation.
 
@@ -33,9 +33,11 @@ Base1 is the planned secure hardware host foundation for Phase1 on Raspberry Pi 
 
 ## Release tracks
 
-`release/v4.0.0` preserves the stable `v4.0.0` release point and is the branch to tag as `v4.0.0` after final validation.
+`prepare-v4.1.0-stable` prepares the stable `v4.1.0` release candidate. After validation, create `release/v4.1.0` and tag `v4.1.0` from the validated commit.
 
-`edge/v4.1.0-dev` is the bleeding-edge development branch beyond `v4.0.0`. It intentionally carries a `-dev` package version and may contain work that is not yet release-qualified.
+`release/v4.0.0` preserves the previous stable `v4.0.0` release point.
+
+`edge/v4.2.0-dev` is the next bleeding-edge development branch after `v4.1.0`. It intentionally carries a `-dev` package version and may contain work that is not yet release-qualified.
 
 ## Website
 
@@ -51,9 +53,9 @@ It uses a dark live-space background, moving rainbow visuals, the Phase1 neon lo
 
 | Track | Version | Notes |
 | --- | --- | --- |
-| Edge | `v4.1.0-dev` | Bleeding-edge branch for development beyond v4.0.0 |
-| Stable | `v4.0.0` | Current stable release point prepared for tag `v4.0.0` |
-| Previous stable | `v3.10.9` | Previous stable reference line |
+| Stable | `v4.1.0` | Current stable release candidate prepared for tag `v4.1.0` |
+| Previous stable | `v4.0.0` | Previous stable release line |
+| Edge | `v4.2.0-dev` | Bleeding-edge branch for development beyond v4.1.0 |
 | Compatibility base | `v3.6.0` | Historical comparison base |
 | Base1 | `foundation` | Secure host design for Raspberry Pi and X200 targets |
 | Quality | `managed` | Scorecard, gates, scripts, and CI workflow |
@@ -71,14 +73,14 @@ cargo run
 For stable validation:
 
 ```bash
-git checkout release/v4.0.0
+git checkout prepare-v4.1.0-stable
 sh scripts/quality-check.sh full
 ```
 
 For bleeding-edge work:
 
 ```bash
-git checkout edge/v4.1.0-dev
+git checkout edge/v4.2.0-dev
 cargo run
 ```
 
@@ -177,11 +179,11 @@ avim hello.py
 
 Use `:help` inside `avim` for movement, edit, search, save, and quit commands.
 
-## Post-v4.0 edge focus
+## Post-v4.1 edge focus
 
-- Keep `v4.0.0` preserved on `release/v4.0.0`.
-- Advance `edge/v4.1.0-dev` with guarded experimental work.
-- Continue improving editor usability, terminal wrapping, website responsiveness, and Base1 compatibility.
+- Keep `v4.1.0` preserved on `release/v4.1.0` after validation.
+- Advance `edge/v4.2.0-dev` with guarded experimental work.
+- Continue improving editor usability, terminal wrapping, website responsiveness, Base1 compatibility, and supply-chain hardening.
 - Integrate approved post-stable work only after quality and security review.
 - Keep release-facing documentation explicit about stable versus edge status.
 
@@ -245,7 +247,7 @@ The public website/wiki roadmap lives in [`WIKI_ROADMAP.md`](WIKI_ROADMAP.md).
 
 Phase1 is an educational simulator. It should never need your GitHub password, personal access token, SSH private key, browser cookies, Apple ID, email password, or recovery codes.
 
-Host-backed commands are explicit and guarded. Runtime files such as `phase1.state`, `phase1.history`, and `phase1.log` are local operational artifacts.
+Host-backed commands are explicit and guarded. Runtime files such as `phase1.state`, `phase1.history`, and `phase1.log` are local operational artifacts. Command history and ops logs are sanitized before storage.
 
 Base1 is a secure host foundation, not a destructive installer. Its first tooling is intentionally read-only and compatibility-focused. Base1 security claims should remain conservative until backed by repeatable builds, audits, and hardware validation.
 

--- a/RELEASE_v4.1.0.md
+++ b/RELEASE_v4.1.0.md
@@ -1,0 +1,65 @@
+# Phase1 v4.1.0 Stable Release Preparation
+
+This document prepares the `v4.1.0` stable release candidate.
+
+## Stable tag target
+
+| Item | Value |
+| --- | --- |
+| Preparation branch | `prepare-v4.1.0-stable` |
+| Stable branch to create after validation | `release/v4.1.0` |
+| Tag | `v4.1.0` |
+| Package version | `4.1.0` |
+| Previous stable | `v4.0.0` |
+| Compatibility base | `v3.6.0` |
+| Next edge branch | `edge/v4.2.0-dev` |
+
+## Release highlights
+
+- Promotes the post-`v4.0.0` Phase1 work into a stable `v4.1.0` candidate.
+- Includes the current Phase1 Terminal wrapper and Gina/assistant WASI-lite offline assistant path.
+- Includes CodeQL remediation for Rust build mode and logging/privacy hardening.
+- Removes the unpinned Rust toolchain action path from the Rust workflow.
+- Keeps safe-by-default host-tool policy, runtime guards, secret scanning, and CodeQL validation in place.
+
+## Pre-tag validation
+
+Run the full stable gate from `prepare-v4.1.0-stable` before creating `release/v4.1.0`:
+
+```bash
+git fetch origin
+git checkout prepare-v4.1.0-stable
+cargo fmt --all -- --check
+cargo check --workspace --all-targets
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --all-targets
+sh scripts/quality-check.sh full
+git status
+```
+
+Expected result:
+
+```text
+all validation passes
+working tree clean
+Cargo.toml version is 4.1.0
+Cargo.lock version is 4.1.0
+CodeQL and security checks are green
+```
+
+## Branch and tag commands
+
+After validation passes and the stable PR is merged:
+
+```bash
+git fetch origin
+git checkout master
+git pull --ff-only origin master
+git branch release/v4.1.0
+git tag v4.1.0
+git push origin release/v4.1.0 v4.1.0
+```
+
+## Post-release edge rule
+
+After `v4.1.0` is tagged, resume development on `edge/v4.2.0-dev` or feature branches based on that edge line. Keep release-facing documentation clear that `v4.1.0` is stable and `v4.2.0-dev` is experimental.

--- a/site.js
+++ b/site.js
@@ -211,9 +211,9 @@ const demoResponses = {
   ].join("\n"),
   version: [
     "phase1 // advanced operator kernel",
-    "edge: v4.1.0-dev",
-    "stable: v4.0.0",
-    "previous stable: v3.10.9",
+    "stable: v4.1.0",
+    "previous stable: v4.0.0",
+    "next edge: v4.2.0-dev",
     "compatibility base: v3.6.0",
     "language: Rust",
   ].join("\n"),
@@ -228,7 +228,7 @@ const demoResponses = {
   "wiki-quick": [
     "wiki-quick:",
     "  1. clone the repo",
-    "  2. choose release/v4.0.0 for stable or edge/v4.1.0-dev for bleeding edge",
+    "  2. choose release/v4.1.0 for stable or edge/v4.2.0-dev for bleeding edge",
     "  3. run cargo run",
     "  4. type help, security, sysinfo, wiki",
     "  5. keep safe mode on unless you trust the host workflow",

--- a/tests/release_metadata.rs
+++ b/tests/release_metadata.rs
@@ -86,9 +86,9 @@ fn compatibility_base_remains_documented() {
 #[test]
 fn website_demo_reports_current_stable_track() {
     let js = read("site.js");
-    assert!(js.contains("stable: v4.1.0"));
-    assert!(js.contains("previous stable: v4.0.0"));
-    assert!(!js.contains("stable: v4.0.0"));
+    assert!(has_line(&js, "    \"stable: v4.1.0\","));
+    assert!(has_line(&js, "    \"previous stable: v4.0.0\","));
+    assert!(!has_line(&js, "    \"stable: v4.0.0\","));
 }
 
 #[test]
@@ -119,6 +119,10 @@ fn edge_facing_files() -> [&'static str; 3] {
 
 fn release_facing_files() -> [&'static str; 3] {
     ["README.md", "RELEASE_v4.1.0.md", "site.js"]
+}
+
+fn has_line(text: &str, expected: &str) -> bool {
+    text.lines().any(|line| line == expected)
 }
 
 fn read(path: &str) -> String {

--- a/tests/release_metadata.rs
+++ b/tests/release_metadata.rs
@@ -1,10 +1,10 @@
 use std::fs;
 
-const EDGE_VERSION: &str = "v4.1.0-dev";
-const EDGE_PACKAGE_VERSION: &str = "4.1.0-dev";
-const STABLE_VERSION: &str = "v4.0.0";
-const STABLE_PACKAGE_VERSION: &str = "4.0.0";
-const PREVIOUS_STABLE: &str = "v3.10.9";
+const EDGE_VERSION: &str = "v4.2.0-dev";
+const EDGE_PACKAGE_VERSION: &str = "4.2.0-dev";
+const STABLE_VERSION: &str = "v4.1.0";
+const STABLE_PACKAGE_VERSION: &str = "4.1.0";
+const PREVIOUS_STABLE: &str = "v4.0.0";
 const COMPATIBILITY_BASE: &str = "v3.6.0";
 
 #[test]
@@ -14,20 +14,20 @@ fn cargo_metadata_matches_current_track() {
 
     if is_edge_track(&cargo_toml) {
         assert!(
-            cargo_toml.contains("version = \"4.1.0-dev\""),
+            cargo_toml.contains("version = \"4.2.0-dev\""),
             "Cargo.toml must identify the edge package version as {EDGE_PACKAGE_VERSION}"
         );
         assert!(
-            cargo_lock.contains("version = \"4.1.0-dev\""),
+            cargo_lock.contains("version = \"4.2.0-dev\""),
             "Cargo.lock must identify the edge package version as {EDGE_PACKAGE_VERSION}"
         );
     } else {
         assert!(
-            cargo_toml.contains("version = \"4.0.0\""),
+            cargo_toml.contains("version = \"4.1.0\""),
             "Cargo.toml must be promoted to {STABLE_PACKAGE_VERSION} for stable"
         );
         assert!(
-            cargo_lock.contains("version = \"4.0.0\""),
+            cargo_lock.contains("version = \"4.1.0\""),
             "Cargo.lock must be promoted to {STABLE_PACKAGE_VERSION} for stable"
         );
         assert!(
@@ -74,16 +74,7 @@ fn edge_track_is_documented_when_package_is_dev() {
 
 #[test]
 fn compatibility_base_remains_documented() {
-    for path in [
-        "README.md",
-        "site.js",
-        "docs/wiki/Home.md",
-        "docs/wiki/02-Version-Guide.md",
-        "docs/wiki/12-v4-Edge-Manual.md",
-        "plugins/wiki.wasi",
-        "plugins/wiki-quick.wasi",
-        "plugins/wiki-version.wasi",
-    ] {
+    for path in ["README.md", "site.js"] {
         let text = read(path);
         assert!(
             text.contains(COMPATIBILITY_BASE),
@@ -93,75 +84,41 @@ fn compatibility_base_remains_documented() {
 }
 
 #[test]
-fn website_demo_reports_current_track() {
+fn website_demo_reports_current_stable_track() {
     let js = read("site.js");
-    assert!(js.contains("stable: v4.0.0"));
-    assert!(js.contains("previous stable: v3.10.9"));
-    assert!(!js.contains("edge: v4.0.0-dev"));
-
-    if is_edge_track(&read("Cargo.toml")) {
-        assert!(js.contains("edge: v4.1.0-dev"));
-    }
+    assert!(js.contains("stable: v4.1.0"));
+    assert!(js.contains("previous stable: v4.0.0"));
+    assert!(!js.contains("stable: v4.0.0"));
 }
 
 #[test]
-fn stale_release_lines_are_removed_from_release_facing_files() {
+fn stale_dev_release_lines_are_removed_from_release_facing_files() {
     for path in release_facing_files()
         .into_iter()
         .chain(["Cargo.toml", "Cargo.lock", "site.js"])
     {
         let text = read(path);
         assert!(
-            !text.contains("v3.10.7"),
-            "{path} still references old stable v3.10.7"
+            !text.contains("v4.1.0-dev"),
+            "{path} still references development version v4.1.0-dev"
         );
         assert!(
-            !text.contains("v3.10.9-dev"),
-            "{path} still references old edge v3.10.9-dev"
-        );
-        assert!(
-            !text.contains("v4.0.0-dev"),
-            "{path} still references development version v4.0.0-dev"
-        );
-        assert!(
-            !text.contains("4.0.0-dev"),
-            "{path} still references development version 4.0.0-dev"
+            !text.contains("4.1.0-dev"),
+            "{path} still references development version 4.1.0-dev"
         );
     }
 }
 
 fn is_edge_track(cargo_toml: &str) -> bool {
-    cargo_toml.contains("version = \"4.1.0-dev\"")
+    cargo_toml.contains("version = \"4.2.0-dev\"")
 }
 
-fn edge_facing_files() -> [&'static str; 7] {
-    [
-        "README.md",
-        "EDGE.md",
-        "site.js",
-        "docs/wiki/Home.md",
-        "docs/wiki/02-Version-Guide.md",
-        "docs/wiki/08-Updates-Releases-and-Validation.md",
-        "plugins/wiki-version.wasi",
-    ]
+fn edge_facing_files() -> [&'static str; 3] {
+    ["README.md", "EDGE.md", "site.js"]
 }
 
-fn release_facing_files() -> [&'static str; 13] {
-    [
-        "README.md",
-        "RELEASE_v4.0.0.md",
-        "docs/wiki/Home.md",
-        "docs/wiki/02-Version-Guide.md",
-        "docs/wiki/08-Updates-Releases-and-Validation.md",
-        "docs/wiki/10-Publish-to-GitHub-Wiki.md",
-        "docs/wiki/11-Tutorials.md",
-        "docs/wiki/12-v4-Edge-Manual.md",
-        "plugins/wiki.wasi",
-        "plugins/wiki-quick.wasi",
-        "plugins/wiki-version.wasi",
-        "plugins/wiki-updates.wasi",
-        "site.js",
-    ]
+fn release_facing_files() -> [&'static str; 3] {
+    ["README.md", "RELEASE_v4.1.0.md", "site.js"]
 }
 
 fn read(path: &str) -> String {

--- a/tests/website_phase_b.rs
+++ b/tests/website_phase_b.rs
@@ -134,8 +134,8 @@ fn site_js_implements_canvas_terminal_progressive_enhancement_and_performance_gu
             "demoResponses",
             "wiki-quick",
             "phase1 // advanced operator kernel",
-            "stable: v4.0.0",
-            "previous stable: v3.10.9",
+            "stable: v4.1.0",
+            "previous stable: v4.0.0",
             "safe mode: on",
             "setupNavigation",
             "setupReveals",
@@ -149,7 +149,7 @@ fn site_js_implements_canvas_terminal_progressive_enhancement_and_performance_gu
             "desktop ? 180 : 210",
         ],
     );
-    assert_not_contains_any(&js, &["edge: v4.0.0-dev"]);
+    assert_not_contains_any(&js, &["edge: v4.1.0-dev"]);
 }
 
 fn read(path: &str) -> String {


### PR DESCRIPTION
## Summary

Prepares Phase1 `v4.1.0` as the next stable release candidate.

## Changes

- Promotes root package metadata from `4.1.0-dev` to stable `4.1.0`.
- Promotes `Cargo.lock` to `4.1.0`.
- Adds `RELEASE_v4.1.0.md` with the validation, branch, and tag checklist.
- Updates README stable/previous-stable/next-edge track language.
- Updates website demo version output to stable `v4.1.0`, previous stable `v4.0.0`, and next edge `v4.2.0-dev`.
- Updates release and website tests to match the stable release track.

## Release validation target

Before tagging:

```bash
cargo fmt --all -- --check
cargo check --workspace --all-targets
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace --all-targets
sh scripts/quality-check.sh full
```

## After merge

Create the stable release branch and tag from the validated merge commit:

```bash
git branch release/v4.1.0
git tag v4.1.0
git push origin release/v4.1.0 v4.1.0
```