### PR TITLE
Guard host passthrough stdin

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -652,6 +652,7 @@ fn run_guarded_host_passthrough(shell: &mut Phase1Shell, tool: &str, args: &[Str
 
     let mut cmd = Command::new(tool);
     cmd.args(args);
+    cmd.stdin(Stdio::null());
 
     match run_command(cmd, host_passthrough_timeout(tool)) {
         Ok(output) => print_output(output),


### PR DESCRIPTION
Prevents guarded host passthrough commands from consuming later pasted Phase1 commands by forcing stdin to null for git, gh, cargo, rustc, and python3. This keeps multi-line operator paste behavior stable at any nested level.