### PR TITLE
Checkpoint learn milestone and roadmap rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,8 @@ Release focus: roadmap foundation, release readiness, and demo-quality operator 
 - End-to-end smoke test harness.
 - macOS Wi-Fi scan fallbacks.
 - Roadmap groundwork for shell, kernel, security, pipelines, plugins, and TUI.
+
+## Development checkpoint - Learn system
+
+- Recorded the completed learn-system milestone through PR #48.
+- Added a roadmap maintenance rule for future feature PRs.

--- a/DEVELOPMENT_CHECKPOINT_LEARN.md
+++ b/DEVELOPMENT_CHECKPOINT_LEARN.md
@@ -1,0 +1,34 @@
+# Phase1 Development Checkpoint - Learn System Milestone
+
+Checkpoint date: 2026-05-08
+Stable base: v4.2.0
+
+## Completed milestone
+
+Phase1 now has an in-shell local-first learning memory layer.
+
+Delivered PRs: #42 in-shell learn; #43 auto-observe; #44 failure-prioritized suggestions; #45 typo recovery; #46 explain typo recovery; #47 local update helper; #48 learn doctor.
+
+## Current command surface
+
+learn status; learn doctor; learn import-history; learn import-file; learn observe; learn teach; learn note; learn ask; learn explain; learn suggest; learn profile; learn forget; learn export.
+
+## Current behavior
+
+Memory is local-only, sanitized, bounded, and not cloud-backed. Learn does not train on itself. Normal commands are auto-observed. Failed commands are prioritized. Typo-like failures can suggest likely commands. Learn explain explains correction reasoning. Learn doctor reports memory health.
+
+## Local update workflow
+
+Use p1up, p1run, and p1full. No zip patch workflow should be required for normal development.
+
+## Roadmap maintenance rule
+
+Future feature PRs must update roadmap and planned implementation docs when they complete roadmap items, change project direction, or add planned work. Review LEARNING.md, WIKI_ROADMAP.md, docs/website/NEXT_ROADMAP_IMPLEMENTATION.md, EDGE.md, and CHANGELOG.md for each milestone. If no roadmap update is needed, the PR body must say why.
+
+## Next planned learning work
+
+1. learn repair - direct repair action for the highest-priority failed command.
+2. learn categories - classify command usage by workflow area.
+3. learn summary - concise operator memory summary for demos.
+4. VFS/project summaries for /home files.
+5. Guarded export/import for shareable non-secret learning profiles.

--- a/LEARNING.md
+++ b/LEARNING.md
@@ -145,10 +145,13 @@ phase1-learn forget <all|notes|rules|commands|query>
 phase1-learn export
 ```
 
+## Completed milestone
+
+The in-shell learning milestone is complete: `learn`, auto-observe, failure-prioritized suggestions, typo recovery, `learn explain`, `learn doctor`, and the local update helper are merged. See `DEVELOPMENT_CHECKPOINT_LEARN.md`.
+
 ## Roadmap
 
-- expose `learn` as an in-shell Phase1 command
-- auto-observe known command success/failure from the shell dispatcher
+- add `learn repair` for direct repair actions from failed commands
 - add VFS summaries for `/home` project files
 - add local classifier weights for command categories
 - add guarded import/export for shareable non-secret learning profiles

--- a/WIKI_ROADMAP.md
+++ b/WIKI_ROADMAP.md
@@ -237,3 +237,7 @@ Start with **PR B1: phase1 project page**.
 Reason:
 
 The product page clarifies what phase1 is before the company page expands Bryforge. After that, build the company page so Bryforge has a professional identity separate from the phase1 technical pitch.
+
+## Development checkpoint rule
+
+Feature milestones must update roadmap and planned implementation docs when they complete planned work or change direction. Review LEARNING.md, WIKI_ROADMAP.md, docs/website/NEXT_ROADMAP_IMPLEMENTATION.md, EDGE.md, and CHANGELOG.md. If no roadmap update is needed, say why in the PR body.

--- a/docs/website/NEXT_ROADMAP_IMPLEMENTATION.md
+++ b/docs/website/NEXT_ROADMAP_IMPLEMENTATION.md
@@ -247,3 +247,7 @@ cargo deny check
 ## Decision
 
 The next implementation should start with `project.html`, because it clarifies the product before expanding the company story. The company page should follow immediately after so Bryforge has a professional public identity separate from the phase1 technical pitch.
+
+## Roadmap maintenance requirement
+
+Future implementation PRs must keep roadmap and planning documents current. When a PR completes a planned item, starts a new track, or changes implementation priority, update the relevant roadmap docs in the same PR or explain why no roadmap change is required. Review LEARNING.md, WIKI_ROADMAP.md, docs/website/NEXT_ROADMAP_IMPLEMENTATION.md, EDGE.md, and CHANGELOG.md during milestone PRs.


### PR DESCRIPTION
Adds a development checkpoint for the completed learn-system milestone and updates roadmap/planning docs so future feature PRs keep roadmaps and planned implementation documents current.