### PR TITLE
Add Phase1 self development dock

### DIFF
--- a/DEV_DOCK.md
+++ b/DEV_DOCK.md
@@ -1,0 +1,31 @@
+# Phase1 Dev Dock
+
+dev lets Phase1 work on itself from inside Phase1.
+
+## Start
+
+Run Phase1 with guarded host tools:
+
+PHASE1_SAFE_MODE=1 PHASE1_ALLOW_HOST_TOOLS=1 cargo run
+
+## Commands inside Phase1
+
+dev status
+dev sync
+dev branch feature/example
+dev quick
+dev test
+dev commit Add example feature
+dev push
+dev pr Add example feature
+dev merge 123
+dev close 123
+dev doctor
+
+## Safety
+
+- Uses guarded host tools.
+- Safe mode can stay enabled.
+- Intended for Phase1 self-development.
+- Avoids staging runtime files like phase1.history, phase1.state, phase1.log, and phase1.learn.
+- Keeps normal copy/paste development workflows inside Phase1.

--- a/plugins/dev.py
+++ b/plugins/dev.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXCLUDED = {
+    "phase1.history",
+    "phase1.state",
+    "phase1.log",
+    "phase1.learn",
+}
+EXCLUDED_PREFIXES = ("target/", ".git/")
+
+
+def run(args: list[str], check: bool = True) -> int:
+    print("+", shlex.join(args))
+    proc = subprocess.run(args, cwd=ROOT)
+    if check and proc.returncode != 0:
+        raise SystemExit(proc.returncode)
+    return proc.returncode
+
+
+def output(args: list[str]) -> str:
+    return subprocess.check_output(args, cwd=ROOT, text=True).strip()
+
+
+def help_text() -> str:
+    return """Phase1 Dev Dock
+
+dev status
+dev sync
+dev branch <name>
+dev quick
+dev test
+dev commit <message>
+dev push
+dev pr <title>
+dev merge <number>
+dev close <number>
+dev doctor
+"""
+
+
+def assert_repo() -> None:
+    if not (ROOT / "Cargo.toml").exists() or not (ROOT / "src").exists():
+        raise SystemExit("dev: not running inside the Phase1 repository")
+
+
+def current_branch() -> str:
+    return output(["git", "branch", "--show-current"])
+
+
+def safe_changed_paths() -> list[str]:
+    raw = output(["git", "status", "--porcelain"])
+    paths: list[str] = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        path = line[3:].strip()
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1].strip()
+        if path in EXCLUDED or path.startswith(EXCLUDED_PREFIXES):
+            continue
+        paths.append(path)
+    return paths
+
+
+def cmd_status() -> int:
+    run(["git", "status", "-sb"], check=False)
+    run(["gh", "pr", "list"], check=False)
+    run(["cargo", "--version"], check=False)
+    run(["rustc", "--version"], check=False)
+    run(["go", "version"], check=False)
+    return 0
+
+
+def cmd_sync() -> int:
+    run(["git", "checkout", "master"])
+    run(["git", "pull", "--ff-only"])
+    return 0
+
+
+def cmd_branch(args: list[str]) -> int:
+    if not args:
+        print("dev branch <name>")
+        return 2
+    run(["git", "checkout", "-B", args[0]])
+    return 0
+
+
+def cmd_quick() -> int:
+    run(["cargo", "fmt", "--all", "--", "--check"])
+    run(["cargo", "test", "-p", "phase1", "--bin", "phase1"])
+    return 0
+
+
+def cmd_test() -> int:
+    run(["cargo", "fmt", "--all", "--", "--check"])
+    run(["cargo", "test", "--workspace", "--all-targets"])
+    return 0
+
+
+def cmd_commit(args: list[str]) -> int:
+    message = " ".join(args).strip()
+    if not message:
+        print("dev commit <message>")
+        return 2
+
+    paths = safe_changed_paths()
+    if not paths:
+        print("dev: no safe changed files to commit")
+        return 0
+
+    run(["git", "add", *paths])
+    run(["git", "commit", "-m", message])
+    return 0
+
+
+def cmd_push() -> int:
+    branch = current_branch()
+    if not branch:
+        print("dev: no current branch")
+        return 2
+    run(["git", "push", "-u", "origin", branch])
+    return 0
+
+
+def cmd_pr(args: list[str]) -> int:
+    title = " ".join(args).strip()
+    if not title:
+        print("dev pr <title>")
+        return 2
+    branch = current_branch()
+    run([
+        "gh",
+        "pr",
+        "create",
+        "--title",
+        title,
+        "--body",
+        f"{title}. Created from inside Phase1 Dev Dock.",
+        "--base",
+        "master",
+        "--head",
+        branch,
+    ])
+    return 0
+
+
+def cmd_merge(args: list[str]) -> int:
+    if not args:
+        print("dev merge <number>")
+        return 2
+    run(["gh", "pr", "merge", args[0], "--squash"])
+    run(["git", "checkout", "master"])
+    run(["git", "pull", "--ff-only"])
+    return 0
+
+
+def cmd_close(args: list[str]) -> int:
+    if not args:
+        print("dev close <number>")
+        return 2
+    run(["gh", "pr", "close", args[0]])
+    return 0
+
+
+def cmd_doctor() -> int:
+    assert_repo()
+    for tool in ["git", "gh", "cargo", "rustc", "python3", "go"]:
+        run([tool, "--version"] if tool != "go" else ["go", "version"], check=False)
+    print("dev: doctor complete")
+    return 0
+
+
+def main() -> int:
+    assert_repo()
+    args = sys.argv[1:]
+    if not args or args[0] in {"help", "-h", "--help"}:
+        print(help_text())
+        return 0
+
+    action, rest = args[0], args[1:]
+
+    commands = {
+        "status": lambda: cmd_status(),
+        "sync": lambda: cmd_sync(),
+        "branch": lambda: cmd_branch(rest),
+        "quick": lambda: cmd_quick(),
+        "test": lambda: cmd_test(),
+        "commit": lambda: cmd_commit(rest),
+        "push": lambda: cmd_push(),
+        "pr": lambda: cmd_pr(rest),
+        "merge": lambda: cmd_merge(rest),
+        "close": lambda: cmd_close(rest),
+        "doctor": lambda: cmd_doctor(),
+    }
+
+    if action not in commands:
+        print(f"dev: unknown action: {action}\n")
+        print(help_text())
+        return 2
+
+    return commands[action]()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -435,6 +435,11 @@ pub fn dispatch(shell: &mut Phase1Shell, cmd: &str, args: &[String]) {
         "git" | "gh" | "cargo" | "rustc" | "python3" | "go" => {
             run_guarded_host_passthrough(shell, command, args)
         }
+        "dev" => {
+            if !shell.try_plugin("dev", args) {
+                println!("dev: plugin missing at plugins/dev.py");
+            }
+        }
         "python" => run_python(shell, args),
         "gcc" => run_c(shell, args),
         "plugins" => print!("{}", shell.list_plugins()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1029,7 +1029,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn pasted_command_lines_split_shell_blocks() {
         let lines = super::pasted_command_lines(
             "git status\ngh pr list\ncargo test --workspace --all-targets\nexit all\n",
@@ -1058,6 +1057,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn command_chain_respects_quotes_and_operators() {
         let chain = parse_chain("echo 'a;b' ; unknown && echo no || echo yes").unwrap();
         assert_eq!(chain.len(), 4);

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -72,6 +72,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     cmd!("ned", &["nano", "vi"], "host", "ned <file>", "Edit a VFS file with a small line editor.", "fs.write"),
     cmd!("avim", &["vim", "edit"], "dev", "avim <file>", "Advanced VFS-only modal editor with search, undo, yank/paste, substitute, and a security-focused no-shell-escape design.", "fs.write"),
     cmd!("lang", &["language", "runlang"], "dev", "lang [list|support|status|doctor|detect|run|security]", "Native guarded multi-language runtime manager for major open-source programming languages.", "host.exec"),
+    cmd!("dev", &["dock", "selfdev"], "dev", "dev [status|sync|branch|quick|test|commit|push|pr|merge|close|doctor]", "Phase1 self-development dock for working on Phase1 from inside Phase1.", "host.exec"),
     cmd!("lspci", &[], "arch", "lspci", "List simulated PCIe devices.", "hw.read"),
     cmd!("pcie", &[], "arch", "pcie", "Show PCIe subsystem summary.", "hw.read"),
     cmd!("cr3", &[], "arch", "cr3", "Show simulated CR3 value.", "hw.read"),
@@ -231,6 +232,8 @@ mod tests {
         assert_eq!(lookup("language").map(|cmd| cmd.name), Some("lang"));
         assert_eq!(lookup("status").map(|cmd| cmd.name), Some("capabilities"));
         assert_eq!(lookup("nests").map(|cmd| cmd.name), Some("nest"));
+        assert_eq!(lookup("dock").map(|cmd| cmd.name), Some("dev"));
+        assert_eq!(lookup("selfdev").map(|cmd| cmd.name), Some("dev"));
     }
 
     #[test]
@@ -284,6 +287,7 @@ mod tests {
         assert!(map.contains("wasm"));
         assert!(map.contains("avim"));
         assert!(map.contains("lang"));
+        assert!(map.contains("dev"));
     }
 
     #[test]
@@ -329,6 +333,8 @@ mod tests {
         assert!(completions("a").contains(&"avim"));
         assert!(completions("v").contains(&"vim"));
         assert!(completions("la").contains(&"lang"));
+        assert!(completions("de").contains(&"dev"));
+        assert!(completions("do").contains(&"dock"));
         assert!(completions("ne").contains(&"nest"));
         assert!(completions("ne").contains(&"nests"));
     }


### PR DESCRIPTION
Adds a Phase1 dev dock so Phase1 can work on itself from inside Phase1. Registers dev as a first-class command, routes it through the guarded plugin system, and documents the self-development workflow.