### PR TITLE
Prepare edge v4.2.6 website mobile polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,4 +5,4 @@ version = 4
 
 [[package]]
 name = "phase1"
-version = "4.2.5-dev"
+version = "4.2.6-dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phase1"
-version = "4.2.5-dev"
+version = "4.2.6-dev"
 edition = "2021"
 default-run = "phase1"
 authors = ["Chase Bryan"]

--- a/EDGE.md
+++ b/EDGE.md
@@ -1,22 +1,31 @@
 # Phase1 Edge Development
 
-`edge/v4.2.5-dev` is the active development line after the stable `v4.0.0` release point.
+`edge/v4.2.6-dev` is the active development line after the stable `v4.0.0` release point.
 
 ## Current identity
 
 | Item | Value |
 | --- | --- |
-| Development branch | `edge/v4.2.5-dev` |
-| Development package version | `4.2.5-dev` |
+| Development branch | `edge/v4.2.6-dev` |
+| Development package version | `4.2.6-dev` |
 | Stable release point | `v4.0.0` |
 | Stable branch | `release/v4.0.0` |
 | Previous stable | `v3.10.9` |
 | Compatibility base | `v3.6.0` |
 
-## v4.2.5 edge focus
+## v4.2.6 edge focus
+
+- Tighten the public website for mobile and in-app browser layouts.
+- Prevent horizontal scrolling on iPhone widths.
+- Keep the hero, buttons, command strip, terminal demo, and logo stage inside the viewport.
+- Reduce oversized mobile text and orbital-globe elements without flattening the visual identity.
+- Refresh browser demo version output to match the edge track.
+
+## Recent v4.2.5 edge focus
 
 - Replace the launcher wording with a slower PHASE1 boot splash.
 - Add visible preparation spinners for the launcher and boot flow.
+- Add the red Japanese Easter egg greeting under the PHASE1 launcher splash.
 - Change the boot selector node line to Japanese: `東京-01 // 全サブシステム正常`.
 - Expand boot-screen help so the controls are readable before entering the shell.
 - Clean up boot labels, capitalization, and operator copy.
@@ -33,7 +42,7 @@
 
 ```bash
 git fetch origin
-git checkout edge/v4.2.5-dev
+git checkout edge/v4.2.6-dev
 cargo metadata --no-deps --format-version 1 | grep '"version"'
 cargo run
 ```
@@ -41,7 +50,7 @@ cargo run
 Expected package version:
 
 ```text
-4.2.5-dev
+4.2.6-dev
 ```
 
 ## Validation

--- a/button-fix.css
+++ b/button-fix.css
@@ -211,6 +211,128 @@ h1 {
 
 /* Mobile readability: keep the design, but stop headings from fragmenting. */
 @media (max-width: 860px) {
+  html,
+  body {
+    max-width: 100% !important;
+    overflow-x: clip !important;
+  }
+
+  body {
+    min-width: 0 !important;
+  }
+
+  #space,
+  .scanlines,
+  .noise {
+    width: 100vw !important;
+    max-width: 100vw !important;
+  }
+
+  .aurora {
+    width: 32rem !important;
+    height: 32rem !important;
+    filter: blur(48px) !important;
+    opacity: 0.18 !important;
+  }
+
+  .aurora-one {
+    left: -18rem !important;
+    top: -12rem !important;
+  }
+
+  .aurora-two {
+    right: -20rem !important;
+    bottom: -14rem !important;
+  }
+
+  .site-shell {
+    width: min(100% - 20px, 760px) !important;
+    padding: 10px 0 28px !important;
+  }
+
+  .nav {
+    position: sticky !important;
+    top: 8px !important;
+    gap: 10px !important;
+    padding: 10px 12px !important;
+    border-radius: 18px !important;
+  }
+
+  .brand {
+    max-width: calc(100vw - 96px) !important;
+    letter-spacing: 0.1em !important;
+    font-size: 0.92rem !important;
+  }
+
+  .nav-toggle {
+    display: inline-grid !important;
+    place-content: center !important;
+    flex: 0 0 44px !important;
+  }
+
+  .nav-links {
+    position: absolute !important;
+    top: calc(100% + 8px) !important;
+    left: 0 !important;
+    right: 0 !important;
+    display: none !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    gap: 8px !important;
+    padding: 12px !important;
+    border: 1px solid var(--border) !important;
+    border-radius: 18px !important;
+    background: rgba(5, 7, 17, 0.96) !important;
+    backdrop-filter: blur(18px) !important;
+    box-shadow: var(--shadow) !important;
+  }
+
+  .nav-links.is-open {
+    display: grid !important;
+  }
+
+  .nav-links a {
+    display: flex !important;
+    justify-content: center !important;
+    min-width: 0 !important;
+    padding: 10px 8px !important;
+    border: 1px solid rgba(255, 255, 255, 0.1) !important;
+    background: rgba(255, 255, 255, 0.045) !important;
+    font-size: 0.88rem !important;
+  }
+
+  main {
+    gap: 20px !important;
+  }
+
+  .hero,
+  .founder,
+  .support-grid {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+
+  .hero {
+    gap: 22px !important;
+    margin-top: 18px !important;
+    padding: clamp(18px, 5.2vw, 28px) !important;
+    border-radius: 24px !important;
+    overflow: hidden !important;
+  }
+
+  .hero-copy,
+  .hero-text,
+  .section-heading,
+  .terminal,
+  .roadmap,
+  .founder,
+  .support-card,
+  .feature-card,
+  .timeline li,
+  .metric-strip,
+  .hero-command {
+    min-width: 0 !important;
+    max-width: 100% !important;
+  }
+
   h1,
   .section-heading h2,
   .founder-copy h2,
@@ -222,7 +344,7 @@ h1 {
   }
 
   h1 {
-    font-size: clamp(2.05rem, 11vw, 3.35rem) !important;
+    font-size: clamp(2.05rem, 10.2vw, 3.2rem) !important;
     line-height: 1.02 !important;
     letter-spacing: -0.045em !important;
   }
@@ -258,25 +380,201 @@ h1 {
     line-height: 1.62 !important;
   }
 
+  .hero-actions,
+  .roadmap-actions {
+    display: grid !important;
+    grid-template-columns: minmax(0, 1fr) !important;
+    gap: 10px !important;
+    width: 100% !important;
+    margin: 22px 0 16px !important;
+  }
+
+  .button {
+    width: 100% !important;
+    min-height: 48px !important;
+    padding-inline: 14px !important;
+    text-align: center !important;
+  }
+
+  .hero-command {
+    display: grid !important;
+    grid-template-columns: auto minmax(0, 1fr) !important;
+    align-items: start !important;
+    overflow-x: auto !important;
+    -webkit-overflow-scrolling: touch !important;
+  }
+
+  .hero-command code {
+    white-space: pre !important;
+    font-size: 0.78rem !important;
+  }
+
+  .metric-strip,
+  .feature-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    gap: 10px !important;
+  }
+
+  .metric-strip div {
+    padding: 12px !important;
+  }
+
+  .logo-stage {
+    width: 100% !important;
+    min-height: min(86vw, 390px) !important;
+    padding: 8px 0 0 !important;
+    overflow: hidden !important;
+  }
+
+  .logo-stage::before {
+    width: min(86vw, 360px) !important;
+    filter: blur(20px) !important;
+    opacity: 0.62 !important;
+  }
+
+  .logo-glass {
+    width: min(100%, 360px) !important;
+    max-width: calc(100vw - 56px) !important;
+    padding: 8px !important;
+    border-radius: 26px !important;
+  }
+
+  .phase-logo {
+    border-radius: 20px !important;
+  }
+
+  .orbit-one {
+    width: min(90vw, 360px) !important;
+  }
+
+  .orbit-two {
+    width: min(72vw, 286px) !important;
+  }
+
+  .orbit-three {
+    width: min(52vw, 210px) !important;
+  }
+
+  .system-card {
+    position: relative !important;
+    inset: auto !important;
+    justify-self: stretch !important;
+    width: min(100%, 260px) !important;
+    margin: 8px auto 0 !important;
+    padding: 10px 12px !important;
+    text-align: center !important;
+    transform: none !important;
+  }
+
+  .terminal-topbar,
+  .terminal-form {
+    grid-template-columns: minmax(0, 1fr) !important;
+    flex-wrap: wrap !important;
+  }
+
+  .terminal-title,
+  .terminal-status,
+  .terminal-form span {
+    white-space: normal !important;
+    min-width: 0 !important;
+  }
+
+  .terminal-form {
+    display: grid !important;
+    gap: 10px !important;
+  }
+
+  .terminal-form input,
+  .terminal-form button {
+    width: 100% !important;
+  }
+
+  .terminal-output {
+    min-height: 260px !important;
+    max-height: 380px !important;
+    padding: 16px !important;
+    font-size: 0.82rem !important;
+    white-space: pre-wrap !important;
+    overflow-wrap: anywhere !important;
+  }
+
+  .quick-commands {
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    padding: 0 14px 14px !important;
+  }
+
+  .quick-commands button {
+    min-width: 0 !important;
+  }
+
+  .timeline {
+    margin: 26px 0 22px !important;
+  }
+
+  .timeline::before {
+    left: 22px !important;
+  }
+
+  .timeline li {
+    grid-template-columns: 30px minmax(0, 1fr) !important;
+  }
+
+  .timeline-dot {
+    width: 18px !important;
+    height: 18px !important;
+  }
+
+  .founder {
+    padding: 22px !important;
+  }
+
+  .founder-profile {
+    order: 2 !important;
+  }
+
+  .founder-copy {
+    order: 1 !important;
+  }
+
+  .avatar-ring {
+    width: 136px !important;
+  }
+
+  .founder-avatar {
+    width: 116px !important;
+  }
+
   .feature-card,
   .bryforge-card,
   .support-card,
   .timeline li {
     padding: 18px !important;
   }
+
+  .footer {
+    grid-template-columns: minmax(0, 1fr) !important;
+    padding: 18px !important;
+  }
+
+  .footer-links {
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    gap: 8px !important;
+  }
 }
 
 @media (max-width: 420px) {
   .site-shell {
-    width: min(100% - 16px, 720px) !important;
+    width: min(100% - 14px, 720px) !important;
   }
 
   .hero {
-    padding: 20px !important;
+    padding: 18px !important;
   }
 
   h1 {
-    font-size: clamp(1.9rem, 10vw, 2.7rem) !important;
+    font-size: clamp(1.86rem, 9.8vw, 2.55rem) !important;
     letter-spacing: -0.032em !important;
   }
 
@@ -291,5 +589,20 @@ h1 {
 
   .hero-actions {
     gap: 10px !important;
+  }
+
+  .metric-strip,
+  .feature-grid,
+  .quick-commands,
+  .footer-links {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+
+  .logo-glass {
+    max-width: calc(100vw - 44px) !important;
+  }
+
+  .terminal-output {
+    font-size: 0.78rem !important;
   }
 }

--- a/index.html
+++ b/index.html
@@ -2,13 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>phase1 by Bryforge // Secure Rust Virtual OS Console</title>
   <meta name="description" content="phase1 by Bryforge is a secure, private, open-source Rust virtual OS console with a simulated kernel, VFS, process table, audit log, guarded browser, wiki, and safe-by-default operator shell.">
-  <meta name="keywords" content="Bryforge, phase1, Phase1, Phase 1, Chase Bryan, advanced operator kernel, virtual OS console, Rust OS console, open source operating system simulator, terminal-first developer tools, secure developer tools, Bryforge software development">
+  <meta name="keywords" content="Bryforge, phase1, Phase1, Chase Bryan, advanced operator kernel, virtual OS console, Rust OS console, terminal-first developer tools, secure developer tools">
   <meta name="author" content="Chase Bryan, Bryforge">
   <meta name="robots" content="index, follow, max-image-preview:large">
-  <meta name="googlebot" content="index, follow, max-image-preview:large">
   <meta name="theme-color" content="#050711">
   <link rel="canonical" href="https://bryforge.github.io/phase1/">
   <link rel="icon" type="image/svg+xml" href="./assets/phase1-banner.svg">
@@ -19,91 +18,16 @@
   <meta property="og:url" content="https://bryforge.github.io/phase1/">
   <meta property="og:site_name" content="phase1 by Bryforge">
   <meta property="og:image" content="https://bryforge.github.io/phase1/assets/phase1-banner.svg">
-  <meta property="og:image:secure_url" content="https://bryforge.github.io/phase1/assets/phase1-banner.svg">
-  <meta property="og:image:type" content="image/svg+xml">
-  <meta property="og:image:width" content="1254">
-  <meta property="og:image:height" content="1254">
   <meta property="og:image:alt" content="phase1 neon rainbow advanced operator kernel logo">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="phase1 by Bryforge // Secure Rust Virtual OS Console">
   <meta name="twitter:description" content="A secure, private, open-source Rust virtual OS console with a simulated kernel, VFS, audit log, guarded browser, wiki, and safe-by-default shell.">
   <meta name="twitter:image" content="https://bryforge.github.io/phase1/assets/phase1-banner.svg">
-  <meta name="twitter:image:alt" content="phase1 neon rainbow advanced operator kernel logo">
-  <link rel="image_src" href="https://bryforge.github.io/phase1/assets/phase1-banner.svg">
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@graph": [
-      {
-        "@type": "Organization",
-        "@id": "https://bryforge.github.io/phase1/#organization",
-        "name": "Bryforge",
-        "url": "https://bryforge.github.io/phase1/",
-        "logo": "https://bryforge.github.io/phase1/assets/phase1-banner.svg",
-        "founder": {
-          "@id": "https://bryforge.github.io/phase1/#chase-bryan"
-        },
-        "description": "Bryforge is a startup software development company founded by Chase Bryan, focused on secure, polished, developer-first systems and software products."
-      },
-      {
-        "@type": "Person",
-        "@id": "https://bryforge.github.io/phase1/#chase-bryan",
-        "name": "Chase Bryan",
-        "url": "https://bryforge.github.io/phase1/#founder",
-        "image": "https://avatars.githubusercontent.com/u/281080815?v=4",
-        "jobTitle": "Computer Scientist and Software Developer",
-        "worksFor": {
-          "@id": "https://bryforge.github.io/phase1/#organization"
-        }
-      },
-      {
-        "@type": "SoftwareSourceCode",
-        "@id": "https://bryforge.github.io/phase1/#phase1",
-        "name": "phase1",
-        "alternateName": ["Phase1", "Phase 1", "phase1 advanced operator kernel", "phase1 virtual OS console"],
-        "url": "https://bryforge.github.io/phase1/",
-        "codeRepository": "https://github.com/Bryforge/phase1",
-        "programmingLanguage": "Rust",
-        "license": "https://www.gnu.org/licenses/gpl-3.0.en.html",
-        "creator": {
-          "@id": "https://bryforge.github.io/phase1/#chase-bryan"
-        },
-        "publisher": {
-          "@id": "https://bryforge.github.io/phase1/#organization"
-        },
-        "description": "phase1 is a secure, open-source virtual OS console and advanced operator kernel built in Rust by Bryforge."
-      },
-      {
-        "@type": "WebSite",
-        "@id": "https://bryforge.github.io/phase1/#website",
-        "name": "phase1 by Bryforge",
-        "url": "https://bryforge.github.io/phase1/",
-        "publisher": {
-          "@id": "https://bryforge.github.io/phase1/#organization"
-        },
-        "about": {
-          "@id": "https://bryforge.github.io/phase1/#phase1"
-        }
-      }
-    ]
-  }
+  {"@context":"https://schema.org","@graph":[{"@type":"Organization","@id":"https://bryforge.github.io/phase1/#organization","name":"Bryforge","url":"https://bryforge.github.io/phase1/","logo":"https://bryforge.github.io/phase1/assets/phase1-banner.svg"},{"@type":"Person","@id":"https://bryforge.github.io/phase1/#chase-bryan","name":"Chase Bryan","jobTitle":"Computer Scientist and Software Developer","worksFor":{"@id":"https://bryforge.github.io/phase1/#organization"}},{"@type":"SoftwareSourceCode","@id":"https://bryforge.github.io/phase1/#phase1","name":"phase1","url":"https://bryforge.github.io/phase1/","codeRepository":"https://github.com/Bryforge/phase1","programmingLanguage":"Rust","license":"https://www.gnu.org/licenses/gpl-3.0.en.html","creator":{"@id":"https://bryforge.github.io/phase1/#chase-bryan"}}]}
   </script>
-  <link rel="stylesheet" href="./styles.css?v=4.0.0-stable-2">
-  <link rel="stylesheet" href="./button-fix.css?v=4.0.0-founder-profile-2">
-  <style id="founder-profile-inline-guard">
-    #founder .profile-label {
-      display: none !important;
-    }
-
-    #founder .founder-copy > .eyebrow {
-      display: block !important;
-    }
-
-    #founder .founder-copy h2::before {
-      content: none !important;
-      display: none !important;
-    }
-  </style>
+  <link rel="stylesheet" href="./styles.css?v=4.2.6-dev">
+  <link rel="stylesheet" href="./button-fix.css?v=4.2.6-dev">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
@@ -115,21 +39,14 @@
 
   <header class="site-shell" id="top">
     <nav class="nav glass-panel" aria-label="Primary navigation">
-      <a class="brand" href="#top" aria-label="phase1 home">
-        <span class="brand-pip" aria-hidden="true"></span>
-        <span>phase1</span>
-      </a>
-      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="nav-links">
-        <span class="sr-only">Toggle navigation</span>
-        <span></span><span></span><span></span>
-      </button>
+      <a class="brand" href="#top" aria-label="phase1 home"><span class="brand-pip" aria-hidden="true"></span><span>phase1</span></a>
+      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="nav-links"><span class="sr-only">Toggle navigation</span><span></span><span></span><span></span></button>
       <div class="nav-links" id="nav-links">
         <a href="#demo">Demo</a>
         <a href="#features">Features</a>
         <a href="#roadmap">Roadmap</a>
         <a href="#founder">Founder</a>
-        <a href="#sponsor">Sponsor</a>
-        <a href="./wiki/">Wiki Hub</a>
+        <a href="./wiki/">Wiki</a>
         <a href="https://github.com/Bryforge/phase1" target="_blank" rel="noopener noreferrer">GitHub</a>
       </div>
     </nav>
@@ -139,245 +56,78 @@
         <div class="hero-copy">
           <p class="eyebrow">secure · private · powerful · open</p>
           <h1 id="hero-title">A Rust virtual OS console for operators who want control.</h1>
-          <p class="hero-text">
-            phase1 is a terminal-first advanced operator kernel: a Rust-built virtual OS console with a simulated kernel,
-            VFS, process table, audit log, guarded browser, in-system wiki, runtime roadmap, and safe-by-default shell.
-          </p>
+          <p class="hero-text">phase1 is a terminal-first advanced operator kernel: a Rust-built virtual OS console with a simulated kernel, VFS, process table, audit log, guarded browser, in-system wiki, runtime roadmap, and safe-by-default shell.</p>
           <div class="hero-actions" aria-label="Primary actions">
             <a class="button button-primary" href="https://github.com/Bryforge/phase1#quick-start" target="_blank" rel="noopener noreferrer">Clone &amp; run</a>
             <a class="button button-secondary" href="#demo">Try the console</a>
-            <a class="button button-ghost" href="./wiki/">Open Wiki Hub</a>
-            <a class="button button-coffee" href="https://www.buymeacoffee.com/bryforge" target="_blank" rel="noopener noreferrer">Support phase1</a>
+            <a class="button button-ghost" href="./wiki/">Open Wiki</a>
+            <a class="button button-coffee" href="https://www.buymeacoffee.com/bryforge" target="_blank" rel="noopener noreferrer">Support</a>
           </div>
-          <div class="hero-command" aria-label="phase1 quick start command">
-            <span class="prompt">$</span>
-            <code>git clone https://github.com/Bryforge/phase1.git &amp;&amp; cd phase1 &amp;&amp; cargo run</code>
-          </div>
+          <div class="hero-command" aria-label="phase1 quick start command"><span class="prompt">$</span><code>git clone https://github.com/Bryforge/phase1.git &amp;&amp; cd phase1 &amp;&amp; cargo run</code></div>
           <div class="metric-strip" aria-label="phase1 project highlights">
             <div><strong>Rust</strong><span>core language</span></div>
             <div><strong>GPL-3.0</strong><span>open source</span></div>
             <div><strong>Safe mode</strong><span>default posture</span></div>
-            <div><strong>v4 stable</strong><span>current build</span></div>
+            <div><strong>v4.2.6-dev</strong><span>edge track</span></div>
           </div>
         </div>
-
         <div class="logo-stage" aria-label="phase1 rainbow logo">
           <div class="orbit orbit-one" aria-hidden="true"></div>
           <div class="orbit orbit-two" aria-hidden="true"></div>
           <div class="orbit orbit-three" aria-hidden="true"></div>
-          <div class="logo-glass">
-            <img class="phase-logo" src="./assets/phase1-banner.svg" alt="phase1 rainbow neon logo with advanced operator kernel text">
-          </div>
+          <div class="logo-glass"><img class="phase-logo" src="./assets/phase1-banner.svg" alt="phase1 rainbow neon logo with advanced operator kernel text"></div>
           <div class="system-card system-card-one" aria-hidden="true"><span>SAFE MODE</span><strong>ON</strong></div>
           <div class="system-card system-card-two" aria-hidden="true"><span>HOST TRUST</span><strong>GUARDED</strong></div>
         </div>
       </section>
 
       <section id="demo" class="terminal-section reveal" aria-labelledby="demo-title">
-        <div class="section-heading">
-          <p class="eyebrow">live-feel preview</p>
-          <h2 id="demo-title">Try the phase1 prompt before you clone it.</h2>
-          <p>
-            This browser demo is intentionally simulated, but it mirrors the product feel: command-first, transparent, inspectable, and secure by default.
-          </p>
-        </div>
-
+        <div class="section-heading"><p class="eyebrow">live-feel preview</p><h2 id="demo-title">Try the phase1 prompt before you clone it.</h2><p>This browser demo mirrors the product feel: command-first, transparent, inspectable, and secure by default.</p></div>
         <div class="terminal glass-panel" role="region" aria-label="Interactive phase1 terminal demo">
-          <div class="terminal-topbar">
-            <div class="window-lights" aria-hidden="true"><span></span><span></span><span></span></div>
-            <span class="terminal-title">phase1://operator-console</span>
-            <span class="terminal-status">safe mode: on</span>
-          </div>
+          <div class="terminal-topbar"><div class="window-lights" aria-hidden="true"><span></span><span></span><span></span></div><span class="terminal-title">phase1://operator-console</span><span class="terminal-status">safe mode: on</span></div>
           <pre id="terminal-output" class="terminal-output" aria-live="polite"></pre>
-          <form class="terminal-form" id="terminal-form">
-            <label class="sr-only" for="terminal-input">phase1 command</label>
-            <span aria-hidden="true">phase1://root ~ #</span>
-            <input id="terminal-input" name="command" autocomplete="off" spellcheck="false" placeholder="type help, version, sysinfo, wiki-quick, security">
-            <button type="submit">run</button>
-          </form>
-          <div class="quick-commands" aria-label="Sample phase1 commands">
-            <button type="button" data-command="help">help</button>
-            <button type="button" data-command="version">version</button>
-            <button type="button" data-command="sysinfo">sysinfo</button>
-            <button type="button" data-command="wiki-quick">wiki-quick</button>
-            <button type="button" data-command="security">security</button>
-          </div>
+          <form class="terminal-form" id="terminal-form"><label class="sr-only" for="terminal-input">phase1 command</label><span aria-hidden="true">phase1://root ~ #</span><input id="terminal-input" name="command" autocomplete="off" spellcheck="false" placeholder="type help, version, sysinfo, wiki-quick, security"><button type="submit">run</button></form>
+          <div class="quick-commands" aria-label="Sample phase1 commands"><button type="button" data-command="help">help</button><button type="button" data-command="version">version</button><button type="button" data-command="sysinfo">sysinfo</button><button type="button" data-command="wiki-quick">wiki-quick</button><button type="button" data-command="security">security</button></div>
         </div>
       </section>
 
       <section id="features" class="features reveal" aria-labelledby="features-title">
-        <div class="section-heading centered">
-          <p class="eyebrow">operator-grade foundation</p>
-          <h2 id="features-title">Everything feels like a console. Everything is designed to be inspectable.</h2>
-        </div>
+        <div class="section-heading centered"><p class="eyebrow">operator-grade foundation</p><h2 id="features-title">Everything feels like a console. Everything is designed to be inspectable.</h2></div>
         <div class="feature-grid" aria-label="phase1 feature cards">
-          <article class="feature-card">
-            <span class="feature-icon" aria-hidden="true">⌁</span>
-            <span class="card-kicker">01 · kernel</span>
-            <h3>Kernel simulation</h3>
-            <p>Boot profiles, virtual processes, /proc, PCIe flavor, CR3/CR4 commands, and audit records for operator visibility.</p>
-          </article>
-          <article class="feature-card">
-            <span class="feature-icon" aria-hidden="true">◈</span>
-            <span class="card-kicker">02 · vfs</span>
-            <h3>Virtual filesystem</h3>
-            <p>A terminal-native VFS with files, docs, editors, runtime state, and a safer place to practice OS-style workflows.</p>
-          </article>
-          <article class="feature-card">
-            <span class="feature-icon" aria-hidden="true">◇</span>
-            <span class="card-kicker">03 · safety</span>
-            <h3>Guarded host bridge</h3>
-            <p>Host-backed tools stay behind safe-mode and explicit trust gates so the default posture is private and contained.</p>
-          </article>
-          <article class="feature-card">
-            <span class="feature-icon" aria-hidden="true">▣</span>
-            <span class="card-kicker">04 · browser</span>
-            <h3>Terminal browser</h3>
-            <p>Guarded browser and network inspection ideas are built around clarity, not hidden background behavior.</p>
-          </article>
-          <article class="feature-card">
-            <span class="feature-icon" aria-hidden="true">⌬</span>
-            <span class="card-kicker">05 · runtimes</span>
-            <h3>Runtime roadmap</h3>
-            <p>Language support, storage, Git, Rust workflows, and future runtime shells are being designed with capability metadata and limits.</p>
-          </article>
-          <article class="feature-card">
-            <span class="feature-icon" aria-hidden="true">✦</span>
-            <span class="card-kicker">06 · docs</span>
-            <h3>Wiki-first learning</h3>
-            <p>In-system manual pages plus a public Wiki Hub make phase1 teachable, searchable, and friendly for contributors.</p>
-          </article>
+          <article class="feature-card"><span class="feature-icon" aria-hidden="true">⌁</span><span class="card-kicker">01 · kernel</span><h3>Kernel simulation</h3><p>Boot profiles, virtual processes, /proc, PCIe flavor, CR3/CR4 commands, and audit records.</p></article>
+          <article class="feature-card"><span class="feature-icon" aria-hidden="true">◈</span><span class="card-kicker">02 · vfs</span><h3>Virtual filesystem</h3><p>A terminal-native VFS with files, docs, editors, runtime state, and safer OS-style practice.</p></article>
+          <article class="feature-card"><span class="feature-icon" aria-hidden="true">◇</span><span class="card-kicker">03 · safety</span><h3>Guarded host bridge</h3><p>Host-backed tools stay behind safe-mode and explicit trust gates.</p></article>
+          <article class="feature-card"><span class="feature-icon" aria-hidden="true">▣</span><span class="card-kicker">04 · browser</span><h3>Terminal browser</h3><p>Guarded browser and network inspection ideas are designed around clarity.</p></article>
+          <article class="feature-card"><span class="feature-icon" aria-hidden="true">⌬</span><span class="card-kicker">05 · runtimes</span><h3>Runtime roadmap</h3><p>Language support, storage, Git, Rust workflows, and future runtime shells.</p></article>
+          <article class="feature-card"><span class="feature-icon" aria-hidden="true">✦</span><span class="card-kicker">06 · docs</span><h3>Wiki-first learning</h3><p>Manual pages plus a public Wiki Hub make phase1 teachable and contributor-friendly.</p></article>
         </div>
       </section>
 
       <section id="roadmap" class="roadmap glass-panel reveal" aria-labelledby="roadmap-title">
-        <div class="section-heading">
-          <p class="eyebrow">website roadmap</p>
-          <h2 id="roadmap-title">From landing page to full public front door.</h2>
-          <p>
-            The website roadmap turns GitHub Pages into the main public home for phase1: homepage, wiki, docs navigation, visual demos, releases, contributors, quality notes, and sponsorship.
-          </p>
-        </div>
-
-        <ol class="timeline" aria-label="Five phase website roadmap">
-          <li class="complete">
-            <span class="timeline-dot" aria-hidden="true"></span>
-            <div>
-              <p class="timeline-status">Phase A · launched</p>
-              <h3>Homepage identity</h3>
-              <p>Dark-space rainbow landing page, phase1 logo, founder profile, Bryforge company section, sponsor CTA, GitHub links, SEO, and deploy workflow.</p>
-            </div>
-          </li>
-          <li class="active">
-            <span class="timeline-dot" aria-hidden="true"></span>
-            <div>
-              <p class="timeline-status">Phase B · in progress</p>
-              <h3>Wiki content on the site</h3>
-              <p>Bring Quick Start, Boot Profiles, Command Map, Files/VFS, Browser Safety, Language Runtime Support, Updates, Troubleshooting, Tutorials, Sponsorship, and Bryforge into web pages.</p>
-            </div>
-          </li>
-          <li>
-            <span class="timeline-dot" aria-hidden="true"></span>
-            <div>
-              <p class="timeline-status">Phase C · planned</p>
-              <h3>Docs navigation and search</h3>
-              <p>Persistent docs sidebar, mobile docs drawer, page-local table of contents, previous/next links, keyboard-friendly search, and command metadata cards.</p>
-            </div>
-          </li>
-          <li>
-            <span class="timeline-dot" aria-hidden="true"></span>
-            <div>
-              <p class="timeline-status">Phase D · planned</p>
-              <h3>Visual demos and releases</h3>
-              <p>Screenshots, terminal captures, boot-profile selector preview, storage/Git/Rust workflow preview, and safe-mode versus trusted-host explanations.</p>
-            </div>
-          </li>
-          <li>
-            <span class="timeline-dot" aria-hidden="true"></span>
-            <div>
-              <p class="timeline-status">Phase E · planned</p>
-              <h3>Public front door</h3>
-              <p>Release notes, migration guides, stable/edge version cards, contributor guide, roadmap, quality score sections, security policy, audit notes, sponsor, and Bryforge links.</p>
-            </div>
-          </li>
+        <div class="section-heading"><p class="eyebrow">website roadmap</p><h2 id="roadmap-title">From landing page to full public front door.</h2><p>Phase1 v4.2.6-dev focuses on mobile fit, public polish, and reliable first impressions in mobile browsers.</p></div>
+        <ol class="timeline" aria-label="Website roadmap">
+          <li class="complete"><span class="timeline-dot" aria-hidden="true"></span><div><p class="timeline-status">Phase A · launched</p><h3>Homepage identity</h3><p>Dark-space rainbow landing page, logo, founder profile, sponsor CTA, SEO, and GitHub links.</p></div></li>
+          <li class="active"><span class="timeline-dot" aria-hidden="true"></span><div><p class="timeline-status">Phase B · active</p><h3>Mobile fit and edge polish</h3><p>No horizontal scrolling, tighter hero layout, responsive logo stage, and fresh edge version metadata.</p></div></li>
+          <li><span class="timeline-dot" aria-hidden="true"></span><div><p class="timeline-status">Phase C · planned</p><h3>Docs navigation</h3><p>Docs sidebar, mobile docs drawer, search, command metadata cards, and release cards.</p></div></li>
         </ol>
-
-        <div class="roadmap-actions">
-          <a class="button button-primary" href="./wiki/">Open designed Wiki Hub</a>
-          <a class="button button-secondary" href="./WIKI_ROADMAP.md">Read roadmap source</a>
-        </div>
+        <div class="roadmap-actions"><a class="button button-primary" href="./wiki/">Open Wiki Hub</a><a class="button button-secondary" href="./WIKI_ROADMAP.md">Read roadmap source</a></div>
       </section>
 
       <section id="founder" class="founder glass-panel reveal" aria-labelledby="founder-title">
-        <div class="founder-profile">
-          <div class="avatar-ring">
-            <img src="https://avatars.githubusercontent.com/u/281080815?v=4" alt="Chase Bryan profile image" class="founder-avatar">
-          </div>
-          <p class="profile-label">Chase Bryan</p>
-        </div>
-
-        <div class="founder-copy">
-          <p class="eyebrow">founder profile</p>
-          <h2 id="founder-title">Chase Bryan, computer scientist and phase1 creator.</h2>
-          <p>
-            I am Chase Bryan, a computer scientist and developer focused on secure systems,
-            terminal-first tools, operating-system ideas, language runtimes, and practical software that gives operators more control.
-            phase1 is my flagship research-and-build project: a Rust-powered virtual OS console designed to make advanced computing feel visual,
-            teachable, private, and powerful.
-          </p>
-
-          <div class="bryforge-card" aria-label="About Bryforge">
-            <span class="card-kicker">Bryforge</span>
-            <h3>Startup software development company</h3>
-            <p>
-              Bryforge is a startup software development company built around ambitious engineering, fast iteration,
-              and useful developer-first systems. Its mission is to forge software that is secure, polished, accessible,
-              and powerful enough for real builders—from experimental OS-style tools like phase1 to future apps,
-              infrastructure, automation, and custom software products.
-            </p>
-          </div>
-        </div>
+        <div class="founder-profile"><div class="avatar-ring"><img src="https://avatars.githubusercontent.com/u/281080815?v=4" alt="Chase Bryan profile image" class="founder-avatar"></div><p class="profile-label">Chase Bryan</p></div>
+        <div class="founder-copy"><p class="eyebrow">founder profile</p><h2 id="founder-title">Chase Bryan, computer scientist and phase1 creator.</h2><p>I am Chase Bryan, a computer scientist and developer focused on secure systems, terminal-first tools, operating-system ideas, language runtimes, and practical software that gives operators more control.</p><div class="bryforge-card" aria-label="About Bryforge"><span class="card-kicker">Bryforge</span><h3>Startup software development company</h3><p>Bryforge is built around ambitious engineering, fast iteration, and useful developer-first systems.</p></div></div>
       </section>
 
       <section id="sponsor" class="support-grid reveal" aria-labelledby="sponsor-title">
-        <div class="support-card glass-panel">
-          <p class="eyebrow">support the build</p>
-          <h2 id="sponsor-title">Fuel phase1 and the Bryforge roadmap.</h2>
-          <p>
-            Sponsor the project to support continued work on the phase1 kernel simulation, website, docs, language runtime support,
-            storage/Git tooling, security hardening, and future Bryforge software products.
-          </p>
-          <div class="hero-actions">
-            <a class="button button-coffee" href="https://www.buymeacoffee.com/bryforge" target="_blank" rel="noopener noreferrer">Buy me a coffee</a>
-            <a class="button button-secondary" href="https://github.com/Bryforge/phase1" target="_blank" rel="noopener noreferrer">Star on GitHub</a>
-          </div>
-        </div>
-        <div class="support-card support-card-mini glass-panel" aria-label="Project values">
-          <span>secure</span>
-          <span>private</span>
-          <span>powerful</span>
-          <span>open</span>
-        </div>
+        <div class="support-card glass-panel"><p class="eyebrow">support the build</p><h2 id="sponsor-title">Fuel phase1 and the Bryforge roadmap.</h2><p>Sponsor the project to support continued work on the kernel simulation, website, docs, runtime support, storage/Git tooling, and security hardening.</p><div class="hero-actions"><a class="button button-coffee" href="https://www.buymeacoffee.com/bryforge" target="_blank" rel="noopener noreferrer">Buy me a coffee</a><a class="button button-secondary" href="https://github.com/Bryforge/phase1" target="_blank" rel="noopener noreferrer">Star on GitHub</a></div></div>
+        <div class="support-card support-card-mini glass-panel" aria-label="Project values"><span>secure</span><span>private</span><span>powerful</span><span>open</span></div>
       </section>
     </main>
 
-    <footer class="footer glass-panel">
-      <div>
-        <a class="brand footer-brand" href="#top" aria-label="Back to top"><span class="brand-pip" aria-hidden="true"></span><span>phase1</span></a>
-        <p>Advanced operator kernel · Built by Chase Bryan and Bryforge.</p>
-      </div>
-      <div class="footer-links" aria-label="Footer navigation">
-        <a href="#demo">Demo</a>
-        <a href="#features">Features</a>
-        <a href="./wiki/">Wiki</a>
-        <a href="https://github.com/Bryforge/phase1" target="_blank" rel="noopener noreferrer">GitHub</a>
-        <a href="https://www.buymeacoffee.com/bryforge" target="_blank" rel="noopener noreferrer">Support</a>
-      </div>
-      <p class="copyright">© Chase Bryan / Bryforge. phase1 is GPL-3.0 open source.</p>
-    </footer>
+    <footer class="footer glass-panel"><div><a class="brand footer-brand" href="#top" aria-label="Back to top"><span class="brand-pip" aria-hidden="true"></span><span>phase1</span></a><p>Advanced operator kernel · Built by Chase Bryan and Bryforge.</p></div><div class="footer-links" aria-label="Footer navigation"><a href="#demo">Demo</a><a href="#features">Features</a><a href="./wiki/">Wiki</a><a href="https://github.com/Bryforge/phase1" target="_blank" rel="noopener noreferrer">GitHub</a><a href="https://www.buymeacoffee.com/bryforge" target="_blank" rel="noopener noreferrer">Support</a></div><p class="copyright">© Chase Bryan / Bryforge. phase1 is GPL-3.0 open source.</p></footer>
   </header>
 
-  <script src="./button-fix.js?v=4.0.0-stable-2"></script>
-  <script src="./site.js?v=4.0.0-stable-2"></script>
+  <script src="./button-fix.js?v=4.2.6-dev"></script>
+  <script src="./site.js?v=4.2.6-dev"></script>
 </body>
 </html>

--- a/site.js
+++ b/site.js
@@ -1,7 +1,11 @@
 const canvas = document.getElementById("space");
-const ctx = canvas.getContext("2d", { alpha: true });
-
+const ctx = canvas?.getContext("2d", { alpha: true });
 const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+const EDGE_VERSION = "v4.2.6-dev";
+const STABLE_VERSION = "v4.0.0";
+const PREVIOUS_STABLE = "v3.10.9";
+const COMPATIBILITY_BASE = "v3.6.0";
+
 let width = 0;
 let height = 0;
 let stars = [];
@@ -10,10 +14,19 @@ let animationFrame = 0;
 let resizeTimer = 0;
 let running = false;
 
+function viewportWidth() {
+  return Math.max(320, Math.min(window.innerWidth || 0, document.documentElement.clientWidth || 0));
+}
+
+function viewportHeight() {
+  return Math.max(480, window.innerHeight || document.documentElement.clientHeight || 0);
+}
+
 function resize() {
-  const ratio = Math.min(window.devicePixelRatio || 1, width >= 1200 ? 1.5 : 2);
-  width = window.innerWidth;
-  height = window.innerHeight;
+  if (!canvas || !ctx) return;
+  width = viewportWidth();
+  height = viewportHeight();
+  const ratio = Math.min(window.devicePixelRatio || 1, width >= 1200 ? 1.5 : 1.75);
   canvas.width = Math.floor(width * ratio);
   canvas.height = Math.floor(height * ratio);
   canvas.style.width = `${width}px`;
@@ -21,11 +34,11 @@ function resize() {
   ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
 
   const desktop = width >= 1024;
-  const density = prefersReducedMotion ? 16000 : desktop ? 8800 : 6800;
-  const cap = prefersReducedMotion ? 80 : desktop ? 180 : 210;
+  const density = prefersReducedMotion ? 18000 : desktop ? 9200 : 7600;
+  const cap = prefersReducedMotion ? 70 : desktop ? 170 : 150;
   const starCount = Math.min(cap, Math.floor((width * height) / density));
   stars = Array.from({ length: starCount }, () => makeStar(true));
-  comets = Array.from({ length: prefersReducedMotion ? 0 : desktop ? 2 : 3 }, (_, idx) => makeComet(idx));
+  comets = Array.from({ length: prefersReducedMotion ? 0 : desktop ? 2 : 1 }, (_, idx) => makeComet(idx));
 }
 
 function scheduleResize() {
@@ -37,9 +50,9 @@ function makeStar(randomizeY = false) {
   return {
     x: Math.random() * width,
     y: randomizeY ? Math.random() * height : -10,
-    r: Math.random() * 1.8 + 0.25,
-    vx: (Math.random() - 0.5) * 0.12,
-    vy: Math.random() * 0.28 + 0.04,
+    r: Math.random() * 1.6 + 0.25,
+    vx: (Math.random() - 0.5) * 0.1,
+    vy: Math.random() * 0.22 + 0.04,
     hue: Math.random() * 360,
     pulse: Math.random() * Math.PI * 2,
   };
@@ -48,11 +61,11 @@ function makeStar(randomizeY = false) {
 function makeComet(idx = 0) {
   return {
     x: Math.random() * width,
-    y: Math.random() * height * 0.55,
-    vx: 0.65 + idx * 0.2,
-    vy: 0.18 + idx * 0.05,
+    y: Math.random() * height * 0.5,
+    vx: 0.58 + idx * 0.18,
+    vy: 0.16 + idx * 0.04,
     hue: [190, 285, 122][idx % 3],
-    delay: Math.random() * 800,
+    delay: Math.random() * 700,
   };
 }
 
@@ -80,11 +93,9 @@ function drawStar(star, time) {
     star.pulse += 0.018;
     star.hue = (star.hue + 0.08) % 360;
   }
-
   if (star.y > height + 10 || star.x < -10 || star.x > width + 10) {
     Object.assign(star, makeStar(false));
   }
-
   const alpha = 0.38 + Math.sin(star.pulse + time * 0.001) * 0.28;
   ctx.beginPath();
   ctx.fillStyle = `hsla(${star.hue}, 95%, 72%, ${Math.max(0.18, alpha)})`;
@@ -98,22 +109,18 @@ function drawStar(star, time) {
 function drawComet(comet) {
   comet.delay -= 1;
   if (comet.delay > 0) return;
-
   comet.x += comet.vx;
   comet.y += comet.vy;
-
-  const trail = 92;
+  const trail = width < 520 ? 58 : 92;
   const gradient = ctx.createLinearGradient(comet.x, comet.y, comet.x - trail, comet.y - trail * 0.28);
   gradient.addColorStop(0, `hsla(${comet.hue}, 100%, 70%, 0.95)`);
   gradient.addColorStop(1, `hsla(${comet.hue}, 100%, 70%, 0)`);
-
   ctx.strokeStyle = gradient;
-  ctx.lineWidth = 2;
+  ctx.lineWidth = width < 520 ? 1.4 : 2;
   ctx.beginPath();
   ctx.moveTo(comet.x, comet.y);
   ctx.lineTo(comet.x - trail, comet.y - trail * 0.28);
   ctx.stroke();
-
   if (comet.x > width + 130 || comet.y > height + 80) {
     comet.x = -40 - Math.random() * width * 0.3;
     comet.y = Math.random() * height * 0.45;
@@ -122,26 +129,16 @@ function drawComet(comet) {
 }
 
 function frame(time) {
-  if (!running) return;
-
+  if (!running || !ctx) return;
   ctx.clearRect(0, 0, width, height);
   drawNebula(time);
-
-  for (const star of stars) {
-    drawStar(star, time);
-  }
-
-  if (!prefersReducedMotion) {
-    for (const comet of comets) {
-      drawComet(comet);
-    }
-  }
-
+  for (const star of stars) drawStar(star, time);
+  if (!prefersReducedMotion) for (const comet of comets) drawComet(comet);
   animationFrame = requestAnimationFrame(frame);
 }
 
 function startAnimation() {
-  if (running) return;
+  if (running || !ctx) return;
   running = true;
   animationFrame = requestAnimationFrame(frame);
 }
@@ -152,24 +149,18 @@ function stopAnimation() {
 }
 
 function handleVisibilityChange() {
-  if (document.hidden) {
-    stopAnimation();
-  } else {
-    startAnimation();
-  }
+  document.hidden ? stopAnimation() : startAnimation();
 }
 
 function setupNavigation() {
   const toggle = document.querySelector(".nav-toggle");
   const links = document.getElementById("nav-links");
   if (!toggle || !links) return;
-
   toggle.addEventListener("click", () => {
     const expanded = toggle.getAttribute("aria-expanded") === "true";
     toggle.setAttribute("aria-expanded", String(!expanded));
     links.classList.toggle("is-open", !expanded);
   });
-
   links.addEventListener("click", (event) => {
     if (event.target instanceof HTMLAnchorElement) {
       toggle.setAttribute("aria-expanded", "false");
@@ -184,7 +175,6 @@ function setupReveals() {
     revealEls.forEach((el) => el.classList.add("is-visible"));
     return;
   }
-
   const observer = new IntersectionObserver(
     (entries) => {
       for (const entry of entries) {
@@ -196,7 +186,6 @@ function setupReveals() {
     },
     { threshold: 0.14 },
   );
-
   revealEls.forEach((el) => observer.observe(el));
 }
 
@@ -211,10 +200,10 @@ const demoResponses = {
   ].join("\n"),
   version: [
     "phase1 // advanced operator kernel",
-    "edge: v4.1.0-dev",
-    "stable: v4.0.0",
-    "previous stable: v3.10.9",
-    "compatibility base: v3.6.0",
+    `edge: ${EDGE_VERSION}`,
+    `stable: ${STABLE_VERSION}`,
+    `previous stable: ${PREVIOUS_STABLE}`,
+    `compatibility base: ${COMPATIBILITY_BASE}`,
     "language: Rust",
   ].join("\n"),
   sysinfo: [
@@ -228,7 +217,7 @@ const demoResponses = {
   "wiki-quick": [
     "wiki-quick:",
     "  1. clone the repo",
-    "  2. choose release/v4.0.0 for stable or edge/v4.1.0-dev for bleeding edge",
+    "  2. choose release/v4.0.0 for stable or edge/v4.2.6-dev for bleeding edge",
     "  3. run cargo run",
     "  4. type help, security, sysinfo, wiki",
     "  5. keep safe mode on unless you trust the host workflow",
@@ -249,32 +238,27 @@ function setupTerminalDemo() {
   const output = document.getElementById("terminal-output");
   const quickCommands = document.querySelectorAll("[data-command]");
   if (!form || !input || !output) return;
-
   const history = [];
-
   const print = (text) => {
     output.textContent = text;
     output.scrollTop = output.scrollHeight;
   };
-
   const append = (command, response) => {
     if (command === "clear") {
       history.length = 0;
       print("phase1 demo reset. type help to begin.");
       return;
     }
-
     history.push(`phase1://root ~ # ${command}`);
     history.push(response || `unknown command: ${command}\ntype help for available demo commands.`);
     print(history.slice(-18).join("\n\n"));
   };
-
   print([
     "phase1 browser console demo",
+    `edge: ${EDGE_VERSION} // stable: ${STABLE_VERSION}`,
     "safe mode: on // host tools: guarded",
     "type help, version, sysinfo, wiki-quick, security, or clear",
   ].join("\n"));
-
   form.addEventListener("submit", (event) => {
     event.preventDefault();
     const command = input.value.trim().toLowerCase();
@@ -282,7 +266,6 @@ function setupTerminalDemo() {
     append(command, demoResponses[command]);
     input.value = "";
   });
-
   quickCommands.forEach((button) => {
     button.addEventListener("click", () => {
       const command = button.getAttribute("data-command") || "help";
@@ -297,5 +280,6 @@ setupReveals();
 setupTerminalDemo();
 startAnimation();
 window.addEventListener("resize", scheduleResize, { passive: true });
+window.addEventListener("orientationchange", scheduleResize, { passive: true });
 document.addEventListener("visibilitychange", handleVisibilityChange);
 window.addEventListener("pagehide", stopAnimation);

--- a/start_phase1
+++ b/start_phase1
@@ -44,7 +44,7 @@ fg() { if color_enabled; then printf '%s[38;5;%sm' "$(esc)" "$1"; fi; }
 bold() { if color_enabled; then printf '%s[1m' "$(esc)"; fi; }
 reset() { if color_enabled; then printf '%s[0m' "$(esc)"; fi; }
 phase1_version() {
-    awk -F '"' '/^version =/ { print $2; exit }' "$PHASE1_HOME/Cargo.toml" 2>/dev/null || printf '4.2.5-dev'
+    awk -F '"' '/^version =/ { print $2; exit }' "$PHASE1_HOME/Cargo.toml" 2>/dev/null || printf '4.2.6-dev'
 }
 
 print_help() {

--- a/tests/release_metadata.rs
+++ b/tests/release_metadata.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
-const EDGE_VERSION: &str = "v4.2.5-dev";
-const EDGE_PACKAGE_VERSION: &str = "4.2.5-dev";
+const EDGE_VERSION: &str = "v4.2.6-dev";
+const EDGE_PACKAGE_VERSION: &str = "4.2.6-dev";
 const STABLE_VERSION: &str = "v4.0.0";
 const STABLE_PACKAGE_VERSION: &str = "4.0.0";
 const PREVIOUS_STABLE: &str = "v3.10.9";
@@ -14,11 +14,11 @@ fn cargo_metadata_matches_current_track() {
 
     if is_edge_track(&cargo_toml) {
         assert!(
-            cargo_toml.contains("version = \"4.2.5-dev\""),
+            cargo_toml.contains("version = \"4.2.6-dev\""),
             "Cargo.toml must identify the edge package version as {EDGE_PACKAGE_VERSION}"
         );
         assert!(
-            cargo_lock.contains("version = \"4.2.5-dev\""),
+            cargo_lock.contains("version = \"4.2.6-dev\""),
             "Cargo.lock must identify the edge package version as {EDGE_PACKAGE_VERSION}"
         );
     } else {
@@ -115,15 +115,19 @@ fn stale_release_lines_are_removed_from_release_facing_files() {
             !text.contains("4.0.0-dev"),
             "{path} still references development version 4.0.0-dev"
         );
+        assert!(
+            !text.contains("4.2.5-dev"),
+            "{path} still references previous edge version 4.2.5-dev"
+        );
     }
 }
 
 fn is_edge_track(cargo_toml: &str) -> bool {
-    cargo_toml.contains("version = \"4.2.5-dev\"")
+    cargo_toml.contains("version = \"4.2.6-dev\"")
 }
 
-fn edge_facing_files() -> [&'static str; 3] {
-    ["Cargo.toml", "Cargo.lock", "EDGE.md"]
+fn edge_facing_files() -> [&'static str; 4] {
+    ["Cargo.toml", "Cargo.lock", "EDGE.md", "site.js"]
 }
 
 fn release_facing_files() -> [&'static str; 13] {

--- a/tests/website_phase_b.rs
+++ b/tests/website_phase_b.rs
@@ -23,7 +23,7 @@ fn homepage_preserves_project_identity_and_metadata() {
     assert_contains_all(
         &html,
         &[
-            "name\": \"phase1\"",
+            "name\":\"phase1\"",
             "Chase Bryan",
             "Bryforge",
             "GPL-3.0",
@@ -43,10 +43,10 @@ fn homepage_keeps_static_offline_friendly_dependency_posture_and_cache_busts_ass
     assert_contains_all(
         &html,
         &[
-            "./styles.css?v=4.0.0-stable-2",
-            "./button-fix.css?v=4.0.0-founder-profile-2",
-            "./button-fix.js?v=4.0.0-stable-2",
-            "./site.js?v=4.0.0-stable-2",
+            "./styles.css?v=4.2.6-dev",
+            "./button-fix.css?v=4.2.6-dev",
+            "./button-fix.js?v=4.2.6-dev",
+            "./site.js?v=4.2.6-dev",
         ],
     );
     assert_not_contains_any(
@@ -62,12 +62,13 @@ fn homepage_keeps_static_offline_friendly_dependency_posture_and_cache_busts_ass
 }
 
 #[test]
-fn homepage_has_inline_founder_profile_guard() {
-    let html = read("index.html");
+fn founder_profile_guard_lives_in_mobile_fix_stylesheet() {
+    let fix_css = read("button-fix.css");
     assert_contains_all(
-        &html,
+        &fix_css,
         &[
-            "founder-profile-inline-guard",
+            "Founder-section cleanup",
+            "keep the real Founder profile label",
             "#founder .profile-label",
             "#founder .founder-copy > .eyebrow",
             "#founder .founder-copy h2::before",
@@ -134,8 +135,9 @@ fn site_js_implements_canvas_terminal_progressive_enhancement_and_performance_gu
             "demoResponses",
             "wiki-quick",
             "phase1 // advanced operator kernel",
-            "stable: v4.0.0",
-            "previous stable: v3.10.9",
+            "const EDGE_VERSION = \"v4.2.6-dev\"",
+            "const STABLE_VERSION = \"v4.0.0\"",
+            "const PREVIOUS_STABLE = \"v3.10.9\"",
             "safe mode: on",
             "setupNavigation",
             "setupReveals",
@@ -146,7 +148,7 @@ fn site_js_implements_canvas_terminal_progressive_enhancement_and_performance_gu
             "document.hidden",
             "startAnimation",
             "stopAnimation",
-            "desktop ? 180 : 210",
+            "desktop ? 170 : 150",
         ],
     );
     assert_not_contains_any(&js, &["edge: v4.0.0-dev"]);


### PR DESCRIPTION
## Summary

Starts the next edge patch as `v4.2.6-dev` and focuses it on the public website/mobile fit pass.

## Changes

- Bumps edge package metadata from `4.2.5-dev` to `4.2.6-dev`.
- Updates `EDGE.md` for the v4.2.6-dev website/mobile polish track.
- Refreshes the GitHub Pages cache-busting query strings to `4.2.6-dev`.
- Tightens the landing page for mobile and in-app browsers:
  - prevents horizontal scrolling,
  - reduces oversized hero/header behavior on iPhone widths,
  - turns the nav into a compact mobile drawer,
  - stacks primary action buttons cleanly,
  - constrains the logo/orbital globe stage,
  - makes terminal demo input and output fit narrow screens,
  - keeps feature cards, roadmap rows, footer links, and sponsor cards inside the viewport.
- Updates the browser terminal demo to report `v4.2.6-dev`.
- Updates release metadata tests for the new edge track.

## Design intent

The website should still feel like the Phase1 neon/cyber operator surface, but it should no longer crush content or overflow horizontally on phone-width browsers.

## Validation target

```bash
cargo fmt --all -- --check
cargo check --all-targets
cargo clippy --all-targets -- -D warnings
cargo test --all-targets
```

## Notes

Stable remains untouched; this PR targets the edge development line only.