### PR TITLE
Add edge stable checkpoint

### DIFF
--- a/EDGE_STABLE_CHECKPOINT.md
+++ b/EDGE_STABLE_CHECKPOINT.md
@@ -1,0 +1,14 @@
+# Phase1 Edge Stable Checkpoint
+
+This checkpoint confirms the new repository model:
+
+- base/v4.2.0 is the frozen stable base.
+- edge/stable is the active default development path.
+- feature branches now target edge/stable.
+- checkpoint branches record verified milestone states.
+
+Verified with:
+
+```text
+cargo test --workspace --all-targets
+```


### PR DESCRIPTION
Adds the first checkpoint after moving Phase1 to the stability-first repository model with base/v4.2.0 as frozen base and edge/stable as the active default path.