### PR TITLE
Add Phase1 eMacs editor command

### DIFF
--- a/PHASE1_EMACS.md
+++ b/PHASE1_EMACS.md
@@ -1,0 +1,33 @@
+# Phase1 eMacs
+
+Phase1 eMacs is the Phase1-branded advanced editor command.
+
+It is VFS-native and powered by AVIM Pro, so it works inside Phase1 without shell escapes or host file reads.
+
+## Commands
+
+```text
+emacs <file>
+phase1-emacs <file>
+phase1emacs <file>
+pemacs <file>
+emac <file>
+```
+
+## Smoke test inside Phase1
+
+```text
+emacs jesse.go
+:help pro
+:template go
+:wq
+lang run go jesse.go
+```
+
+## Safety model
+
+- Edits Phase1 VFS files.
+- Uses the AVIM Pro engine.
+- No host shell escape.
+- No direct host filesystem read.
+- Safe for nested Phase1 workflows.

--- a/src/main.rs
+++ b/src/main.rs
@@ -481,7 +481,7 @@ fn execute_one(
             let canonical = registry::canonical_name(cmd).unwrap_or(cmd);
             let known = registry::lookup(cmd).is_some()
                 || plugin_exists(shell, canonical)
-                || matches!(canonical, "avim" | "lang" | "opslog");
+                || matches!(canonical, "avim" | "emacs" | "lang" | "opslog");
             match canonical {
                 "help" => ui::print_help(),
                 "accounts" => print!("{}", accounts_report(shell)),
@@ -504,6 +504,7 @@ fn execute_one(
                 "find" => print!("{}", text::find(&shell.kernel.vfs, args)),
                 "matrix" => matrix::run(args),
                 "avim" => avim::edit(&mut shell.kernel.vfs, args),
+                "emacs" => avim::edit(&mut shell.kernel.vfs, args),
                 "lang" => print!("{}", languages::run(shell, args)),
                 "opslog" => print!("{}", ops_log::run(args)),
                 "bootcfg" => handle_bootcfg(boot_config, args),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1030,7 +1030,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn pasted_command_lines_split_shell_blocks() {
         let lines = super::pasted_command_lines(
             "git status\ngh pr list\ncargo test --workspace --all-targets\nexit all\n",
@@ -1059,6 +1058,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn command_chain_respects_quotes_and_operators() {
         let chain = parse_chain("echo 'a;b' ; unknown && echo no || echo yes").unwrap();
         assert_eq!(chain.len(), 4);

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -71,6 +71,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     cmd!("update", &["upgrade"], "host", "update [plan|check|--execute|protocol|test] [latest|stable] [--build]", "Safely plan updates or run developer validation suites; protocol prints patch-versioning rules.", "host.exec"),
     cmd!("ned", &["nano", "vi"], "host", "ned <file>", "Edit a VFS file with a small line editor.", "fs.write"),
     cmd!("avim", &["vim", "edit"], "dev", "avim <file>", "Advanced VFS-only modal editor with search, undo, yank/paste, substitute, and a security-focused no-shell-escape design.", "fs.write"),
+    cmd!("emacs", &["emac", "phase1-emacs", "phase1emacs", "pemacs"], "editor", "emacs <file>", "Phase1 eMacs editor: VFS-native advanced editor powered by AVIM Pro.", "fs.write"),
     cmd!("lang", &["language", "runlang"], "dev", "lang [list|support|status|doctor|detect|run|security]", "Native guarded multi-language runtime manager for major open-source programming languages.", "host.exec"),
     cmd!("lspci", &[], "arch", "lspci", "List simulated PCIe devices.", "hw.read"),
     cmd!("pcie", &[], "arch", "pcie", "Show PCIe subsystem summary.", "hw.read"),
@@ -231,6 +232,10 @@ mod tests {
         assert_eq!(lookup("language").map(|cmd| cmd.name), Some("lang"));
         assert_eq!(lookup("status").map(|cmd| cmd.name), Some("capabilities"));
         assert_eq!(lookup("nests").map(|cmd| cmd.name), Some("nest"));
+        assert_eq!(lookup("emac").map(|cmd| cmd.name), Some("emacs"));
+        assert_eq!(lookup("phase1-emacs").map(|cmd| cmd.name), Some("emacs"));
+        assert_eq!(lookup("phase1emacs").map(|cmd| cmd.name), Some("emacs"));
+        assert_eq!(lookup("pemacs").map(|cmd| cmd.name), Some("emacs"));
     }
 
     #[test]
@@ -327,6 +332,8 @@ mod tests {
         assert!(completions("wa").contains(&"wasm"));
         assert!(completions("wa").contains(&"wasi"));
         assert!(completions("a").contains(&"avim"));
+        assert!(completions("em").contains(&"emacs"));
+        assert!(completions("ph").contains(&"phase1-emacs"));
         assert!(completions("v").contains(&"vim"));
         assert!(completions("la").contains(&"lang"));
         assert!(completions("ne").contains(&"nest"));


### PR DESCRIPTION
Adds Phase1 eMacs as an AVIM-backed VFS-native advanced editor command with aliases emac, phase1-emacs, phase1emacs, and pemacs. Includes command routing, registry integration, docs, and safe editor behavior with no host shell escapes.