### PR TITLE
Checkpoint edge 4.3.0-dev version and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v4.3.0-dev Edge Checkpoint
+
+- Moved the active package line from stable `4.2.0` to edge `4.3.0-dev`.
+- Preserved `v4.2.0` as the stable public representation, `v4.1.0` as previous stable, and `v3.6.0` as compatibility base.
+- Checkpointed guarded host runtime execution so trusted language/runtime commands can run with safe mode still enabled while privileged host mutation remains gated.
+- Checkpointed compact dynamic prompt chips across mobile, laptop, and desktop modes: `phase1://root ~ [edge safe trust] ⇢`.
+- Checkpointed mobile-safe line editing and collision-safe WASM test fixtures.
+
 # v4.2.0 Stable
 
 - Promoted Phase1 v4.2.0 from development checkpoint to stable representation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 
 [[package]]
 name = "phase1"
-version = "4.2.0"
+version = "4.3.0-dev"
 
 [[package]]
 name = "phase1-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phase1"
-version = "4.2.0"
+version = "4.3.0-dev"
 edition = "2021"
 default-run = "phase1"
 authors = ["Chase Bryan"]

--- a/DEVELOPMENT_CHECKPOINT_EDGE_4_3_0_DEV.md
+++ b/DEVELOPMENT_CHECKPOINT_EDGE_4_3_0_DEV.md
@@ -1,0 +1,50 @@
+# Development Checkpoint: Edge 4.3.0-dev
+
+This checkpoint records the first active edge line after the stable `v4.2.0` public representation.
+
+## Version identity
+
+| Item | Value |
+| --- | --- |
+| Active package version | `4.3.0-dev` |
+| Edge label | `v4.3.0-dev` |
+| Stable release point | `v4.2.0` |
+| Previous stable | `v4.1.0` |
+| Compatibility base | `v3.6.0` |
+| Version scheme | `MAJOR.MINOR.PATCH[-dev]` |
+
+## Checkpoint scope
+
+This checkpoint includes the post-`v4.2.0` work that improves Phase1 for real local development and mobile operator usage:
+
+- Guarded host runtime execution is separated from privileged host mutation.
+- `PHASE1_ALLOW_HOST_TOOLS=1` can enable guarded language/runtime execution while safe mode remains enabled.
+- Privileged host mutation still requires safe mode off plus the trust gate.
+- `lang run` supports guarded temporary workspaces, bounded stdin, timeout controls, promptless host-tool environment variables, redacted output, and audit metadata.
+- Mobile/narrow terminals use a simple line-editor path to avoid prompt redraw scroll, NUL padding, and paste artifacts.
+- The default prompt now uses compact dynamic chips across all device modes, such as `phase1://root ~ [edge safe trust] ⇢`.
+- The legacy HUD prompt can still be restored with `PHASE1_COMPACT_PROMPT=0`.
+- WASM test fixture directories are unique per process and counter to avoid parallel test collisions.
+
+## Validation target
+
+Before merging future edge work, keep this validation set green:
+
+```bash
+cargo fmt --all -- --check
+cargo check --workspace --all-targets
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --all-targets
+sh scripts/quality-check.sh quick
+sh scripts/test-release-metadata.sh
+sh scripts/test-website.sh
+```
+
+## Roadmap notes
+
+Recommended follow-up work after this checkpoint:
+
+1. Migrate direct `python`, `py`, `gcc`, and `cc` wrappers onto the same guarded runtime helper used by `lang run`.
+2. Add `doctor mobile` for terminal width, prompt mode, line-editor mode, color mode, safe mode, trust gate, and launch advice.
+3. Add named boot profiles for phone, laptop development, release demo, and trusted-runtime workflows.
+4. Continue keeping `v4.2.0` stable docs intact until the next formal stable promotion.

--- a/EDGE.md
+++ b/EDGE.md
@@ -1,16 +1,28 @@
 # Phase1 Edge Development
 
-`v4.3.0-dev` is the next development line after the stable `v4.2.0` release point.
+`v4.3.0-dev` is the active development line after the stable `v4.2.0` release point.
 
 ## Current identity
 
 | Item | Value |
 | --- | --- |
+| Current package version | `4.3.0-dev` |
+| Current edge label | `v4.3.0-dev` |
 | Stable package version | `4.2.0` |
 | Stable release point | `v4.2.0` |
 | Previous stable | `v4.1.0` |
 | Compatibility base | `v3.6.0` |
-| Next development package version | `4.3.0-dev` |
+
+## Current checkpoint
+
+The current edge checkpoint includes the post-`v4.2.0` development work that made Phase1 more practical from mobile and trusted-host workflows:
+
+- Guarded host runtime execution can run with safe mode still enabled when the host trust gate is explicit.
+- Privileged host mutation remains behind safe mode off plus the trust gate.
+- `lang run` has bounded stdin, timeout controls, guarded temporary workspaces, promptless host-tool environment, and audit metadata.
+- Mobile and narrow-terminal input uses a simple line editor path to avoid prompt repaint/NUL-padding artifacts.
+- The prompt now defaults to compact dynamic status chips across all modes, for example `phase1://root ~ [edge safe trust] ⇢`.
+- WASM test fixture directories are collision-safe under parallel test execution.
 
 ## Development rules
 

--- a/site.js
+++ b/site.js
@@ -213,7 +213,7 @@ const demoResponses = {
     "phase1 // advanced operator kernel",
     "stable: v4.2.0",
     "previous stable: v4.1.0",
-    "next edge: v4.2.0",
+    "next edge: v4.3.0-dev",
     "compatibility base: v3.6.0",
     "language: Rust",
   ].join("\n"),
@@ -228,7 +228,7 @@ const demoResponses = {
   "wiki-quick": [
     "wiki-quick:",
     "  1. clone the repo",
-    "  2. choose release/v4.1.0 for stable or edge/v4.2.0 for bleeding edge",
+    "  2. use v4.2.0 for stable or v4.3.0-dev for active edge development",
     "  3. run cargo run",
     "  4. type help, security, sysinfo, wiki",
     "  5. keep safe mode on unless you trust the host workflow",

--- a/src/release.rs
+++ b/src/release.rs
@@ -3,11 +3,17 @@ use crate::kernel::VERSION;
 pub const STABLE_VERSION: &str = "4.2.0";
 pub const COMPATIBILITY_BASE: &str = "3.6.0";
 pub const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
-pub const CHANNEL: &str = "stable";
+pub const CHANNEL: &str = "edge";
 pub const UPDATE_PROTOCOL_FILE: &str = "UPDATE_PROTOCOL.md";
 pub const VERSION_SCHEME: &str = "MAJOR.MINOR.PATCH[-dev]";
 
 const BLEEDING_FEATURES: &[&str] = &[
+    "guarded host runtime execution with safe mode still enabled under explicit trust",
+    "privileged host mutation remains behind safe mode off plus the trust gate",
+    "lang run guarded workspaces with bounded stdin, timeout controls, and audit metadata",
+    "compact dynamic prompt chips across mobile, laptop, and desktop modes",
+    "mobile-safe simple line editor path for narrow terminals",
+    "collision-safe WASM test fixtures for parallel validation",
     "persistent shell history with private-value redaction",
     "structured shell command chains",
     "structured text pipelines",
@@ -30,6 +36,9 @@ const BLEEDING_FEATURES: &[&str] = &[
 ];
 
 const ROADMAP_STATUS: &[(&str, &str)] = &[
+    ("Guarded host runtime execution", "complete: trusted runtime commands can run while safe mode remains enabled"),
+    ("Compact dynamic prompt", "complete: prompt chips show edge/release, safe/host, and trust/no-trust across all modes"),
+    ("Mobile-safe line editing", "complete: mobile terminals use a simple paste-safe input path by default"),
     ("Persistent shell history", "complete"),
     ("Structured command output and pipelines", "complete"),
     (
@@ -97,7 +106,7 @@ pub fn version_report(args: &[String]) -> String {
     out.push_str(&format!("channel         : {}\n", CHANNEL));
     out.push_str(&format!("version scheme  : {}\n", VERSION_SCHEME));
     out.push_str(&format!("protocol file   : {}\n", UPDATE_PROTOCOL_FILE));
-    out.push_str("\nstable v4.2.0 validated capabilities:\n");
+    out.push_str("\nedge v4.3.0-dev checkpoint capabilities:\n");
     for feature in BLEEDING_FEATURES {
         out.push_str("  - ");
         out.push_str(feature);
@@ -140,6 +149,9 @@ mod tests {
         assert!(out.contains("stable version"));
         assert!(out.contains(VERSION_SCHEME));
         assert!(out.contains(UPDATE_PROTOCOL_FILE));
+        assert!(out.contains("guarded host runtime execution"));
+        assert!(out.contains("compact dynamic prompt chips"));
+        assert!(out.contains("mobile-safe simple line editor"));
         assert!(out.contains("structured text pipelines"));
         assert!(out.contains("patch-level SemVer"));
         assert!(out.contains("metadata-backed capability enforcement"));
@@ -166,6 +178,9 @@ mod tests {
         let out = roadmap_report();
         assert!(out.contains("current"));
         assert!(out.contains("stable"));
+        assert!(out.contains("Guarded host runtime execution"));
+        assert!(out.contains("Compact dynamic prompt"));
+        assert!(out.contains("Mobile-safe line editing"));
         assert!(out.contains("Structured command output and pipelines"));
         assert!(out.contains("Update protocol and semantic patch versioning"));
         assert!(out.contains("Capability enforcement based on command metadata"));

--- a/tests/release_metadata.rs
+++ b/tests/release_metadata.rs
@@ -87,7 +87,7 @@ fn edge_checkpoint_records_current_dev_boundary() {
         STABLE_VERSION,
         PREVIOUS_STABLE,
         COMPATIBILITY_BASE,
-        "guarded host runtime execution",
+        "Guarded host runtime execution",
         "compact dynamic chips",
         "Mobile/narrow terminals",
         "PHASE1_COMPACT_PROMPT=0",

--- a/tests/release_metadata.rs
+++ b/tests/release_metadata.rs
@@ -6,6 +6,7 @@ const STABLE_VERSION: &str = "v4.2.0";
 const STABLE_PACKAGE_VERSION: &str = "4.2.0";
 const PREVIOUS_STABLE: &str = "v4.1.0";
 const COMPATIBILITY_BASE: &str = "v3.6.0";
+const EDGE_CHECKPOINT: &str = "DEVELOPMENT_CHECKPOINT_EDGE_4_3_0_DEV.md";
 
 #[test]
 fn cargo_metadata_matches_current_track() {
@@ -73,6 +74,32 @@ fn edge_track_is_documented_when_package_is_dev() {
 }
 
 #[test]
+fn edge_checkpoint_records_current_dev_boundary() {
+    let cargo_toml = read("Cargo.toml");
+    if !is_edge_track(&cargo_toml) {
+        return;
+    }
+
+    let checkpoint = read(EDGE_CHECKPOINT);
+    for expected in [
+        EDGE_VERSION,
+        EDGE_PACKAGE_VERSION,
+        STABLE_VERSION,
+        PREVIOUS_STABLE,
+        COMPATIBILITY_BASE,
+        "guarded host runtime execution",
+        "compact dynamic chips",
+        "Mobile/narrow terminals",
+        "PHASE1_COMPACT_PROMPT=0",
+    ] {
+        assert!(
+            checkpoint.contains(expected),
+            "{EDGE_CHECKPOINT} is missing checkpoint marker {expected}"
+        );
+    }
+}
+
+#[test]
 fn compatibility_base_remains_documented() {
     for path in ["README.md", "site.js"] {
         let text = read(path);
@@ -88,7 +115,9 @@ fn website_demo_reports_current_stable_track() {
     let js = read("site.js");
     assert!(has_line(&js, "    \"stable: v4.2.0\","));
     assert!(has_line(&js, "    \"previous stable: v4.1.0\","));
+    assert!(has_line(&js, "    \"next edge: v4.3.0-dev\","));
     assert!(!has_line(&js, "    \"stable: v4.1.0\","));
+    assert!(!has_line(&js, "    \"next edge: v4.2.0\","));
 }
 
 #[test]
@@ -113,8 +142,14 @@ fn is_edge_track(cargo_toml: &str) -> bool {
     cargo_toml.contains("version = \"4.3.0-dev\"")
 }
 
-fn edge_facing_files() -> [&'static str; 3] {
-    ["README.md", "EDGE.md", "site.js"]
+fn edge_facing_files() -> [&'static str; 5] {
+    [
+        "README.md",
+        "EDGE.md",
+        "CHANGELOG.md",
+        "site.js",
+        EDGE_CHECKPOINT,
+    ]
 }
 
 fn release_facing_files() -> [&'static str; 3] {


### PR DESCRIPTION
## Summary
- Bump the active package and lockfile version from `4.2.0` to `4.3.0-dev` for the new edge development line.
- Keep `v4.2.0` stable, `v4.1.0` previous stable, and `v3.6.0` compatibility-base references intact.
- Update `EDGE.md`, `CHANGELOG.md`, `site.js`, and `src/release.rs` so public docs, website demo text, `version --compare`, and `roadmap` all describe the current edge checkpoint consistently.
- Add `DEVELOPMENT_CHECKPOINT_EDGE_4_3_0_DEV.md` to record the guarded runtime, compact prompt, mobile-safe line editor, and WASM fixture checkpoint.
- Strengthen release metadata tests so the edge checkpoint file is required whenever the package is on `4.3.0-dev`.

## Validation target
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `sh scripts/test-release-metadata.sh`
- `sh scripts/test-website.sh`