### PR TITLE
Add guarded operator host passthrough

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -432,6 +432,9 @@ pub fn dispatch(shell: &mut Phase1Shell, cmd: &str, args: &[String]) {
                 );
             }
         }
+        "git" | "gh" | "cargo" | "rustc" | "python3" => {
+            run_guarded_host_passthrough(shell, command, args)
+        }
         "python" => run_python(shell, args),
         "gcc" => run_c(shell, args),
         "plugins" => print!("{}", shell.list_plugins()),
@@ -623,6 +626,63 @@ fn spawn(shell: &mut Phase1Shell, args: &[String]) {
         Ok(pid) => println!("spawned pid {}", pid),
         Err(err) => println!("spawn: {}", err),
     }
+}
+
+
+fn run_guarded_host_passthrough(shell: &mut Phase1Shell, tool: &str, args: &[String]) {
+    if !is_host_passthrough_tool(tool) {
+        println!("{tool}: not an approved host passthrough tool");
+        return;
+    }
+
+    if host_tools_blocked() {
+        println!("{}", crate::policy::host_denial_message(tool));
+        return;
+    }
+
+    if let Some(arg) = args.iter().find(|arg| !is_safe_host_passthrough_arg(arg)) {
+        println!("{tool}: blocked unsafe argument: {arg}");
+        return;
+    }
+
+    shell
+        .kernel
+        .audit
+        .record(format!("host.passthrough tool={tool} argc={}", args.len()));
+
+    let mut cmd = Command::new(tool);
+    cmd.args(args);
+
+    match run_command(cmd, host_passthrough_timeout(tool)) {
+        Ok(output) => print_output(output),
+        Err(err) => println!("{tool}: {err}"),
+    }
+}
+
+fn is_host_passthrough_tool(tool: &str) -> bool {
+    matches!(tool, "git" | "gh" | "cargo" | "rustc" | "python3")
+}
+
+fn host_passthrough_timeout(tool: &str) -> Duration {
+    match tool {
+        "cargo" => Duration::from_secs(180),
+        "git" | "gh" => Duration::from_secs(60),
+        _ => Duration::from_secs(30),
+    }
+}
+
+fn is_safe_host_passthrough_arg(arg: &str) -> bool {
+    !arg.is_empty()
+        && !arg.contains('\0')
+        && !arg.contains('\n')
+        && !arg.contains('\r')
+        && !arg.contains(';')
+        && !arg.contains('|')
+        && !arg.contains('&')
+        && !arg.contains('<')
+        && !arg.contains('>')
+        && !arg.contains('`')
+        && !arg.contains("$(")
 }
 
 fn run_python(shell: &mut Phase1Shell, args: &[String]) {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -58,6 +58,11 @@ pub const COMMANDS: &[CommandSpec] = &[
     cmd!("ping", &[], "net", "ping <host>", "Run bounded host ping only when trusted host tools are enabled.", "net.read"),
     cmd!("nmcli", &[], "net", "nmcli", "Show NetworkManager state on Linux only when trusted host tools are enabled.", "net.read"),
     cmd!("browser", &[], "host", "browser <url|phase1|about>", "Fetch and render HTTP/HTTPS text using guarded curl.", "host.net"),
+    cmd!("git", &[], "host", "git <args...>", "Run host Git through guarded operator passthrough at any Phase1 nest level.", "host.exec"),
+    cmd!("gh", &["github"], "host", "gh <args...>", "Run GitHub CLI through guarded operator passthrough at any Phase1 nest level.", "host.exec"),
+    cmd!("cargo", &[], "host", "cargo <args...>", "Run host Cargo through guarded operator passthrough at any Phase1 nest level.", "host.exec"),
+    cmd!("rustc", &[], "host", "rustc <args...>", "Run host rustc through guarded operator passthrough at any Phase1 nest level.", "host.exec"),
+    cmd!("python3", &[], "host", "python3 <args...>", "Run host Python 3 through guarded operator passthrough at any Phase1 nest level.", "host.exec"),
     cmd!("python", &["py"], "host", "python <file.py> | python -c <code>", "Run Python with a timeout.", "host.exec"),
     cmd!("gcc", &["cc"], "host", "gcc <file.c> | gcc <code>", "Compile and run C with host compiler timeout guards.", "host.exec"),
     cmd!("plugins", &["plugin"], "host", "plugins", "List Python and WASI-lite plugins in ./plugins.", "host.exec"),
@@ -320,6 +325,16 @@ mod tests {
         assert!(completions("a").contains(&"avim"));
         assert!(completions("v").contains(&"vim"));
         assert!(completions("la").contains(&"lang"));
+    }
+
+    #[test]
+    fn host_passthrough_commands_are_registered() {
+        for name in ["git", "gh", "cargo", "rustc", "python3"] {
+            let cmd = lookup(name).expect("host passthrough command registered");
+            assert_eq!(cmd.category, "host");
+            assert_eq!(cmd.capability, "host.exec");
+        }
+        assert_eq!(canonical_name("github"), Some("gh"));
     }
 
     #[test]


### PR DESCRIPTION
Adds native guarded passthrough for git, gh, cargo, rustc, and python3 from inside Phase1 at any nested level. Uses direct command arguments without shell passthrough, requires PHASE1_ALLOW_HOST_TOOLS=1, remains safe-mode compatible, and keeps host execution auditable.