### PR TITLE
Explain learned command typo recovery

### DIFF
--- a/docs/wiki/LEARN_COMMAND.md
+++ b/docs/wiki/LEARN_COMMAND.md
@@ -91,3 +91,26 @@ hlep     -> help
 
 The match is local and heuristic. It uses command metadata already present in Phase1; it does not call an external service.
 
+
+## Explain
+
+`learn explain <command>` shows why Phase1 maps an input to a likely command correction.
+
+Example:
+
+```text
+learn explain systinfo
+```
+
+Expected shape:
+
+```text
+phase1 learn explain
+input   : systinfo
+match   : sysinfo
+reason  : edit distance 1 within typo threshold 2
+action  : try `sysinfo`
+```
+
+This keeps typo recovery inspectable instead of mysterious.
+

--- a/src/learn.rs
+++ b/src/learn.rs
@@ -54,6 +54,10 @@ pub fn run(shell: &mut Phase1Shell, args: &[String]) -> String {
             args.remove(0);
             memory.ask(&args.join(" "))
         }
+        Some("explain") => {
+            args.remove(0);
+            explain_command(&args.join(" "))
+        }
         Some("note") => {
             args.remove(0);
             let result = memory.add_note(&args.join(" "));
@@ -516,6 +520,45 @@ fn is_safe_command_name(command: &str) -> bool {
             .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_'))
 }
 
+fn explain_command(raw: &str) -> String {
+    let input = raw.trim();
+    if input.is_empty() {
+        return "learn: usage: learn explain <command>\n".to_string();
+    }
+
+    let Some(normalized) = command_name(input) else {
+        return format!(
+            "phase1 learn explain\ninput   : {input}\nmatch   : none\nreason  : could not identify a safe command name\naction  : run `help`\n"
+        );
+    };
+
+    if let Some(canonical) = registry::canonical_name(&normalized) {
+        return format!(
+            "phase1 learn explain\ninput   : {input}\nmatch   : {canonical}\nreason  : exact command or alias match\naction  : run `{canonical}`\n"
+        );
+    }
+
+    if let Some(candidate) = closest_command(&normalized) {
+        let distance = edit_distance(&normalized, candidate);
+        let threshold = typo_threshold(&normalized);
+        return format!(
+            "phase1 learn explain\ninput   : {input}\nmatch   : {candidate}\nreason  : edit distance {distance} within typo threshold {threshold}\naction  : try `{candidate}`\n"
+        );
+    }
+
+    let prefix = normalized.chars().take(2).collect::<String>();
+    let action = if prefix.is_empty() {
+        "run `help`".to_string()
+    } else {
+        format!("run `complete {prefix}` or `help`")
+    };
+
+    format!(
+        "phase1 learn explain\ninput   : {input}\nmatch   : none\nreason  : no close command found within typo threshold {}\naction  : {action}\n",
+        typo_threshold(&normalized)
+    )
+}
+
 fn failure_recovery(command: &str) -> String {
     if let Some(candidate) = closest_command(command) {
         return format!("try `{candidate}`; it looks closest to `{command}`");
@@ -692,7 +735,7 @@ fn help() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{auto_observe_at, command_name, Memory};
+    use super::{auto_observe_at, command_name, explain_command, Memory};
     use std::collections::VecDeque;
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -799,6 +842,15 @@ mod tests {
         let suggestion = memory.suggest();
         assert!(suggestion.contains("focus: systinfo failed 1 time"));
         assert!(suggestion.contains("try `sysinfo`; it looks closest to `systinfo`"));
+    }
+
+    #[test]
+    fn explain_describes_typo_recovery() {
+        let explanation = explain_command("systinfo");
+        assert!(explanation.contains("input   : systinfo"));
+        assert!(explanation.contains("match   : sysinfo"));
+        assert!(explanation.contains("edit distance 1 within typo threshold 2"));
+        assert!(explanation.contains("action  : try `sysinfo`"));
     }
 
     #[test]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -90,7 +90,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     cmd!("su", &[], "user", "su <user>", "Switch simulated user.", "user.switch"),
     cmd!("accounts", &["users"], "user", "accounts", "Explain and list simulated Unix accounts without real emails or credentials.", "user.read"),
     cmd!("history", &[], "user", "history [list|status|path|save|clear]", "Show shell command history and persistent-history status.", "user.read"),
-    cmd!("learn", &["memory"], "user", "learn [status|import-history|note|teach|ask|suggest|profile|forget|export]", "Use the local learning memory from inside Phase1 with sanitized notes, rules, command observations, and suggestions.", "learn.write"),
+    cmd!("learn", &["memory"], "user", "learn [status|import-history|note|teach|ask|explain|suggest|profile|forget|export]", "Use the local learning memory from inside Phase1 with sanitized notes, rules, command observations, and suggestions.", "learn.write"),
     cmd!("security", &["sec", "policy"], "user", "security", "Show safe mode, host tool gates, persistence, and privacy status.", "user.read"),
     cmd!("theme", &["style"], "user", "theme [show|list|rainbow|matrix|cyber|amber|ice|synthwave|crimson|mono|ascii|reset]", "Switch or inspect selectable terminal palettes. Rainbow remains the default.", "user.env"),
     cmd!("banner", &["splash"], "user", "banner [mobile|desktop|mono|rainbow|matrix|cyber|amber|ice|synthwave|crimson|ascii|safe|host|persist]", "Preview boot splash profile and color palette choices without changing saved config.", "user.read"),


### PR DESCRIPTION
Adds learn explain so Phase1 can show why a failed command maps to a likely correction, including edit distance, threshold, and suggested action.