### PR TITLE
Add Go operator support for Jesse

### DIFF
--- a/JESSE_GO_TESTING.md
+++ b/JESSE_GO_TESTING.md
@@ -1,0 +1,29 @@
+# Jesse Go Testing Guide
+
+Phase1 Go support is available in two layers:
+
+1. `lang run go` for guarded temporary-workspace execution from the Phase1 VFS.
+2. `go <args...>` for guarded host Go tool passthrough at any Phase1 nest level.
+
+## Quick Go smoke test inside Phase1
+
+```text
+go version
+lang doctor go
+echo 'package main; import "fmt"; func main() { fmt.Println("hello Jesse from Go inside Phase1") }' > jesse.go
+lang run go jesse.go
+```
+
+Expected result:
+
+```text
+hello Jesse from Go inside Phase1
+```
+
+## Safety model
+
+- Go uses the host Go toolchain.
+- Phase1 does not yet contain its own Go compiler.
+- Commands are passed directly without a shell.
+- Host tool access requires `PHASE1_ALLOW_HOST_TOOLS=1`.
+- Safe mode may stay enabled for guarded runtime workflows.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -432,7 +432,7 @@ pub fn dispatch(shell: &mut Phase1Shell, cmd: &str, args: &[String]) {
                 );
             }
         }
-        "git" | "gh" | "cargo" | "rustc" | "python3" => {
+        "git" | "gh" | "cargo" | "rustc" | "python3" | "go" => {
             run_guarded_host_passthrough(shell, command, args)
         }
         "python" => run_python(shell, args),
@@ -628,7 +628,6 @@ fn spawn(shell: &mut Phase1Shell, args: &[String]) {
     }
 }
 
-
 fn run_guarded_host_passthrough(shell: &mut Phase1Shell, tool: &str, args: &[String]) {
     if !is_host_passthrough_tool(tool) {
         println!("{tool}: not an approved host passthrough tool");
@@ -652,6 +651,7 @@ fn run_guarded_host_passthrough(shell: &mut Phase1Shell, tool: &str, args: &[Str
 
     let mut cmd = Command::new(tool);
     cmd.args(args);
+    cmd.stdin(Stdio::null());
 
     match run_command(cmd, host_passthrough_timeout(tool)) {
         Ok(output) => print_output(output),
@@ -660,12 +660,13 @@ fn run_guarded_host_passthrough(shell: &mut Phase1Shell, tool: &str, args: &[Str
 }
 
 fn is_host_passthrough_tool(tool: &str) -> bool {
-    matches!(tool, "git" | "gh" | "cargo" | "rustc" | "python3")
+    matches!(tool, "git" | "gh" | "cargo" | "rustc" | "python3" | "go")
 }
 
 fn host_passthrough_timeout(tool: &str) -> Duration {
     match tool {
         "cargo" => Duration::from_secs(180),
+        "go" => Duration::from_secs(120),
         "git" | "gh" => Duration::from_secs(60),
         _ => Duration::from_secs(30),
     }

--- a/src/languages.rs
+++ b/src/languages.rs
@@ -798,7 +798,11 @@ fn find_tool(tools: &'static [&'static str]) -> Option<&'static str> {
 
 fn tool_version(tool: &str) -> String {
     let mut cmd = Command::new(tool);
-    cmd.arg("--version");
+    if tool == "go" {
+        cmd.arg("version");
+    } else {
+        cmd.arg("--version");
+    }
     match run_command(cmd, Duration::from_secs(3), None) {
         Ok(output) => first_line(&format_output(output)),
         Err(_) => "version unavailable".to_string(),

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -63,6 +63,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     cmd!("cargo", &[], "host", "cargo <args...>", "Run host Cargo through guarded operator passthrough at any Phase1 nest level.", "host.exec"),
     cmd!("rustc", &[], "host", "rustc <args...>", "Run host rustc through guarded operator passthrough at any Phase1 nest level.", "host.exec"),
     cmd!("python3", &[], "host", "python3 <args...>", "Run host Python 3 through guarded operator passthrough at any Phase1 nest level.", "host.exec"),
+    cmd!("go", &["golang"], "host", "go <args...>", "Run host Go tooling through guarded operator passthrough at any Phase1 nest level.", "host.exec"),
     cmd!("python", &["py"], "host", "python <file.py> | python -c <code>", "Run Python with a timeout.", "host.exec"),
     cmd!("gcc", &["cc"], "host", "gcc <file.c> | gcc <code>", "Compile and run C with host compiler timeout guards.", "host.exec"),
     cmd!("plugins", &["plugin"], "host", "plugins", "List Python and WASI-lite plugins in ./plugins.", "host.exec"),
@@ -329,12 +330,13 @@ mod tests {
 
     #[test]
     fn host_passthrough_commands_are_registered() {
-        for name in ["git", "gh", "cargo", "rustc", "python3"] {
+        for name in ["git", "gh", "cargo", "rustc", "python3", "go"] {
             let cmd = lookup(name).expect("host passthrough command registered");
             assert_eq!(cmd.category, "host");
             assert_eq!(cmd.capability, "host.exec");
         }
         assert_eq!(canonical_name("github"), Some("gh"));
+        assert_eq!(canonical_name("golang"), Some("go"));
     }
 
     #[test]


### PR DESCRIPTION
Adds guarded direct Go host passthrough, keeps existing lang run go workflow, fixes Go doctor output, closes passthrough stdin to protect multi-line Phase1 pastes, and adds a Jesse-focused Go testing guide.