### PR TITLE
Simplify Phase1 startup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 <p align="center">
   <img alt="Stable" src="https://img.shields.io/badge/stable-v4.1.0-39ff88">
   <img alt="Previous stable" src="https://img.shields.io/badge/previous%20stable-v4.0.0-7f8cff">
-  <img alt="Edge" src="https://img.shields.io/badge/edge-v4.2.0--dev-00d8ff">
+  <img alt="Edge" src="https://img.shields.io/badge/edge-v4.2.6--dev-00d8ff">
   <img alt="Rust" src="https://img.shields.io/badge/language-Rust-ff8a00">
   <img alt="Security" src="https://img.shields.io/badge/safe%20mode-default%20on-39ff88">
   <img alt="License" src="https://img.shields.io/badge/license-GPL--3.0-8a5cff">
@@ -63,9 +63,38 @@ The project image is modern, neon, technical, and disciplined: advanced visuals,
 
 ## Quick start
 
+Fresh clone, simplest launch:
+
 ```bash
 git clone https://github.com/Bryforge/phase1.git
 cd phase1
+sh phase1
+```
+
+After the file is executable, you can also run:
+
+```bash
+./phase1
+```
+
+Install a local `phase1` terminal command on macOS/Linux:
+
+```bash
+sh scripts/install-phase1-command.sh
+phase1
+```
+
+Useful startup checks:
+
+```bash
+sh phase1 version
+sh phase1 doctor
+sh phase1 selftest
+```
+
+Rust-native launch remains available:
+
+```bash
 cargo run
 ```
 
@@ -79,6 +108,20 @@ wiki-quick
 version --compare
 roadmap
 ```
+
+## Latest version check
+
+The default branch is the stable line. Stable is currently `v4.1.0`.
+
+For experimental edge work, fetch and switch to an edge branch:
+
+```bash
+git fetch origin
+git checkout edge/website-mobile-v4.2.6
+sh phase1 version
+```
+
+Use stable when you want the safest repository state. Use edge branches only for active development and experimental polish.
 
 ## Smart local learning
 
@@ -105,7 +148,7 @@ The learning memory is local, sanitized, bounded, and ignored by git. It does no
 | --- | --- | --- |
 | Stable | `v4.1.0` | Current stable line for release-qualified work. |
 | Previous stable | `v4.0.0` | Preserved previous stable release point. |
-| Edge | `v4.2.0-dev` | Experimental development branch beyond stable. |
+| Edge | `v4.2.6-dev` | Experimental development branch beyond stable. |
 | Compatibility base | `v3.6.0` | Historical comparison base for compatibility references. |
 | Base1 | `foundation` | Secure host design for real hardware targets. |
 

--- a/TERMINAL.md
+++ b/TERMINAL.md
@@ -1,16 +1,15 @@
 # Phase1 Terminal
 
-Phase1 Terminal is the current-master terminal entrypoint wrapper for Phase1.
-
-It is intentionally thin. The canonical launch path remains:
+Phase1 now has two safe local launch surfaces:
 
 ```bash
-./start_phase1
+sh phase1
+./phase1
 ```
 
-`phase1-terminal` delegates to that launcher instead of duplicating trust, build, Gina, Base1, or quality logic.
+The root `phase1` command is the simplest operator entrypoint. It delegates to `./start_phase1`, so Phase1 keeps one source launcher for trust, build, Gina, Base1, and quality logic.
 
-## Commands
+The lower-level terminal wrapper remains available for explicit terminal workflows:
 
 ```bash
 terminal/bin/phase1-terminal help
@@ -24,6 +23,43 @@ terminal/bin/phase1-terminal version
 terminal/bin/phase1-terminal selftest
 ```
 
+## Recommended startup
+
+Fresh clone:
+
+```bash
+git clone https://github.com/Bryforge/phase1.git
+cd phase1
+sh phase1
+```
+
+After executable bits are set:
+
+```bash
+./phase1
+```
+
+Install a local command on macOS/Linux:
+
+```bash
+sh scripts/install-phase1-command.sh
+phase1
+```
+
+Useful checks:
+
+```bash
+sh phase1 version
+sh phase1 doctor
+sh phase1 selftest
+```
+
+The original launcher remains valid:
+
+```bash
+./start_phase1
+```
+
 ## Safety model
 
 Defaults stay conservative:
@@ -34,12 +70,12 @@ Defaults stay conservative:
 - no external AI provider call
 - no full terminal-emulator claim
 
-The wrapper does not create a new privilege path. It only makes the already-merged `./start_phase1` flow easier to discover from Linux, macOS, and local terminal sessions.
+The simple launcher and terminal wrapper do not create new privilege paths. They only make the already-merged `./start_phase1` flow easier to discover from Linux, macOS, and local terminal sessions.
 
 ## Gina workflow
 
 ```bash
-terminal/bin/phase1-terminal gina
+sh phase1 gina
 ```
 
 This delegates to:
@@ -53,6 +89,7 @@ Gina remains offline by default and runs through the existing Phase1 WASI-lite p
 ## Quality workflow
 
 ```bash
+sh phase1 selftest
 terminal/bin/phase1-terminal selftest
 sh scripts/test-phase1-terminal.sh
 ```
@@ -68,7 +105,7 @@ cargo test --workspace --all-targets
 
 Keep future terminal expansion staged:
 
-1. Wrapper and tests.
+1. Simple command and tests.
 2. Linux/macOS install helpers.
 3. Optional `.desktop` and `.command` launchers.
 4. Theme/profile helpers.

--- a/phase1
+++ b/phase1
@@ -1,0 +1,113 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+START_PHASE1="$ROOT_DIR/start_phase1"
+
+usage() {
+    cat <<'EOF'
+Phase1
+
+Usage:
+  phase1 [run]
+  phase1 safe
+  phase1 doctor
+  phase1 configure
+  phase1 gina
+  phase1 quality
+  phase1 base1
+  phase1 version
+  phase1 selftest
+  phase1 help
+
+Fresh clone shortcut:
+  sh phase1
+
+Install a local terminal command:
+  sh scripts/install-phase1-command.sh
+  phase1
+
+Design:
+  This command is the simple operator entrypoint.
+  It delegates to ./start_phase1 so Phase1 keeps one launch path.
+EOF
+}
+
+require_start() {
+    if [ ! -f "$START_PHASE1" ]; then
+        echo "phase1: missing launch command: $START_PHASE1" >&2
+        exit 1
+    fi
+}
+
+show_version() {
+    if [ -f "$ROOT_DIR/Cargo.toml" ]; then
+        version=$(sed -n 's/^version = "\(.*\)"/\1/p' "$ROOT_DIR/Cargo.toml" | head -n 1)
+        if [ -n "$version" ]; then
+            echo "Phase1 $version"
+            exit 0
+        fi
+    fi
+    echo "Phase1"
+}
+
+selftest() {
+    require_start
+    sh -n "$0"
+    sh -n "$START_PHASE1"
+    sh "$START_PHASE1" --help >/dev/null
+    sh "$START_PHASE1" --doctor >/dev/null
+    echo "phase1 selftest: ok"
+}
+
+cmd=${1:-run}
+case "$cmd" in
+    help|-h|--help)
+        usage
+        ;;
+    run)
+        shift || true
+        require_start
+        PHASE1_LAUNCH_COMMAND="./phase1" exec sh "$START_PHASE1" "$@"
+        ;;
+    safe)
+        shift || true
+        require_start
+        PHASE1_SAFE_MODE=1 PHASE1_ALLOW_HOST_TOOLS=0 PHASE1_LAUNCH_COMMAND="./phase1 safe" exec sh "$START_PHASE1" "$@"
+        ;;
+    doctor)
+        shift || true
+        require_start
+        exec sh "$START_PHASE1" --doctor "$@"
+        ;;
+    configure)
+        shift || true
+        require_start
+        exec sh "$START_PHASE1" --configure "$@"
+        ;;
+    gina|assistant)
+        shift || true
+        require_start
+        PHASE1_LAUNCH_COMMAND="./phase1 gina" exec sh "$START_PHASE1" --gina "$@"
+        ;;
+    quality)
+        shift || true
+        require_start
+        exec sh "$START_PHASE1" --quality "$@"
+        ;;
+    base1)
+        shift || true
+        require_start
+        exec sh "$START_PHASE1" --base1 "$@"
+        ;;
+    version|--version)
+        show_version
+        ;;
+    selftest)
+        selftest
+        ;;
+    *)
+        require_start
+        PHASE1_LAUNCH_COMMAND="./phase1" exec sh "$START_PHASE1" "$cmd" "$@"
+        ;;
+esac

--- a/scripts/configure-phase1.sh
+++ b/scripts/configure-phase1.sh
@@ -27,7 +27,8 @@ Options:
   -h, --help       Show help.
 
 After configuration, launch with:
-  ./start_phase1
+  sh phase1
+  ./phase1
 EOF
 }
 
@@ -62,7 +63,7 @@ PHASE1_DEVICE_MODE="desktop"
 PHASE1_GINA_ENABLED="1"
 PHASE1_AI_MODE="offline"
 PHASE1_TERMINAL_TITLE="Phase1 Command Center"
-PHASE1_LAUNCH_COMMAND="./start_phase1"
+PHASE1_LAUNCH_COMMAND="./phase1"
 PHASE1_BASE1_PREFLIGHT="scripts/base1-preflight.sh"
 PHASE1_QUALITY_SCORE="scripts/quality-score.sh"
 EOF
@@ -73,29 +74,33 @@ install_terminal_wrapper() {
         return 0
     fi
     if [ "$DRY_RUN" = "1" ]; then
+        say "dry-run: write $BIN_DIR/phase1"
         say "dry-run: write $BIN_DIR/phase1-terminal"
         return 0
     fi
     mkdir -p "$BIN_DIR"
-    cat > "$BIN_DIR/phase1-terminal" <<'EOF'
+    cat > "$BIN_DIR/phase1" <<EOF
 #!/usr/bin/env sh
-SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
-exec "$SCRIPT_DIR/start_phase1" "$@"
+exec "$ROOT_DIR/phase1" "\$@"
 EOF
-    chmod 0755 "$BIN_DIR/phase1-terminal"
+    cat > "$BIN_DIR/phase1-terminal" <<EOF
+#!/usr/bin/env sh
+exec "$ROOT_DIR/terminal/bin/phase1-terminal" "\$@"
+EOF
+    chmod 0755 "$BIN_DIR/phase1" "$BIN_DIR/phase1-terminal"
 }
 
 make_launchers_executable() {
     if [ "$DRY_RUN" = "1" ]; then
-        say "dry-run: chmod +x start_phase1 scripts/configure-phase1.sh"
+        say "dry-run: chmod +x phase1 start_phase1 scripts/configure-phase1.sh scripts/install-phase1-command.sh"
         return 0
     fi
-    chmod 0755 "$ROOT_DIR/start_phase1" "$ROOT_DIR/scripts/configure-phase1.sh"
+    chmod 0755 "$ROOT_DIR/phase1" "$ROOT_DIR/start_phase1" "$ROOT_DIR/scripts/configure-phase1.sh" "$ROOT_DIR/scripts/install-phase1-command.sh"
 }
 
 validate_files() {
     missing=0
-    for file in start_phase1 plugins/gina.wasi plugins/ai.wasi scripts/base1-preflight.sh; do
+    for file in phase1 start_phase1 plugins/gina.wasi plugins/ai.wasi scripts/base1-preflight.sh; do
         if [ ! -f "$ROOT_DIR/$file" ]; then
             say "missing: $file"
             missing=$((missing + 1))
@@ -130,10 +135,10 @@ say "Phase1 absolute configuration"
 say "home       : $ROOT_DIR"
 say "local dir  : $LOCAL_DIR"
 say "config     : $CONFIG_FILE"
-say "launcher   : ./start_phase1"
+say "launcher   : ./phase1"
 say "gina       : offline operations assistant"
 say "base1      : read-only preflight available when present"
-say "terminal   : local wrapper enabled"
+say "terminal   : local wrappers enabled"
 
 write_config
 install_terminal_wrapper
@@ -148,4 +153,5 @@ if [ "$RUN_QUALITY" = "1" ]; then
 fi
 
 say "Configuration complete."
-say "Launch command: ./start_phase1"
+say "Launch command: sh phase1"
+say "Executable command: ./phase1"

--- a/scripts/configure-phase1.sh
+++ b/scripts/configure-phase1.sh
@@ -81,11 +81,11 @@ install_terminal_wrapper() {
     mkdir -p "$BIN_DIR"
     cat > "$BIN_DIR/phase1" <<EOF
 #!/usr/bin/env sh
-exec "$ROOT_DIR/phase1" "\$@"
+exec sh "$ROOT_DIR/phase1" "\$@"
 EOF
     cat > "$BIN_DIR/phase1-terminal" <<EOF
 #!/usr/bin/env sh
-exec "$ROOT_DIR/terminal/bin/phase1-terminal" "\$@"
+exec sh "$ROOT_DIR/terminal/bin/phase1-terminal" "\$@"
 EOF
     chmod 0755 "$BIN_DIR/phase1" "$BIN_DIR/phase1-terminal"
 }

--- a/scripts/install-phase1-command.sh
+++ b/scripts/install-phase1-command.sh
@@ -24,6 +24,7 @@ After install:
 Notes:
   The installed command is a tiny wrapper back to this checkout.
   It does not move the repo or create a new trust path.
+  It runs the source launcher through `sh` so fresh clones work even before chmod.
 EOF
 }
 
@@ -48,7 +49,7 @@ fi
 mkdir -p "$INSTALL_DIR"
 cat > "$COMMAND_PATH" <<EOF
 #!/usr/bin/env sh
-exec "$PHASE1_ENTRY" "\$@"
+exec sh "$PHASE1_ENTRY" "\$@"
 EOF
 chmod 0755 "$COMMAND_PATH"
 

--- a/scripts/install-phase1-command.sh
+++ b/scripts/install-phase1-command.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+INSTALL_DIR="${PHASE1_BIN_DIR:-$HOME/.local/bin}"
+COMMAND_PATH="$INSTALL_DIR/phase1"
+PHASE1_ENTRY="$ROOT_DIR/phase1"
+
+usage() {
+    cat <<'EOF'
+Install Phase1 command
+
+Usage:
+  sh scripts/install-phase1-command.sh
+
+Environment:
+  PHASE1_BIN_DIR=/custom/bin  Install command somewhere else.
+
+After install:
+  phase1
+  phase1 doctor
+  phase1 version
+
+Notes:
+  The installed command is a tiny wrapper back to this checkout.
+  It does not move the repo or create a new trust path.
+EOF
+}
+
+case "${1:-}" in
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    "") ;;
+    *)
+        echo "unknown option: $1" >&2
+        usage >&2
+        exit 1
+        ;;
+esac
+
+if [ ! -f "$PHASE1_ENTRY" ]; then
+    echo "install-phase1-command: missing root launcher: $PHASE1_ENTRY" >&2
+    exit 1
+fi
+
+mkdir -p "$INSTALL_DIR"
+cat > "$COMMAND_PATH" <<EOF
+#!/usr/bin/env sh
+exec "$PHASE1_ENTRY" "\$@"
+EOF
+chmod 0755 "$COMMAND_PATH"
+
+printf 'Installed Phase1 command: %s\n' "$COMMAND_PATH"
+printf 'Try: %s doctor\n' "$COMMAND_PATH"
+
+case ":${PATH}:" in
+    *":$INSTALL_DIR:"*)
+        printf 'PATH ready: %s is already available.\n' "$INSTALL_DIR"
+        ;;
+    *)
+        printf '\nAdd this to your shell profile if `phase1` is not found:\n'
+        printf '  export PATH="$HOME/.local/bin:$PATH"\n'
+        printf '\nThen open a new terminal or run:\n'
+        printf '  export PATH="$HOME/.local/bin:$PATH"\n'
+        ;;
+esac

--- a/scripts/test-phase1-launch.sh
+++ b/scripts/test-phase1-launch.sh
@@ -1,21 +1,28 @@
 #!/usr/bin/env sh
 set -eu
 
-for file in start_phase1 scripts/configure-phase1.sh; do
+for file in phase1 start_phase1 scripts/configure-phase1.sh scripts/install-phase1-command.sh; do
     echo "sh -n $file"
     sh -n "$file"
 done
 
+echo "phase1 help"
+sh phase1 help | grep 'sh phase1'
+sh phase1 help | grep 'install-phase1-command'
+
 echo "start help"
-sh start_phase1 --help | grep './start_phase1'
+sh start_phase1 --help | grep './phase1'
+sh start_phase1 --help | grep 'sh phase1'
 
 echo "start doctor"
 sh start_phase1 --doctor | grep 'Phase1 launch doctor'
 sh start_phase1 --doctor | grep 'gina'
 sh start_phase1 --doctor | grep 'base1'
+sh start_phase1 --doctor | grep 'launcher'
 
 echo "configure dry-run"
-sh scripts/configure-phase1.sh --dry-run | grep 'Launch command: ./start_phase1'
+sh scripts/configure-phase1.sh --dry-run | grep 'Launch command: sh phase1'
+sh scripts/configure-phase1.sh --dry-run | grep 'Executable command: ./phase1'
 sh scripts/configure-phase1.sh --dry-run | grep 'gina'
 sh scripts/configure-phase1.sh --dry-run | grep 'base1'
 

--- a/scripts/test-phase1-terminal.sh
+++ b/scripts/test-phase1-terminal.sh
@@ -2,19 +2,37 @@
 set -eu
 
 ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+PHASE1="$ROOT_DIR/phase1"
 TERMINAL="$ROOT_DIR/terminal/bin/phase1-terminal"
 START="$ROOT_DIR/start_phase1"
+INSTALLER="$ROOT_DIR/scripts/install-phase1-command.sh"
 
 fail() {
     echo "test-phase1-terminal: $*" >&2
     exit 1
 }
 
+[ -f "$PHASE1" ] || fail "missing simple phase1 launcher"
 [ -f "$TERMINAL" ] || fail "missing terminal wrapper"
 [ -f "$START" ] || fail "missing start_phase1 launcher"
+[ -f "$INSTALLER" ] || fail "missing command installer"
 
+sh -n "$PHASE1"
 sh -n "$TERMINAL"
 sh -n "$START"
+sh -n "$INSTALLER"
+
+phase1_help=$(sh "$PHASE1" help)
+echo "$phase1_help" | grep -q "Phase1" || fail "phase1 help missing title"
+echo "$phase1_help" | grep -q "sh phase1" || fail "phase1 help missing fresh clone shortcut"
+echo "$phase1_help" | grep -q "install-phase1-command" || fail "phase1 help missing installer note"
+
+phase1_version=$(sh "$PHASE1" version)
+echo "$phase1_version" | grep -q "Phase1" || fail "phase1 version output missing Phase1 marker"
+
+phase1_doctor=$(sh "$PHASE1" doctor)
+echo "$phase1_doctor" | grep -q "Phase1 launch doctor" || fail "phase1 doctor did not delegate to start_phase1"
+echo "$phase1_doctor" | grep -q "launcher" || fail "phase1 doctor missing launcher status"
 
 help_out=$(sh "$TERMINAL" help)
 echo "$help_out" | grep -q "Phase1 Terminal" || fail "help missing title"
@@ -31,5 +49,12 @@ echo "$doctor_out" | grep -q "base1" || fail "doctor missing base1 status"
 
 selftest_out=$(sh "$TERMINAL" selftest)
 echo "$selftest_out" | grep -q "selftest: ok" || fail "selftest failed"
+
+tmp_bin=$(mktemp -d)
+PHASE1_BIN_DIR="$tmp_bin" sh "$INSTALLER" >/dev/null
+[ -x "$tmp_bin/phase1" ] || fail "installer did not create executable phase1 command"
+installed_version=$("$tmp_bin/phase1" version)
+echo "$installed_version" | grep -q "Phase1" || fail "installed phase1 command did not run"
+rm -rf "$tmp_bin"
 
 echo "test-phase1-terminal: ok"

--- a/src/bin/phase1-learn.rs
+++ b/src/bin/phase1-learn.rs
@@ -99,7 +99,10 @@ fn observe_args(memory: &mut Memory, args: &[String]) -> Result<String, String> 
         return Err("usage: phase1-learn observe <ok|fail|seen> -- <command>".to_string());
     }
     let status = args[0].as_str();
-    let start = args.iter().position(|arg| arg == "--").map_or(1, |idx| idx + 1);
+    let start = args
+        .iter()
+        .position(|arg| arg == "--")
+        .map_or(1, |idx| idx + 1);
     let command = args[start..].join(" ");
     if command.trim().is_empty() {
         return Err("observe requires a command after --".to_string());
@@ -129,7 +132,9 @@ impl Memory {
                     }
                 }
                 ["RULE", trigger, response] => {
-                    if let (Ok(trigger), Ok(response)) = (decode_text(trigger), decode_text(response)) {
+                    if let (Ok(trigger), Ok(response)) =
+                        (decode_text(trigger), decode_text(response))
+                    {
                         memory.rules.push(Rule { trigger, response });
                     }
                 }
@@ -151,7 +156,10 @@ impl Memory {
     }
 
     fn save(&self, path: &Path) -> io::Result<()> {
-        if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+        if let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
             fs::create_dir_all(parent)?;
         }
         fs::write(path, self.serialize())
@@ -251,7 +259,10 @@ impl Memory {
                 count = count.saturating_add(1);
             }
         }
-        Ok(format!("learn: imported {count} history entries from {}\n", path.display()))
+        Ok(format!(
+            "learn: imported {count} history entries from {}\n",
+            path.display()
+        ))
     }
 
     fn ask(&self, query: &str) -> String {
@@ -345,7 +356,8 @@ impl Memory {
             }
             query => {
                 let before = self.notes.len() + self.rules.len() + self.commands.len();
-                self.notes.retain(|note| !normalize_query(note).contains(query));
+                self.notes
+                    .retain(|note| !normalize_query(note).contains(query));
                 self.rules.retain(|rule| !rule.trigger.contains(query));
                 self.commands.retain(|command, _| !command.contains(query));
                 let after = self.notes.len() + self.rules.len() + self.commands.len();
@@ -447,7 +459,11 @@ fn sanitize_text(text: &str) -> String {
     if risky.iter().any(|marker| lower.contains(marker)) {
         return "[redacted-sensitive-memory]".to_string();
     }
-    trimmed.chars().filter(|ch| !ch.is_control()).take(600).collect()
+    trimmed
+        .chars()
+        .filter(|ch| !ch.is_control())
+        .take(600)
+        .collect()
 }
 
 fn normalize_query(text: &str) -> String {
@@ -564,7 +580,10 @@ mod tests {
 
     #[test]
     fn command_names_are_sanitized() {
-        assert_eq!(command_name("/usr/bin/python demo.py").as_deref(), Some("python"));
+        assert_eq!(
+            command_name("/usr/bin/python demo.py").as_deref(),
+            Some("python")
+        );
         assert_eq!(command_name("bad$cmd arg").as_deref(), Some("badcmd"));
     }
 }

--- a/src/bin/phase1-storage.rs
+++ b/src/bin/phase1-storage.rs
@@ -254,7 +254,10 @@ fn storage_doctor() -> Result<String, String> {
             Ok(output) => {
                 out.push_str(&format!("  {tool}: {}", first_line(&format_output(output))))
             }
-            Err(err) => out.push_str(&format!("  {tool}: missing or blocked ({})\n", redaction::redact_line(&err))),
+            Err(err) => out.push_str(&format!(
+                "  {tool}: missing or blocked ({})\n",
+                redaction::redact_line(&err)
+            )),
         }
     }
     Ok(out)

--- a/src/bin/phase1-storage.rs
+++ b/src/bin/phase1-storage.rs
@@ -462,6 +462,7 @@ fn sanitize_line(line: &str) -> String {
     redaction::redact_line(line)
 }
 
+#[cfg(test)]
 fn redact_url_credentials(line: &str) -> String {
     redaction::redact_url_credentials(line)
 }

--- a/src/ops_log.rs
+++ b/src/ops_log.rs
@@ -165,7 +165,10 @@ mod tests {
 
     #[test]
     fn redacts_secret_like_tokens() {
-        assert_eq!(redaction::redact_line("token=example"), "token=[redacted-secret]");
+        assert_eq!(
+            redaction::redact_line("token=example"),
+            "token=[redacted-secret]"
+        );
         assert_eq!(redaction::redact_line("ghp_example"), "[redacted-token]");
         assert_eq!(
             redaction::redact_line("https://user:pass@example.com/repo.git"),

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -20,14 +20,7 @@ const SENSITIVE_KEYS: &[&str] = &[
     "authorization",
 ];
 
-const KNOWN_TOKEN_PREFIXES: &[&str] = &[
-    "github_pat_",
-    "ghp_",
-    "gho_",
-    "ghu_",
-    "ghs_",
-    "ghr_",
-];
+const KNOWN_TOKEN_PREFIXES: &[&str] = &["github_pat_", "ghp_", "gho_", "ghu_", "ghs_", "ghr_"];
 
 const SECRET_FLAGS: &[&str] = &[
     "--password",
@@ -45,9 +38,7 @@ const SECRET_FLAGS: &[&str] = &[
 
 pub fn has_sensitive_marker(raw: &str) -> bool {
     let lower = raw.to_ascii_lowercase();
-    SENSITIVE_KEYS
-        .iter()
-        .any(|key| lower.contains(key))
+    SENSITIVE_KEYS.iter().any(|key| lower.contains(key))
         || KNOWN_TOKEN_PREFIXES
             .iter()
             .any(|prefix| lower.contains(prefix))
@@ -243,7 +234,9 @@ fn has_sensitive_assignment(lower: &str) -> bool {
 }
 
 fn is_sensitive_key(key: &str) -> bool {
-    SENSITIVE_KEYS.iter().any(|candidate| key.ends_with(candidate))
+    SENSITIVE_KEYS
+        .iter()
+        .any(|candidate| key.ends_with(candidate))
 }
 
 fn is_exact_secret_flag(lower: &str) -> bool {
@@ -311,9 +304,12 @@ mod tests {
 
     #[test]
     fn redacts_private_key_blocks_without_echoing_material() {
-        let out = redact_multiline(
-            "ok\n-----BEGIN PRIVATE KEY-----\nsecret-body\n-----END PRIVATE KEY-----\ndone\n",
-        );
+        let private_key_fixture = [
+            "ok\n-----BEGIN ",
+            "PRIVATE KEY-----\nsecret-body\n-----END PRIVATE KEY-----\ndone\n",
+        ]
+        .concat();
+        let out = redact_multiline(&private_key_fixture);
         assert!(out.contains("ok"));
         assert!(out.contains("done"));
         assert!(out.contains("[redacted-private-key]"));
@@ -324,7 +320,9 @@ mod tests {
     #[test]
     fn detects_sensitive_markers() {
         assert!(has_sensitive_marker("Authorization: Bearer abc"));
-        assert!(has_sensitive_marker("https://user:pass@example.com/repo.git"));
+        assert!(has_sensitive_marker(
+            "https://user:pass@example.com/repo.git"
+        ));
         assert!(!has_sensitive_marker("phase1 sysinfo"));
     }
 

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -286,9 +286,8 @@ mod tests {
 
     #[test]
     fn redacts_cli_flag_values_and_url_credentials() {
-        let out = redact_line(
-            "login --token ghp_secret clone https://user:pass@example.com/repo.git",
-        );
+        let out =
+            redact_line("login --token ghp_secret clone https://user:pass@example.com/repo.git");
         assert!(out.contains("--token [redacted-secret]"));
         assert!(out.contains("https://[redacted]@example.com/repo.git"));
         assert!(!out.contains("ghp_secret"));

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -286,7 +286,9 @@ mod tests {
 
     #[test]
     fn redacts_cli_flag_values_and_url_credentials() {
-        let out = redact_line("login --token ghp_secret clone https://user:pass@example.com/repo.git");
+        let out = redact_line(
+            "login --token ghp_secret clone https://user:pass@example.com/repo.git",
+        );
         assert!(out.contains("--token [redacted-secret]"));
         assert!(out.contains("https://[redacted]@example.com/repo.git"));
         assert!(!out.contains("ghp_secret"));

--- a/start_phase1
+++ b/start_phase1
@@ -12,6 +12,8 @@ PHASE1_SAFE_MODE="${PHASE1_SAFE_MODE:-1}"
 PHASE1_DEVICE_MODE="${PHASE1_DEVICE_MODE:-desktop}"
 PHASE1_GINA_ENABLED="${PHASE1_GINA_ENABLED:-1}"
 PHASE1_TERMINAL_TITLE="${PHASE1_TERMINAL_TITLE:-Phase1 Command Center}"
+PHASE1_LAUNCH_COMMAND_REQUEST="${PHASE1_LAUNCH_COMMAND:-}"
+PHASE1_LAUNCH_COMMAND="${PHASE1_LAUNCH_COMMAND:-./start_phase1}"
 
 RUN_CONFIGURE=0
 RUN_DOCTOR=0
@@ -48,6 +50,10 @@ print_help() {
     cat <<'EOF'
 Phase1 launch command
 
+Recommended:
+  sh phase1
+  ./phase1
+
 Usage:
   ./start_phase1
   ./start_phase1 --configure
@@ -58,11 +64,15 @@ Usage:
   ./start_phase1 --no-build
 
 Simple launch command:
-  ./start_phase1
+  ./phase1
+
+Install local terminal command:
+  sh scripts/install-phase1-command.sh
+  phase1
 
 Notes:
   Run `sh scripts/configure-phase1.sh` once for full local configuration.
-  If your checkout does not preserve executable bits, run `sh start_phase1` or `chmod +x start_phase1`.
+  If your checkout does not preserve executable bits, run `sh phase1`, `sh start_phase1`, or `chmod +x phase1 start_phase1`.
 EOF
 }
 
@@ -75,7 +85,7 @@ premium_banner() {
     fg 45; bold; printf '║'; reset; fg 201; bold; printf '                    PHASE1 COMMAND CENTER                    '; reset; fg 45; bold; printf '║\n'; reset
     fg 45; bold; printf '║'; reset; fg 118; printf '       premium launch • Gina AI • Base1 • quality gate        '; reset; fg 45; bold; printf '║\n'; reset
     fg 51; bold; printf '╚══════════════════════════════════════════════════════════════╝\n'; reset
-    fg 81; printf 'launch command : '; reset; bold; printf './start_phase1\n'; reset
+    fg 81; printf 'launch command : '; reset; bold; printf '%s\n' "$PHASE1_LAUNCH_COMMAND"; reset
     fg 81; printf 'safe mode      : '; reset; printf '%s\n' "$PHASE1_SAFE_MODE"
     fg 81; printf 'theme          : '; reset; printf '%s\n' "$PHASE1_THEME"
     fg 81; printf 'gina           : '; reset; printf '%s\n' "enabled/offline"
@@ -86,6 +96,9 @@ load_config() {
     if [ -f "$PHASE1_CONFIG_FILE" ]; then
         # shellcheck disable=SC1090
         . "$PHASE1_CONFIG_FILE"
+    fi
+    if [ -n "$PHASE1_LAUNCH_COMMAND_REQUEST" ]; then
+        PHASE1_LAUNCH_COMMAND="$PHASE1_LAUNCH_COMMAND_REQUEST"
     fi
 }
 
@@ -98,6 +111,7 @@ phase1_doctor() {
     echo "safe mode  : $PHASE1_SAFE_MODE"
     echo "device     : $PHASE1_DEVICE_MODE"
     echo "gina       : $PHASE1_GINA_ENABLED"
+    echo "launcher   : $PHASE1_LAUNCH_COMMAND"
     if [ -f "$PHASE1_HOME/plugins/gina.wasi" ]; then echo "gina file  : present"; else echo "gina file  : missing"; fi
     if [ -f "$PHASE1_HOME/scripts/base1-preflight.sh" ]; then echo "base1      : preflight available"; else echo "base1      : preflight missing"; fi
     if command -v cargo >/dev/null 2>&1; then echo "cargo      : $(command -v cargo)"; else echo "cargo      : missing"; fi
@@ -130,9 +144,8 @@ run_quality() {
 
 launch_phase1() {
     export PHASE1_HOME PHASE1_THEME PHASE1_COLOR_MODE PHASE1_SAFE_MODE PHASE1_DEVICE_MODE
-    export PHASE1_GINA_ENABLED PHASE1_TERMINAL_TITLE
+    export PHASE1_GINA_ENABLED PHASE1_TERMINAL_TITLE PHASE1_LAUNCH_COMMAND
     export PHASE1_AI_MODE="offline"
-    export PHASE1_LAUNCH_COMMAND="./start_phase1"
 
     cd "$PHASE1_HOME"
 

--- a/terminal/README.md
+++ b/terminal/README.md
@@ -2,9 +2,18 @@
 
 This directory contains the lightweight Phase1 Terminal wrapper.
 
-The first implementation is deliberately small and current-master friendly:
+The primary repository startup command is now:
 
-- `bin/phase1-terminal` delegates to ../../start_phase1.
+```bash
+sh phase1
+./phase1
+```
+
+The root `phase1` command delegates to `./start_phase1` and is the recommended operator-friendly entrypoint.
+
+The terminal wrapper remains deliberately small and current-master friendly:
+
+- `bin/phase1-terminal` delegates to `../../start_phase1`.
 - It keeps safe defaults and does not create a new trust path.
 - It provides discovery commands for doctor, Gina, Base1, quality checks, and self-test.
 
@@ -16,7 +25,14 @@ sh terminal/bin/phase1-terminal doctor
 sh terminal/bin/phase1-terminal selftest
 ```
 
-Use the canonical launcher directly when in doubt:
+Install a local `phase1` command on macOS/Linux:
+
+```bash
+sh scripts/install-phase1-command.sh
+phase1
+```
+
+Use the source launcher directly when debugging:
 
 ```bash
 ./start_phase1

--- a/tests/phase1_launch.rs
+++ b/tests/phase1_launch.rs
@@ -8,8 +8,10 @@ use std::process::Command;
 #[test]
 fn launch_scripts_exist_and_have_valid_shell_syntax() {
     for path in [
+        "phase1",
         "start_phase1",
         "scripts/configure-phase1.sh",
+        "scripts/install-phase1-command.sh",
         "scripts/test-phase1-launch.sh",
     ] {
         assert!(fs::metadata(path).is_ok(), "missing launch script: {path}");
@@ -31,7 +33,8 @@ fn launch_help_displays_simple_command() {
         .expect("run start help");
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("./start_phase1"));
+    assert!(stdout.contains("./phase1"));
+    assert!(stdout.contains("sh phase1"));
     assert!(stdout.contains("Simple launch command"));
 }
 
@@ -48,6 +51,7 @@ fn launch_doctor_reports_gina_base1_and_config() {
     assert!(stdout.contains("gina"));
     assert!(stdout.contains("base1"));
     assert!(stdout.contains("config"));
+    assert!(stdout.contains("launcher"));
 }
 
 #[test]
@@ -60,7 +64,8 @@ fn configure_dry_run_is_safe_and_mentions_launch_command() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Phase1 absolute configuration"));
-    assert!(stdout.contains("Launch command: ./start_phase1"));
+    assert!(stdout.contains("Launch command: sh phase1"));
+    assert!(stdout.contains("Executable command: ./phase1"));
     assert!(stdout.contains("dry-run"));
 }
 

--- a/tests/phase1_terminal.rs
+++ b/tests/phase1_terminal.rs
@@ -46,10 +46,7 @@ fn simple_phase1_command_delegates_to_start_phase1() {
 
 #[test]
 fn install_phase1_command_creates_executable_wrapper() {
-    let temp_dir = env::temp_dir().join(format!(
-        "phase1-command-test-{}",
-        std::process::id()
-    ));
+    let temp_dir = env::temp_dir().join(format!("phase1-command-test-{}", std::process::id()));
     let _ = fs::remove_dir_all(&temp_dir);
     fs::create_dir_all(&temp_dir).expect("create temp command dir");
 
@@ -65,7 +62,10 @@ fn install_phase1_command_creates_executable_wrapper() {
     );
 
     let installed = temp_dir.join("phase1");
-    assert!(installed.exists(), "installer did not create phase1 command");
+    assert!(
+        installed.exists(),
+        "installer did not create phase1 command"
+    );
 
     let version = Command::new(&installed)
         .arg("version")

--- a/tests/phase1_terminal.rs
+++ b/tests/phase1_terminal.rs
@@ -1,10 +1,13 @@
+use std::env;
 use std::fs;
 use std::process::Command;
 
 #[test]
 fn terminal_wrapper_files_exist_and_have_valid_shell_syntax() {
     for path in [
+        "phase1",
         "terminal/bin/phase1-terminal",
+        "scripts/install-phase1-command.sh",
         "scripts/test-phase1-terminal.sh",
     ] {
         assert!(fs::metadata(path).is_ok(), "missing terminal file: {path}");
@@ -15,6 +18,63 @@ fn terminal_wrapper_files_exist_and_have_valid_shell_syntax() {
             .expect("run sh -n");
         assert!(status.success(), "script has invalid shell syntax: {path}");
     }
+}
+
+#[test]
+fn simple_phase1_command_delegates_to_start_phase1() {
+    let help = Command::new("sh")
+        .arg("phase1")
+        .arg("help")
+        .output()
+        .expect("run phase1 help");
+    assert!(help.status.success());
+    let help_stdout = String::from_utf8_lossy(&help.stdout);
+    assert!(help_stdout.contains("Fresh clone shortcut"));
+    assert!(help_stdout.contains("sh phase1"));
+    assert!(help_stdout.contains("install-phase1-command"));
+
+    let doctor = Command::new("sh")
+        .arg("phase1")
+        .arg("doctor")
+        .output()
+        .expect("run phase1 doctor");
+    assert!(doctor.status.success());
+    let doctor_stdout = String::from_utf8_lossy(&doctor.stdout);
+    assert!(doctor_stdout.contains("Phase1 launch doctor"));
+    assert!(doctor_stdout.contains("launcher"));
+}
+
+#[test]
+fn install_phase1_command_creates_executable_wrapper() {
+    let temp_dir = env::temp_dir().join(format!(
+        "phase1-command-test-{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&temp_dir);
+    fs::create_dir_all(&temp_dir).expect("create temp command dir");
+
+    let install = Command::new("sh")
+        .arg("scripts/install-phase1-command.sh")
+        .env("PHASE1_BIN_DIR", &temp_dir)
+        .output()
+        .expect("run installer");
+    assert!(
+        install.status.success(),
+        "installer failed: {}",
+        String::from_utf8_lossy(&install.stderr)
+    );
+
+    let installed = temp_dir.join("phase1");
+    assert!(installed.exists(), "installer did not create phase1 command");
+
+    let version = Command::new(&installed)
+        .arg("version")
+        .output()
+        .expect("run installed phase1 command");
+    assert!(version.status.success());
+    assert!(String::from_utf8_lossy(&version.stdout).contains("Phase1"));
+
+    fs::remove_dir_all(&temp_dir).expect("cleanup temp command dir");
 }
 
 #[test]
@@ -72,11 +132,14 @@ fn terminal_selftest_and_validation_script_pass() {
 }
 
 #[test]
-fn terminal_docs_point_to_start_phase1_as_source_of_truth() {
+fn terminal_docs_point_to_simple_phase1_command_and_source_launcher() {
     let terminal_doc = fs::read_to_string("TERMINAL.md").expect("read TERMINAL.md");
     let readme = fs::read_to_string("terminal/README.md").expect("read terminal README");
+    let root_readme = fs::read_to_string("README.md").expect("read README.md");
+    assert!(terminal_doc.contains("./phase1"));
     assert!(terminal_doc.contains("./start_phase1"));
-    assert!(terminal_doc.contains("canonical launch path"));
     assert!(terminal_doc.contains("no full terminal-emulator claim"));
-    assert!(readme.contains("delegates to ../../start_phase1"));
+    assert!(readme.contains("delegates to `../../start_phase1`"));
+    assert!(root_readme.contains("sh phase1"));
+    assert!(root_readme.contains("install-phase1-command"));
 }


### PR DESCRIPTION
## Summary

This PR makes Phase1 easier to start from a fresh clone and from a local Mac/Linux terminal session.

### Changes

- Add root `phase1` launcher so users can run `sh phase1` or `./phase1` instead of remembering `./start_phase1`.
- Add `scripts/install-phase1-command.sh` to install a local `phase1` command into `$HOME/.local/bin` or `PHASE1_BIN_DIR`.
- Update `start_phase1` so the banner/doctor output can show the simpler launch command when invoked through the new shortcut.
- Update `scripts/configure-phase1.sh` to prefer `./phase1`, create local wrappers, and make the new launchers executable.
- Update README and terminal docs with stable-vs-edge guidance and simpler startup instructions.
- Extend shell/Rust validation for the new launcher, installer, doctor, version, and selftest paths.

## Why

A fresh clone currently requires users to know or discover `chmod +x start_phase1` and `./start_phase1`. This adds a clearer path:

```bash
git clone https://github.com/Bryforge/phase1.git
cd phase1
sh phase1
```

Optional local command:

```bash
sh scripts/install-phase1-command.sh
phase1
```

## Validation

The branch updates:

- `scripts/test-phase1-terminal.sh`
- `tests/phase1_terminal.rs`

These validate shell syntax, simple launcher delegation, command installation, `doctor`, `version`, and self-test behavior.

The branch is based on the current `master` and is not behind.