### PR TITLE
Fix guarded host runtime execution

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 phase1 is an educational userspace simulator, not a hardened host sandbox. The simulator is designed to keep its virtual filesystem, process table, scheduler, audit log, boot state, and host-facing helpers separate from the real host operating system.
 
-## Secure default
+## Secure default and trust gate
 
-phase1 defaults to safe mode. If no environment variable or saved boot config disables it, host-backed execution and host-network inspection are blocked.
+phase1 defaults to safe mode with the host trust gate off. In the default launch, host-backed execution and host-network inspection are blocked.
 
 Recommended launch:
 
@@ -18,39 +18,55 @@ Equivalent explicit safe launch:
 PHASE1_SAFE_MODE=1 cargo run
 ```
 
-Safe mode blocks or avoids host-backed behavior for:
+To intentionally test guarded host-backed runtimes while keeping the safe boot profile enabled, enable only the host trust gate:
+
+```bash
+PHASE1_SAFE_MODE=1 PHASE1_ALLOW_HOST_TOOLS=1 cargo run
+```
+
+or leave the shield enabled in the preboot selector and press `t` to enable trusted host tools.
+
+This mode allows guarded runtime and read-only host-inspection commands such as:
 
 - `browser`
 - `ping`
 - `wifi-scan`
-- `wifi-connect`
 - `python` / `py`
 - `gcc` / `cc`
+- `lang run ...`
 - Python plugins
-- host network-interface inspection beyond a simulated loopback view
-- mutating storage/Git/Rust helper actions
+- read-only host network-interface inspection
 
-To intentionally test host-backed tools, disable safe mode at the preboot selector with option `4`, or launch with:
+Safe mode still blocks privileged host mutation. Mutating host actions require both safe mode off and the trust gate on:
 
 ```bash
-PHASE1_SAFE_MODE=0 cargo run
+PHASE1_SAFE_MODE=0 PHASE1_ALLOW_HOST_TOOLS=1 cargo run
 ```
 
-Only do this when you trust the commands, code, plugins, URLs, and network actions being tested.
+Network mutation, such as an actual `wifi-connect`, additionally requires:
+
+```bash
+PHASE1_ALLOW_HOST_NETWORK_CHANGES=1
+```
+
+Only enable trusted host tools when you trust the commands, code, plugins, URLs, and network actions being tested.
 
 ## Host isolation boundaries
 
-Safe mode is designed to prevent accidental host interaction, but phase1 is still a normal userspace program. It is not a virtualization boundary and should not be treated like a production sandbox.
+Safe mode is designed to prevent accidental host mutation, but phase1 is still a normal userspace program. It is not a virtualization boundary and should not be treated like a production sandbox or chroot.
 
 Current defensive controls:
 
 - Safe mode is on by default.
-- Host network discovery is skipped in safe mode and shows loopback only.
-- Host-backed commands are disabled in safe mode.
+- Host trust is off by default.
+- Guarded runtime execution can run with safe mode still enabled when `PHASE1_ALLOW_HOST_TOOLS=1` is set.
+- Privileged host mutations still require `PHASE1_SAFE_MODE=0` plus the trust gate.
+- Language source comes from the phase1 VFS or explicit inline input and is copied into a temporary guarded workspace.
+- Guarded language commands receive a temporary `HOME`/`TMPDIR`, bounded stdin, bounded stdout/stderr, promptless host-tool environment variables, audit events, and command timeouts.
+- `lang run` supports `--stdin`, `--stdin-file`, `--timeout`, and `PHASE1_LANG_TIMEOUT`; runtime timeout is capped.
 - Browser fetches are restricted to `http://` and `https://` through `curl` protocol restrictions, timeout, and download-size limits.
 - `ping` validates host text before invoking the host command.
 - `wifi-connect` remains dry-run unless `PHASE1_ALLOW_HOST_NETWORK_CHANGES=1` is explicitly set.
-- Python, C compiler, and plugin execution use timeouts and are disabled in safe mode.
 - `phase1-storage` mutating Git/Rust actions require both `PHASE1_SAFE_MODE=0` and `PHASE1_ALLOW_HOST_TOOLS=1`.
 - Runtime files and common secret material are ignored by Git.
 
@@ -81,15 +97,15 @@ Do not paste GitHub tokens, passwords, API keys, SSH keys, recovery codes, sessi
 
 ## Host-backed commands
 
-Some phase1 commands can call host tools when safe mode is disabled:
+Some phase1 commands can call host tools when the trust gate is enabled:
 
 - `browser` uses `curl` for HTTP/HTTPS text fetching.
 - `ping`, `wifi-scan`, `ifconfig`, `iwconfig`, and `nmcli` can inspect host network state.
-- `python`, `gcc`, and plugin commands can execute host programs.
-- `phase1-storage` can run guarded Git and Rust commands when explicitly trusted.
-- `wifi-connect` is dry-run unless `PHASE1_ALLOW_HOST_NETWORK_CHANGES=1` is set.
+- `python`, `gcc`, plugin commands, and `lang run` can execute host programs through guarded runtime controls.
+- `phase1-storage` can run guarded Git and Rust commands when explicitly trusted; mutating actions also require safe mode off.
+- `wifi-connect` is dry-run unless safe mode is off and `PHASE1_ALLOW_HOST_NETWORK_CHANGES=1` is set.
 
-Treat host-backed commands as trusted-user tools only. Do not run untrusted code or commands from someone else.
+Treat host-backed commands as trusted-user tools only. Do not run untrusted code or commands from someone else until a stronger OS-level sandbox backend is added.
 
 ## Persistent state and history
 

--- a/src/languages.rs
+++ b/src/languages.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::fs;
-use std::io;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::thread;
@@ -9,7 +9,9 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use crate::commands::Phase1Shell;
 
 const MAX_SOURCE_BYTES: usize = 256 * 1024;
-const RUN_TIMEOUT: Duration = Duration::from_secs(8);
+const MAX_STDIN_BYTES: usize = 64 * 1024;
+const DEFAULT_RUN_TIMEOUT: Duration = Duration::from_secs(8);
+const MAX_RUN_TIMEOUT: Duration = Duration::from_secs(60);
 const COMPILE_TIMEOUT: Duration = Duration::from_secs(20);
 const MAX_OUTPUT_BYTES: usize = 24 * 1024;
 
@@ -41,13 +43,19 @@ pub struct LanguageSpec {
     runner: Runner,
 }
 
+#[derive(Clone, Debug)]
+struct RunOptions {
+    timeout: Duration,
+    stdin: Option<String>,
+}
+
 pub const LANGUAGES: &[LanguageSpec] = &[
     spec(
         "rust",
         &["rs"],
         &["rs"],
         "systems",
-        "compiled with rustc; host execution is gated",
+        "compiled with rustc; host execution uses the guarded runtime gate",
         Runner::Rust,
     ),
     spec(
@@ -55,7 +63,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &["ansi-c"],
         &["c"],
         "systems",
-        "compiled with cc/gcc/clang; host execution is gated",
+        "compiled with cc/gcc/clang; host execution uses the guarded runtime gate",
         Runner::CompileRun {
             tools: &["cc", "gcc", "clang"],
             compile_args: &["-Wall", "-Wextra", "-O0"],
@@ -66,7 +74,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &["c++", "cplusplus"],
         &["cpp", "cc", "cxx"],
         "systems",
-        "compiled with c++/g++/clang++; host execution is gated",
+        "compiled with c++/g++/clang++; host execution uses the guarded runtime gate",
         Runner::CompileRun {
             tools: &["c++", "g++", "clang++"],
             compile_args: &["-Wall", "-Wextra", "-O0"],
@@ -77,7 +85,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &["golang"],
         &["go"],
         "systems/cloud",
-        "go run in a temp workspace; host execution is gated",
+        "go run in a temporary guarded workspace",
         Runner::Go,
     ),
     spec(
@@ -85,7 +93,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &[],
         &["zig"],
         "systems",
-        "zig run; host execution is gated",
+        "zig run in a temporary guarded workspace",
         Runner::Interpreted {
             tools: &["zig"],
             args: &["run"],
@@ -96,7 +104,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &["py", "python3"],
         &["py"],
         "scripting/data",
-        "python3/python execution is gated",
+        "python3/python through the guarded runtime gate",
         Runner::Interpreted {
             tools: &["python3", "python"],
             args: &[],
@@ -107,7 +115,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &["js", "node"],
         &["js", "mjs", "cjs"],
         "web",
-        "node execution is gated",
+        "node through the guarded runtime gate",
         Runner::Interpreted {
             tools: &["node"],
             args: &[],
@@ -118,7 +126,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &["ts", "deno"],
         &["ts"],
         "web",
-        "deno run without extra permissions; host execution is gated",
+        "deno run without extra permissions through the guarded runtime gate",
         Runner::Interpreted {
             tools: &["deno"],
             args: &["run", "--no-prompt"],
@@ -129,7 +137,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &[],
         &["java"],
         "jvm",
-        "Java source-file mode; host execution is gated",
+        "Java source-file mode through the guarded runtime gate",
         Runner::JavaSource,
     ),
     spec(
@@ -137,7 +145,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &["kt"],
         &["kt"],
         "jvm",
-        "kotlinc jar build then java -jar; host execution is gated",
+        "kotlinc jar build then java -jar through the guarded runtime gate",
         Runner::Kotlin,
     ),
     spec(
@@ -145,7 +153,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &[],
         &["scala", "sc"],
         "jvm",
-        "scala source runner where installed; host execution is gated",
+        "scala source runner where installed through the guarded runtime gate",
         Runner::Interpreted {
             tools: &["scala"],
             args: &[],
@@ -156,7 +164,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &["c#", "cs", "dotnet"],
         &["cs"],
         ".net",
-        "dotnet console wrapper; host execution is gated",
+        "dotnet console wrapper through the guarded runtime gate",
         Runner::Dotnet,
     ),
     spec(
@@ -164,7 +172,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &["fs", "f#"],
         &["fsx"],
         ".net",
-        "dotnet fsi where installed; host execution is gated",
+        "dotnet fsi where installed through the guarded runtime gate",
         Runner::Interpreted {
             tools: &["dotnet"],
             args: &["fsi"],
@@ -175,7 +183,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &[],
         &["swift"],
         "apple/systems",
-        "swift script runner; host execution is gated",
+        "swift script runner through the guarded runtime gate",
         Runner::Interpreted {
             tools: &["swift"],
             args: &[],
@@ -186,7 +194,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &["rb"],
         &["rb"],
         "scripting/web",
-        "ruby execution is gated",
+        "ruby through the guarded runtime gate",
         Runner::Interpreted {
             tools: &["ruby"],
             args: &[],
@@ -197,7 +205,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &[],
         &["php"],
         "web",
-        "php cli execution is gated",
+        "php cli through the guarded runtime gate",
         Runner::Interpreted {
             tools: &["php"],
             args: &[],
@@ -208,7 +216,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &["pl"],
         &["pl", "pm"],
         "scripting",
-        "perl execution is gated",
+        "perl through the guarded runtime gate",
         Runner::Interpreted {
             tools: &["perl"],
             args: &[],
@@ -219,7 +227,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &[],
         &["lua"],
         "scripting/embedded",
-        "lua execution is gated",
+        "lua through the guarded runtime gate",
         Runner::Interpreted {
             tools: &["lua", "lua5.4", "lua5.3"],
             args: &[],
@@ -230,7 +238,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &["rscript"],
         &["r"],
         "data/science",
-        "Rscript execution is gated",
+        "Rscript through the guarded runtime gate",
         Runner::Interpreted {
             tools: &["Rscript"],
             args: &[],
@@ -241,7 +249,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &["jl"],
         &["jl"],
         "data/science",
-        "julia execution is gated",
+        "julia through the guarded runtime gate",
         Runner::Interpreted {
             tools: &["julia"],
             args: &[],
@@ -252,7 +260,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &["hs"],
         &["hs"],
         "functional",
-        "runghc execution is gated",
+        "runghc through the guarded runtime gate",
         Runner::Interpreted {
             tools: &["runghc", "runhaskell"],
             args: &[],
@@ -263,7 +271,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &["ml"],
         &["ml"],
         "functional",
-        "ocaml interpreter execution is gated",
+        "ocaml interpreter through the guarded runtime gate",
         Runner::Interpreted {
             tools: &["ocaml"],
             args: &[],
@@ -274,7 +282,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &["exs"],
         &["exs", "ex"],
         "beam",
-        "elixir execution is gated",
+        "elixir through the guarded runtime gate",
         Runner::Interpreted {
             tools: &["elixir"],
             args: &[],
@@ -285,7 +293,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &["escript"],
         &["erl", "escript"],
         "beam",
-        "escript execution is gated",
+        "escript through the guarded runtime gate",
         Runner::Interpreted {
             tools: &["escript"],
             args: &[],
@@ -296,7 +304,7 @@ pub const LANGUAGES: &[LanguageSpec] = &[
         &[],
         &["dart"],
         "mobile/web",
-        "dart execution is gated",
+        "dart through the guarded runtime gate",
         Runner::Interpreted {
             tools: &["dart"],
             args: &[],
@@ -356,7 +364,7 @@ pub fn run(shell: &mut Phase1Shell, args: &[String]) -> String {
 }
 
 fn help() -> String {
-    "phase1 lang // native guarded language runtime manager\n\nusage:\n  lang list\n  lang support\n  lang status [language]\n  lang doctor [language]\n  lang detect <file>\n  lang run <language|auto> <vfs-file | inline-code>\n  lang security\n\nexamples:\n  echo 'fn main() { println!(\"hi\"); }' > hello.rs\n  lang run rust hello.rs\n  lang run python 'print(\"hello\")'\n  lang detect app.ts\n\nsafety:\n  Language execution is host-backed except WASI-lite inspection and requires:\n    PHASE1_SAFE_MODE=0 PHASE1_ALLOW_HOST_TOOLS=1\n  Source is copied from the phase1 VFS or inline input into a temporary file, output is bounded, and common sensitive markers are redacted.\n"
+    "phase1 lang // native guarded language runtime manager\n\nusage:\n  lang list\n  lang support\n  lang status [language]\n  lang doctor [language]\n  lang detect <file>\n  lang run [--timeout seconds] [--stdin text | --stdin-file vfs-file] <language|auto> <vfs-file | inline-code>\n  lang security\n\nexamples:\n  echo 'fn main() { println!(\"hi\"); }' > hello.rs\n  lang run rust hello.rs\n  lang run python 'print(\"hello\")'\n  lang run --stdin 'hello' python 'import sys; print(sys.stdin.read().upper())'\n  lang run --timeout 20 python script.py\n  lang detect app.ts\n\nsafety:\n  Guarded language execution requires the explicit trust gate only:\n    PHASE1_ALLOW_HOST_TOOLS=1\n  Safe mode may remain enabled. Safe mode now means guarded runtime execution, not privileged host mutation.\n  Source is copied from the phase1 VFS or inline input into a temporary workspace. Commands run with bounded stdin/stdout/stderr, configurable timeouts, audit events, promptless env vars, and temp HOME/TMPDIR.\n  This is a guardrail layer, not a chroot/VM sandbox; do not run untrusted code until a stronger OS-level sandbox backend is added.\n"
         .to_string()
 }
 
@@ -408,7 +416,7 @@ fn status(language: Option<&str>) -> String {
 }
 
 fn doctor(language: Option<&str>) -> String {
-    if !crate::policy::host_tools_allowed() {
+    if !crate::policy::guarded_host_execution_allowed() {
         return format!("{}\n", crate::policy::host_denial_message("lang doctor"));
     }
     let specs = match language.and_then(find_language) {
@@ -442,19 +450,24 @@ fn doctor(language: Option<&str>) -> String {
 }
 
 fn run_language(shell: &mut Phase1Shell, args: &[String]) -> String {
-    if args.len() < 2 {
-        return "usage: lang run <language|auto> <vfs-file | inline-code>\n".to_string();
-    }
-    if !crate::policy::host_tools_allowed() && args[0] != "wasm" && args[0] != "wasi" {
+    let (mut language, source_arg, options) = match parse_run_request(shell, args) {
+        Ok(request) => request,
+        Err(err) => return err,
+    };
+
+    if !crate::policy::guarded_host_execution_allowed()
+        && language != "wasm"
+        && language != "wasi"
+    {
         return format!("{}\n", crate::policy::host_denial_message("lang run"));
     }
 
-    let mut language = args[0].as_str();
-    let source_arg = args[1..].join(" ");
     if language == "auto" {
-        language = detect_language_from_path(&source_arg).unwrap_or("unknown");
+        language = detect_language_from_path(&source_arg)
+            .unwrap_or("unknown")
+            .to_string();
     }
-    let Some(spec) = find_language(language) else {
+    let Some(spec) = find_language(&language) else {
         return format!("lang: unsupported language '{language}'\n");
     };
 
@@ -468,11 +481,13 @@ fn run_language(shell: &mut Phase1Shell, args: &[String]) -> String {
     }
 
     shell.kernel.audit.record(format!(
-        "host.lang.run language={} bytes={}",
+        "host.lang.run language={} bytes={} timeout={}s stdin={}",
         spec.name,
-        source.len()
+        source.len(),
+        options.timeout.as_secs(),
+        options.stdin.as_ref().map(|value| value.len()).unwrap_or(0)
     ));
-    match execute(spec, &source) {
+    match execute(spec, &source, &options) {
         Ok(output) => sanitize_output(&format_output(output)),
         Err(err) => format!("lang {}: {}\n", spec.name, err),
     }
@@ -486,11 +501,98 @@ fn detect(path: Option<&str>) -> String {
 }
 
 fn security_report() -> String {
-    "phase1 language runtime security\n\n- execution is blocked by default safe mode\n- host-backed language execution requires PHASE1_SAFE_MODE=0 and PHASE1_ALLOW_HOST_TOOLS=1\n- source comes from the phase1 VFS or explicit inline input\n- source is copied to temporary files and bounded to 256 KiB\n- compile and run commands have timeouts\n- stdout/stderr are capped and redacted for common sensitive markers\n- package install, network fetch, editor shell escapes, and background daemons are not implemented here\n- WASM/WASI remains the preferred long-term sandbox target\n"
+    "phase1 language runtime security\n\n- guarded language execution no longer requires disabling safe mode\n- host-backed language execution requires the explicit trust gate: PHASE1_ALLOW_HOST_TOOLS=1\n- safe mode still blocks privileged host mutation; it does not block guarded runtimes once trusted\n- source comes from the phase1 VFS or explicit inline input\n- source is copied to temporary workspaces and bounded to 256 KiB\n- stdin may be provided with --stdin or --stdin-file and is capped to 64 KiB\n- run timeout is configurable with --timeout or PHASE1_LANG_TIMEOUT and capped at 60 seconds\n- stdout/stderr are capped and redacted for common sensitive markers\n- package install, network fetch, editor shell escapes, and background daemons are not implemented here\n- this is a guardrail layer, not a chroot/VM sandbox; WASM/WASI remains the preferred long-term sandbox target\n"
         .to_string()
 }
 
-fn execute(spec: &LanguageSpec, source: &str) -> io::Result<Output> {
+fn parse_run_request(
+    shell: &mut Phase1Shell,
+    args: &[String],
+) -> Result<(String, String, RunOptions), String> {
+    if args.len() < 2 {
+        return Err("usage: lang run [--timeout seconds] [--stdin text | --stdin-file vfs-file] <language|auto> <vfs-file | inline-code>\n".to_string());
+    }
+
+    let mut timeout = env_timeout().unwrap_or(DEFAULT_RUN_TIMEOUT);
+    let mut stdin = None;
+    let mut positional = Vec::new();
+    let mut idx = 0;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--timeout" | "-t" => {
+                let Some(raw) = args.get(idx + 1) else {
+                    return Err("lang run: --timeout requires seconds\n".to_string());
+                };
+                timeout = parse_timeout(raw)?;
+                idx += 2;
+            }
+            "--stdin" => {
+                let Some(raw) = args.get(idx + 1) else {
+                    return Err("lang run: --stdin requires input text\n".to_string());
+                };
+                if raw.len() > MAX_STDIN_BYTES {
+                    return Err(format!(
+                        "lang run: stdin is too large; limit is {MAX_STDIN_BYTES} bytes\n"
+                    ));
+                }
+                stdin = Some(raw.clone());
+                idx += 2;
+            }
+            "--stdin-file" => {
+                let Some(path) = args.get(idx + 1) else {
+                    return Err("lang run: --stdin-file requires a VFS file path\n".to_string());
+                };
+                let input = shell
+                    .kernel
+                    .sys_read(path)
+                    .map_err(|err| format!("lang run: --stdin-file: {err}\n"))?;
+                if input.len() > MAX_STDIN_BYTES {
+                    return Err(format!(
+                        "lang run: stdin file is too large; limit is {MAX_STDIN_BYTES} bytes\n"
+                    ));
+                }
+                stdin = Some(input);
+                idx += 2;
+            }
+            "--no-stdin" => {
+                stdin = None;
+                idx += 1;
+            }
+            other => {
+                positional.push(other.to_string());
+                idx += 1;
+            }
+        }
+    }
+
+    if positional.len() < 2 {
+        return Err("usage: lang run [--timeout seconds] [--stdin text | --stdin-file vfs-file] <language|auto> <vfs-file | inline-code>\n".to_string());
+    }
+
+    Ok((
+        positional[0].clone(),
+        positional[1..].join(" "),
+        RunOptions { timeout, stdin },
+    ))
+}
+
+fn env_timeout() -> Option<Duration> {
+    env::var("PHASE1_LANG_TIMEOUT")
+        .ok()
+        .and_then(|raw| parse_timeout(raw.trim()).ok())
+}
+
+fn parse_timeout(raw: &str) -> Result<Duration, String> {
+    let secs = raw
+        .parse::<u64>()
+        .map_err(|_| format!("lang run: invalid timeout '{raw}'\n"))?;
+    if secs == 0 {
+        return Err("lang run: timeout must be at least 1 second\n".to_string());
+    }
+    Ok(Duration::from_secs(secs).min(MAX_RUN_TIMEOUT))
+}
+
+fn execute(spec: &LanguageSpec, source: &str, options: &RunOptions) -> io::Result<Output> {
     let nonce = unique_nonce();
     let root = env::temp_dir().join(format!("phase1_lang_{nonce}"));
     fs::create_dir_all(&root)?;
@@ -508,7 +610,8 @@ fn execute(spec: &LanguageSpec, source: &str) -> io::Result<Output> {
             })?;
             let mut cmd = Command::new(tool);
             cmd.args(args).arg(&source_path);
-            run_command(cmd, RUN_TIMEOUT)
+            prepare_guarded_command(&mut cmd, &root);
+            run_command(cmd, options.timeout, options.stdin.as_deref())
         }
         Runner::CompileRun {
             tools,
@@ -527,10 +630,12 @@ fn execute(spec: &LanguageSpec, source: &str) -> io::Result<Output> {
                 .arg(&source_path)
                 .arg("-o")
                 .arg(&binary);
-            let compile_output = run_command(compile, COMPILE_TIMEOUT)?;
+            prepare_guarded_command(&mut compile, &root);
+            let compile_output = run_command(compile, COMPILE_TIMEOUT, None)?;
             if compile_output.status.success() {
-                let run = Command::new(&binary);
-                run_command(run, RUN_TIMEOUT)
+                let mut run = Command::new(&binary);
+                prepare_guarded_command(&mut run, &root);
+                run_command(run, options.timeout, options.stdin.as_deref())
             } else {
                 Ok(compile_output)
             }
@@ -543,25 +648,29 @@ fn execute(spec: &LanguageSpec, source: &str) -> io::Result<Output> {
                 .arg(&source_path)
                 .arg("-o")
                 .arg(&binary);
-            let compile_output = run_command(compile, COMPILE_TIMEOUT)?;
+            prepare_guarded_command(&mut compile, &root);
+            let compile_output = run_command(compile, COMPILE_TIMEOUT, None)?;
             if compile_output.status.success() {
-                let run = Command::new(&binary);
-                run_command(run, RUN_TIMEOUT)
+                let mut run = Command::new(&binary);
+                prepare_guarded_command(&mut run, &root);
+                run_command(run, options.timeout, options.stdin.as_deref())
             } else {
                 Ok(compile_output)
             }
         }
         Runner::Go => {
             let mut cmd = Command::new("go");
-            cmd.arg("run").arg(&source_path).current_dir(&root);
-            run_command(cmd, RUN_TIMEOUT)
+            cmd.arg("run").arg(&source_path);
+            prepare_guarded_command(&mut cmd, &root);
+            run_command(cmd, options.timeout, options.stdin.as_deref())
         }
         Runner::JavaSource => {
             let java_source = root.join("Main.java");
             fs::write(&java_source, normalize_java_source(source))?;
             let mut cmd = Command::new("java");
-            cmd.arg(&java_source).current_dir(&root);
-            run_command(cmd, RUN_TIMEOUT)
+            cmd.arg(&java_source);
+            prepare_guarded_command(&mut cmd, &root);
+            run_command(cmd, options.timeout, options.stdin.as_deref())
         }
         Runner::Kotlin => {
             let jar = root.join("main.jar");
@@ -570,13 +679,14 @@ fn execute(spec: &LanguageSpec, source: &str) -> io::Result<Output> {
                 .arg(&source_path)
                 .arg("-include-runtime")
                 .arg("-d")
-                .arg(&jar)
-                .current_dir(&root);
-            let compile_output = run_command(compile, COMPILE_TIMEOUT)?;
+                .arg(&jar);
+            prepare_guarded_command(&mut compile, &root);
+            let compile_output = run_command(compile, COMPILE_TIMEOUT, None)?;
             if compile_output.status.success() {
                 let mut run = Command::new("java");
                 run.arg("-jar").arg(&jar);
-                run_command(run, RUN_TIMEOUT)
+                prepare_guarded_command(&mut run, &root);
+                run_command(run, options.timeout, options.stdin.as_deref())
             } else {
                 Ok(compile_output)
             }
@@ -587,8 +697,9 @@ fn execute(spec: &LanguageSpec, source: &str) -> io::Result<Output> {
             fs::write(project.join("phase1.csproj"), "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net8.0</TargetFramework><ImplicitUsings>enable</ImplicitUsings><Nullable>enable</Nullable></PropertyGroup></Project>")?;
             fs::write(project.join("Program.cs"), source)?;
             let mut cmd = Command::new("dotnet");
-            cmd.arg("run").current_dir(project);
-            run_command(cmd, Duration::from_secs(30))
+            cmd.arg("run");
+            prepare_guarded_command(&mut cmd, &project);
+            run_command(cmd, options.timeout.max(Duration::from_secs(30)), options.stdin.as_deref())
         }
         Runner::WasmInfo => unreachable!(),
     };
@@ -597,8 +708,23 @@ fn execute(spec: &LanguageSpec, source: &str) -> io::Result<Output> {
     result
 }
 
+fn prepare_guarded_command(cmd: &mut Command, root: &Path) {
+    cmd.current_dir(root)
+        .env("HOME", root)
+        .env("TMPDIR", root)
+        .env("TEMP", root)
+        .env("TMP", root)
+        .env("PHASE1_GUARDED_EXEC", "1")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GCM_INTERACTIVE", "never")
+        .env("PYTHONNOUSERSITE", "1")
+        .env("PIP_DISABLE_PIP_VERSION_CHECK", "1")
+        .env("CARGO_TERM_COLOR", "never")
+        .env("NO_COLOR", "1");
+}
+
 fn load_source(shell: &mut Phase1Shell, raw: &str) -> String {
-    let looks_like_path = raw.starts_with('/') || raw.contains('.') || raw.ends_with('s');
+    let looks_like_path = raw.starts_with('/') || raw.starts_with("./") || raw.contains('.');
     if looks_like_path {
         if let Ok(content) = shell.kernel.sys_read(raw) {
             return content;
@@ -671,20 +797,30 @@ fn find_tool(tools: &'static [&'static str]) -> Option<&'static str> {
 fn tool_version(tool: &str) -> String {
     let mut cmd = Command::new(tool);
     cmd.arg("--version");
-    match run_command(cmd, Duration::from_secs(3)) {
+    match run_command(cmd, Duration::from_secs(3), None) {
         Ok(output) => first_line(&format_output(output)),
         Err(_) => "version unavailable".to_string(),
     }
 }
 
-fn run_command(mut cmd: Command, timeout: Duration) -> io::Result<Output> {
+fn run_command(mut cmd: Command, timeout: Duration, stdin_text: Option<&str>) -> io::Result<Output> {
+    let timeout = timeout.min(MAX_RUN_TIMEOUT);
+    let stdin_mode = if stdin_text.is_some() {
+        Stdio::piped()
+    } else {
+        Stdio::null()
+    };
     let mut child = cmd
-        .stdin(Stdio::null())
+        .stdin(stdin_mode)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .env("GCM_INTERACTIVE", "never")
         .spawn()?;
+    if let Some(input) = stdin_text {
+        if let Some(stdin) = child.stdin.as_mut() {
+            stdin.write_all(input.as_bytes())?;
+        }
+        drop(child.stdin.take());
+    }
     let start = Instant::now();
     loop {
         if child.try_wait()?.is_some() {
@@ -754,8 +890,10 @@ fn workspace_root() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::{
-        detect_language_from_path, find_language, normalize_java_source, sanitize_output, LANGUAGES,
+        detect_language_from_path, find_language, normalize_java_source, parse_timeout,
+        sanitize_output, DEFAULT_RUN_TIMEOUT, LANGUAGES, MAX_RUN_TIMEOUT,
     };
+    use std::time::Duration;
 
     #[test]
     fn all_registered_languages_have_extensions() {
@@ -789,6 +927,14 @@ mod tests {
         let wrapped = normalize_java_source("System.out.println(\"hi\");");
         assert!(wrapped.contains("class Main"));
         assert!(wrapped.contains("System.out.println"));
+    }
+
+    #[test]
+    fn timeout_parsing_is_bounded() {
+        assert_eq!(parse_timeout("1").unwrap(), Duration::from_secs(1));
+        assert_eq!(parse_timeout("999").unwrap(), MAX_RUN_TIMEOUT);
+        assert!(parse_timeout("0").is_err());
+        assert_eq!(DEFAULT_RUN_TIMEOUT, Duration::from_secs(8));
     }
 
     #[test]

--- a/src/languages.rs
+++ b/src/languages.rs
@@ -455,9 +455,7 @@ fn run_language(shell: &mut Phase1Shell, args: &[String]) -> String {
         Err(err) => return err,
     };
 
-    if !crate::policy::guarded_host_execution_allowed()
-        && language != "wasm"
-        && language != "wasi"
+    if !crate::policy::guarded_host_execution_allowed() && language != "wasm" && language != "wasi"
     {
         return format!("{}\n", crate::policy::host_denial_message("lang run"));
     }
@@ -699,7 +697,11 @@ fn execute(spec: &LanguageSpec, source: &str, options: &RunOptions) -> io::Resul
             let mut cmd = Command::new("dotnet");
             cmd.arg("run");
             prepare_guarded_command(&mut cmd, &project);
-            run_command(cmd, options.timeout.max(Duration::from_secs(30)), options.stdin.as_deref())
+            run_command(
+                cmd,
+                options.timeout.max(Duration::from_secs(30)),
+                options.stdin.as_deref(),
+            )
         }
         Runner::WasmInfo => unreachable!(),
     };
@@ -803,7 +805,11 @@ fn tool_version(tool: &str) -> String {
     }
 }
 
-fn run_command(mut cmd: Command, timeout: Duration, stdin_text: Option<&str>) -> io::Result<Output> {
+fn run_command(
+    mut cmd: Command,
+    timeout: Duration,
+    stdin_text: Option<&str>,
+) -> io::Result<Output> {
     let timeout = timeout.min(MAX_RUN_TIMEOUT);
     let stdin_mode = if stdin_text.is_some() {
         Stdio::piped()

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -94,6 +94,7 @@ fn privileged_host_tools_allowed_from_values(
     !safe_mode_from_value(safe_mode) && host_tools_from_value(host_tools)
 }
 
+#[cfg(test)]
 fn host_tools_allowed_from_values(safe_mode: Option<&str>, host_tools: Option<&str>) -> bool {
     guarded_host_execution_allowed_from_values(safe_mode, host_tools)
 }

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -204,7 +204,10 @@ mod tests {
             capability_denial_message_from_values("browser", "host.net", Some("0"), None).unwrap();
         assert!(host.contains("PHASE1_ALLOW_HOST_TOOLS"));
 
-        assert!(capability_denial_message_from_values("python", "host.exec", None, Some("1")).is_none());
+        assert!(
+            capability_denial_message_from_values("python", "host.exec", None, Some("1"))
+                .is_none()
+        );
         assert!(
             capability_denial_message_from_values("python", "host.exec", Some("1"), Some("1"))
                 .is_none()

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -204,7 +204,9 @@ mod tests {
             capability_denial_message_from_values("browser", "host.net", Some("0"), None).unwrap();
         assert!(host.contains("PHASE1_ALLOW_HOST_TOOLS"));
 
-        assert!(capability_denial_message_from_values("python", "host.exec", None, Some("1")).is_none());
+        assert!(
+            capability_denial_message_from_values("python", "host.exec", None, Some("1")).is_none()
+        );
         assert!(
             capability_denial_message_from_values("python", "host.exec", Some("1"), Some("1"))
                 .is_none()

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -204,10 +204,7 @@ mod tests {
             capability_denial_message_from_values("browser", "host.net", Some("0"), None).unwrap();
         assert!(host.contains("PHASE1_ALLOW_HOST_TOOLS"));
 
-        assert!(
-            capability_denial_message_from_values("python", "host.exec", None, Some("1"))
-                .is_none()
-        );
+        assert!(capability_denial_message_from_values("python", "host.exec", None, Some("1")).is_none());
         assert!(
             capability_denial_message_from_values("python", "host.exec", Some("1"), Some("1"))
                 .is_none()

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,8 +1,9 @@
 pub fn security_report(persistent_state: bool, history_state: &str) -> String {
     format!(
-        "security mode       : {}\nhost tools          : {}\nhost network changes: {}\ncapability metadata : {}\npersistent state    : {}\nhistory             : {}\nprivacy             : no real emails, passwords, tokens, or account secrets are stored by phase1\n",
+        "security mode       : {}\nhost tools          : {}\nguarded runtime exec: {}\nhost network changes: {}\ncapability metadata : {}\npersistent state    : {}\nhistory             : {}\nprivacy             : no real emails, passwords, tokens, or account secrets are stored by phase1\n",
         if safe_mode_enabled() { "safe" } else { "host-capable" },
         host_tools_status_label(),
+        if guarded_host_execution_allowed() { "enabled" } else { "off" },
         if host_network_changes_enabled() { "enabled" } else { "disabled" },
         capability_metadata_status(),
         if persistent_state { "on" } else { "off" },
@@ -20,25 +21,37 @@ pub fn host_tools_enabled() -> bool {
 
 pub fn host_tools_status_label() -> &'static str {
     match (host_tools_enabled(), safe_mode_enabled()) {
-        (true, true) => "armed/safe",
-        (true, false) => "enabled",
+        (true, true) => "trusted/guarded",
+        (true, false) => "trusted/privileged",
         (false, _) => "off",
     }
 }
 
-pub fn host_network_changes_enabled() -> bool {
-    host_tools_from_value(
-        std::env::var("PHASE1_ALLOW_HOST_NETWORK_CHANGES")
-            .ok()
-            .as_deref(),
-    )
-}
-
-pub fn host_tools_allowed() -> bool {
-    host_tools_allowed_from_values(
+pub fn guarded_host_execution_allowed() -> bool {
+    guarded_host_execution_allowed_from_values(
         std::env::var("PHASE1_SAFE_MODE").ok().as_deref(),
         std::env::var("PHASE1_ALLOW_HOST_TOOLS").ok().as_deref(),
     )
+}
+
+pub fn privileged_host_tools_allowed() -> bool {
+    privileged_host_tools_allowed_from_values(
+        std::env::var("PHASE1_SAFE_MODE").ok().as_deref(),
+        std::env::var("PHASE1_ALLOW_HOST_TOOLS").ok().as_deref(),
+    )
+}
+
+pub fn host_network_changes_enabled() -> bool {
+    privileged_host_tools_allowed()
+        && host_tools_from_value(
+            std::env::var("PHASE1_ALLOW_HOST_NETWORK_CHANGES")
+                .ok()
+                .as_deref(),
+        )
+}
+
+pub fn host_tools_allowed() -> bool {
+    guarded_host_execution_allowed()
 }
 
 pub fn capability_denial_message(command: &str, capability: &str) -> Option<String> {
@@ -67,8 +80,22 @@ fn host_tools_from_value(value: Option<&str>) -> bool {
     value == Some("1")
 }
 
-fn host_tools_allowed_from_values(safe_mode: Option<&str>, host_tools: Option<&str>) -> bool {
+fn guarded_host_execution_allowed_from_values(
+    _safe_mode: Option<&str>,
+    host_tools: Option<&str>,
+) -> bool {
+    host_tools_from_value(host_tools)
+}
+
+fn privileged_host_tools_allowed_from_values(
+    safe_mode: Option<&str>,
+    host_tools: Option<&str>,
+) -> bool {
     !safe_mode_from_value(safe_mode) && host_tools_from_value(host_tools)
+}
+
+fn host_tools_allowed_from_values(safe_mode: Option<&str>, host_tools: Option<&str>) -> bool {
+    guarded_host_execution_allowed_from_values(safe_mode, host_tools)
 }
 
 fn capability_denial_message_from_values(
@@ -79,7 +106,7 @@ fn capability_denial_message_from_values(
 ) -> Option<String> {
     match capability {
         "host.exec" | "host.net" if command != "update" => {
-            (!host_tools_allowed_from_values(safe_mode, host_tools)).then(|| {
+            (!guarded_host_execution_allowed_from_values(safe_mode, host_tools)).then(|| {
                 host_denial_message_from_values(
                     command,
                     safe_mode_from_value(safe_mode),
@@ -87,29 +114,45 @@ fn capability_denial_message_from_values(
                 )
             })
         }
-        "net.admin" => (!host_tools_allowed_from_values(safe_mode, host_tools)).then(|| {
-            host_denial_message_from_values(
-                command,
-                safe_mode_from_value(safe_mode),
-                host_tools_from_value(host_tools),
-            )
-        }),
+        "net.admin" => (!privileged_host_tools_allowed_from_values(safe_mode, host_tools)).then(
+            || {
+                privileged_denial_message_from_values(
+                    command,
+                    safe_mode_from_value(safe_mode),
+                    host_tools_from_value(host_tools),
+                )
+            },
+        ),
         _ => None,
     }
 }
 
 fn host_denial_message_from_values(
     command: &str,
+    _safe_mode: bool,
+    host_tools_enabled: bool,
+) -> String {
+    if !host_tools_enabled {
+        format!(
+            "{command}: disabled; enable the trust gate with PHASE1_ALLOW_HOST_TOOLS=1 or reboot and press t. Safe mode can remain enabled for guarded runtime execution."
+        )
+    } else {
+        format!("{command}: blocked by policy")
+    }
+}
+
+fn privileged_denial_message_from_values(
+    command: &str,
     safe_mode: bool,
     host_tools_enabled: bool,
 ) -> String {
-    if safe_mode {
+    if !host_tools_enabled {
         format!(
-            "{command}: disabled by safe boot profile; for Python/language runtimes reboot and press 4 then t, or use the new r/runtimes boot shortcut when available"
+            "{command}: disabled; enable the trust gate with PHASE1_ALLOW_HOST_TOOLS=1 or reboot and press t"
         )
-    } else if !host_tools_enabled {
+    } else if safe_mode {
         format!(
-            "{command}: disabled; set PHASE1_ALLOW_HOST_TOOLS=1 to enable trusted host tools, or reboot and press t / r for runtimes"
+            "{command}: blocked by safe boot profile; privileged host changes require safe mode off plus the trust gate"
         )
     } else {
         format!("{command}: blocked by policy")
@@ -119,8 +162,9 @@ fn host_denial_message_from_values(
 #[cfg(test)]
 mod tests {
     use super::{
-        capability_denial_message_from_values, host_tools_allowed_from_values,
-        host_tools_from_value, safe_mode_from_value, security_report,
+        capability_denial_message_from_values, guarded_host_execution_allowed_from_values,
+        host_tools_allowed_from_values, host_tools_from_value, privileged_host_tools_allowed_from_values,
+        safe_mode_from_value, security_report,
     };
 
     #[test]
@@ -131,26 +175,43 @@ mod tests {
     }
 
     #[test]
-    fn host_tools_require_explicit_opt_in() {
-        assert!(!host_tools_allowed_from_values(Some("0"), None));
-        assert!(!host_tools_allowed_from_values(None, Some("1")));
+    fn guarded_host_tools_do_not_require_disabling_safe_mode() {
+        assert!(guarded_host_execution_allowed_from_values(None, Some("1")));
+        assert!(host_tools_allowed_from_values(Some("1"), Some("1")));
         assert!(host_tools_allowed_from_values(Some("0"), Some("1")));
     }
 
     #[test]
-    fn command_metadata_blocks_guarded_capabilities() {
+    fn privileged_host_changes_still_require_safe_mode_off() {
+        assert!(!privileged_host_tools_allowed_from_values(None, Some("1")));
+        assert!(!privileged_host_tools_allowed_from_values(Some("1"), Some("1")));
+        assert!(privileged_host_tools_allowed_from_values(Some("0"), Some("1")));
+    }
+
+    #[test]
+    fn command_metadata_blocks_untrusted_capabilities() {
         let safe =
             capability_denial_message_from_values("python", "host.exec", None, None).unwrap();
-        assert!(safe.contains("disabled by safe boot profile"));
+        assert!(safe.contains("PHASE1_ALLOW_HOST_TOOLS"));
 
         let host =
             capability_denial_message_from_values("browser", "host.net", Some("0"), None).unwrap();
         assert!(host.contains("PHASE1_ALLOW_HOST_TOOLS"));
 
         assert!(
-            capability_denial_message_from_values("python", "host.exec", Some("0"), Some("1"))
+            capability_denial_message_from_values("python", "host.exec", None, Some("1"))
                 .is_none()
         );
+        assert!(
+            capability_denial_message_from_values("python", "host.exec", Some("1"), Some("1"))
+                .is_none()
+        );
+
+        let admin_safe =
+            capability_denial_message_from_values("wifi-connect", "net.admin", None, Some("1"))
+                .unwrap();
+        assert!(admin_safe.contains("safe mode off"));
+
         assert!(capability_denial_message_from_values(
             "wifi-connect",
             "net.admin",
@@ -169,5 +230,6 @@ mod tests {
     fn security_report_mentions_metadata_enforcement() {
         let out = security_report(false, "memory-only");
         assert!(out.contains("capability metadata : enforced"));
+        assert!(out.contains("guarded runtime exec"));
     }
 }

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -114,15 +114,15 @@ fn capability_denial_message_from_values(
                 )
             })
         }
-        "net.admin" => (!privileged_host_tools_allowed_from_values(safe_mode, host_tools)).then(
-            || {
+        "net.admin" => {
+            (!privileged_host_tools_allowed_from_values(safe_mode, host_tools)).then(|| {
                 privileged_denial_message_from_values(
                     command,
                     safe_mode_from_value(safe_mode),
                     host_tools_from_value(host_tools),
                 )
-            },
-        ),
+            })
+        }
         _ => None,
     }
 }
@@ -163,8 +163,8 @@ fn privileged_denial_message_from_values(
 mod tests {
     use super::{
         capability_denial_message_from_values, guarded_host_execution_allowed_from_values,
-        host_tools_allowed_from_values, host_tools_from_value, privileged_host_tools_allowed_from_values,
-        safe_mode_from_value, security_report,
+        host_tools_allowed_from_values, host_tools_from_value,
+        privileged_host_tools_allowed_from_values, safe_mode_from_value, security_report,
     };
 
     #[test]
@@ -184,8 +184,14 @@ mod tests {
     #[test]
     fn privileged_host_changes_still_require_safe_mode_off() {
         assert!(!privileged_host_tools_allowed_from_values(None, Some("1")));
-        assert!(!privileged_host_tools_allowed_from_values(Some("1"), Some("1")));
-        assert!(privileged_host_tools_allowed_from_values(Some("0"), Some("1")));
+        assert!(!privileged_host_tools_allowed_from_values(
+            Some("1"),
+            Some("1")
+        ));
+        assert!(privileged_host_tools_allowed_from_values(
+            Some("0"),
+            Some("1")
+        ));
     }
 
     #[test]
@@ -198,10 +204,7 @@ mod tests {
             capability_denial_message_from_values("browser", "host.net", Some("0"), None).unwrap();
         assert!(host.contains("PHASE1_ALLOW_HOST_TOOLS"));
 
-        assert!(
-            capability_denial_message_from_values("python", "host.exec", None, Some("1"))
-                .is_none()
-        );
+        assert!(capability_denial_message_from_values("python", "host.exec", None, Some("1")).is_none());
         assert!(
             capability_denial_message_from_values("python", "host.exec", Some("1"), Some("1"))
                 .is_none()

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -133,7 +133,11 @@ fn guarded_execute(request: UpdateRequest) -> String {
     if !crate::policy::privileged_host_tools_allowed() {
         let denial = crate::policy::capability_denial_message("update", "net.admin")
             .unwrap_or_else(|| crate::policy::host_denial_message("update"));
-        return format!("update: {}\n{}", denial, plan(request.target, request.build));
+        return format!(
+            "update: {}\n{}",
+            denial,
+            plan(request.target, request.build)
+        );
     }
 
     let target = request.target;

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -130,12 +130,10 @@ fn guarded_execute(request: UpdateRequest) -> String {
             plan(request.target, request.build)
         );
     }
-    if !crate::policy::host_tools_allowed() {
-        return format!(
-            "update: {}\n{}",
-            crate::policy::host_denial_message("update"),
-            plan(request.target, request.build)
-        );
+    if !crate::policy::privileged_host_tools_allowed() {
+        let denial = crate::policy::capability_denial_message("update", "net.admin")
+            .unwrap_or_else(|| crate::policy::host_denial_message("update"));
+        return format!("update: {}\n{}", denial, plan(request.target, request.build));
     }
 
     let target = request.target;
@@ -489,10 +487,12 @@ mod tests {
     #[test]
     fn update_now_trust_still_requires_safe_mode_off() {
         std::env::remove_var("PHASE1_SAFE_MODE");
-        std::env::remove_var("PHASE1_ALLOW_HOST_TOOLS");
+        std::env::set_var("PHASE1_ALLOW_HOST_TOOLS", "1");
         let out = run(&["now".to_string(), "--trust-host".to_string()]);
-        assert!(out.contains("disabled by safe boot profile"));
+        assert!(out.contains("blocked by safe boot profile"));
+        assert!(out.contains("privileged host changes require safe mode off"));
         assert!(out.contains("update latest --trust-host --execute --build"));
+        std::env::remove_var("PHASE1_SAFE_MODE");
         std::env::remove_var("PHASE1_ALLOW_HOST_TOOLS");
     }
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -130,8 +130,8 @@ fn secure_default_blocks_host_backed_commands() {
             "wifi-scan: disabled by safe boot profile",
             "wifi-connect: disabled by safe boot profile",
             "ping: disabled by safe boot profile",
-            "browser: disabled by safe boot profile",
-            "python: disabled by safe boot profile",
+            "browser: disabled; enable the trust gate with PHASE1_ALLOW_HOST_TOOLS=1",
+            "python: disabled; enable the trust gate with PHASE1_ALLOW_HOST_TOOLS=1",
         ],
     );
     assert!(
@@ -151,8 +151,8 @@ fn safe_off_without_host_tools_still_blocks_host_commands() {
             "security   host bridge",
             "security mode       : host-capable",
             "host tools          : off",
-            "python: disabled; set PHASE1_ALLOW_HOST_TOOLS=1 to enable trusted host tools",
-            "browser: disabled; set PHASE1_ALLOW_HOST_TOOLS=1 to enable trusted host tools",
+            "python: disabled; enable the trust gate with PHASE1_ALLOW_HOST_TOOLS=1",
+            "browser: disabled; enable the trust gate with PHASE1_ALLOW_HOST_TOOLS=1",
         ],
     );
     assert!(
@@ -372,7 +372,7 @@ fn user_env_browser_and_sandbox_commands_work() {
             "uid=0(root)",
             "phase1",
             "PHASE1",
-            "browser: disabled by safe boot profile",
+            "browser: disabled; enable the trust gate with PHASE1_ALLOW_HOST_TOOLS=1",
             "sandbox: VFS/processes are simulated",
             "up ",
         ],


### PR DESCRIPTION
## Summary
- Split host policy into guarded runtime execution vs privileged host mutation.
- Allow guarded host/runtime commands with safe mode still enabled when `PHASE1_ALLOW_HOST_TOOLS=1` is set.
- Keep privileged host mutations behind safe mode off + trust gate; network changes still require `PHASE1_ALLOW_HOST_NETWORK_CHANGES=1`.
- Improve `lang run` with configurable timeouts, `--stdin`, `--stdin-file`, temp HOME/TMPDIR workspace, promptless host-tool env vars, audit metadata, and clearer security reporting.
- Update SECURITY.md so the docs no longer imply users must disable all security just to test Python/language runtimes.

## Notes
This remains a guardrail layer, not a VM/chroot/hardened sandbox. The preferred development path is now `lang run ...`; legacy direct `python`/`gcc` wrappers should be migrated to the same runtime helper in a follow-up.

## Testing
Not run locally through the connector.