### PR TITLE
Add Phase1 repo doctrine command

### DIFF
--- a/REPO_DOCTRINE.md
+++ b/REPO_DOCTRINE.md
@@ -1,0 +1,23 @@
+# Phase1 Repository Doctrine
+
+Phase1 now uses a stability-first repository model.
+
+## Channels
+
+- `base/v4.2.0` is the frozen stable base.
+- `edge/stable` is the active default development path.
+- `checkpoint/*` branches are verified milestone snapshots.
+- `feature/*` branches target `edge/stable`.
+
+## Inside Phase1
+
+```text
+repo status
+repo base
+repo edge
+repo checkpoint
+```
+
+## Rule
+
+Keep the base boring. Move tested work through edge/stable. Cut checkpoints after validated milestones.

--- a/src/main.rs
+++ b/src/main.rs
@@ -481,7 +481,7 @@ fn execute_one(
             let canonical = registry::canonical_name(cmd).unwrap_or(cmd);
             let known = registry::lookup(cmd).is_some()
                 || plugin_exists(shell, canonical)
-                || matches!(canonical, "avim" | "emacs" | "lang" | "opslog");
+                || matches!(canonical, "avim" | "emacs" | "repo" | "lang" | "opslog");
             match canonical {
                 "help" => ui::print_help(),
                 "accounts" => print!("{}", accounts_report(shell)),
@@ -509,6 +509,7 @@ fn execute_one(
                 "opslog" => print!("{}", ops_log::run(args)),
                 "bootcfg" => handle_bootcfg(boot_config, args),
                 "nest" => print!("{}", nest_command(shell, args)),
+                "repo" => print!("{}", repo_command(args)),
                 "exit"
                     if args
                         .first()
@@ -542,6 +543,37 @@ fn theme_command(shell: &mut Phase1Shell, args: &[String]) -> String {
         out.push_str(&format!("pack   : {}\n", linux_colors::summary(shell)));
     }
     out
+}
+
+fn repo_command(args: &[String]) -> String {
+    match args.first().map(String::as_str) {
+        None | Some("status") => repo_status(),
+        Some("base") => repo_base(),
+        Some("edge") | Some("stable") => repo_edge(),
+        Some("checkpoint") | Some("checkpoints") => repo_checkpoint(),
+        Some("help") | Some("-h") | Some("--help") => repo_help(),
+        Some(other) => format!("repo: unknown action {other}\n{}", repo_help()),
+    }
+}
+
+fn repo_status() -> String {
+    "phase1 repo doctrine\nbase       : base/v4.2.0 frozen stable base\nedge       : edge/stable active default development path\ncheckpoint : checkpoint/* verified milestone snapshots\nfeature    : feature/* working branches targeting edge/stable\nrule       : stable base stays boring; edge/stable carries current tested work\ncommands   : repo base | repo edge | repo checkpoint | repo help\n".to_string()
+}
+
+fn repo_base() -> String {
+    "phase1 repo base\nbranch : base/v4.2.0\nrole   : frozen stable base\npolicy : no feature work; only emergency metadata or archival fixes\nreason : gives Phase1 a known-good recovery and comparison point\n".to_string()
+}
+
+fn repo_edge() -> String {
+    "phase1 repo edge\nbranch : edge/stable\nrole   : active default development path\npolicy : new tested work lands here through PRs\nreason : keeps forward motion separate from the frozen 4.2.0 base\n".to_string()
+}
+
+fn repo_checkpoint() -> String {
+    "phase1 repo checkpoints\npattern : checkpoint/*\nrole    : verified milestone snapshots\npolicy  : cut checkpoints after test-passing milestones\nexample : checkpoint/edge-stable-4.3.0-dev\n".to_string()
+}
+
+fn repo_help() -> String {
+    "phase1 repo command\n\nusage:\n  repo status\n  repo base\n  repo edge\n  repo checkpoint\n\nmodel:\n  base/v4.2.0  frozen stable base\n  edge/stable  active tested development path\n  checkpoint/* verified milestone snapshots\n  feature/*    working branches into edge/stable\n".to_string()
 }
 
 fn nest_command(shell: &mut Phase1Shell, args: &[String]) -> String {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -72,7 +72,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     cmd!("ned", &["nano", "vi"], "host", "ned <file>", "Edit a VFS file with a small line editor.", "fs.write"),
     cmd!("avim", &["vim", "edit"], "dev", "avim <file>", "Advanced VFS-only modal editor with search, undo, yank/paste, substitute, and a security-focused no-shell-escape design.", "fs.write"),
     cmd!("emacs", &["emac", "phase1-emacs", "phase1emacs", "pemacs"], "editor", "emacs <file>", "Phase1 eMacs editor: VFS-native advanced editor powered by AVIM Pro.", "fs.write"),
-    cmd!("dev", &["dock", "selfdev"], "dev", "dev [status|sync|branch|quick|test|commit|push|pr|merge|close|doctor]", "Phase1 self-development dock for working on Phase1 from inside Phase1.", "host.exec"),
+    cmd!("dev", &["dock", "selfdev"], "dev", "dev [status|sync|branch|quick|test|commit|push|pr|merge|close|doctor]", "Phase1 self-development dock for working on Phase1 from inside Phase1.", "host.exec"),\n    cmd!("repo", &["channels", "branches", "doctrine"], "dev", "repo [status|base|edge|checkpoint]", "Show the Phase1 repository channel doctrine: frozen base, active edge/stable path, checkpoints, and feature branch targets.", "none"),
     cmd!("lang", &["language", "runlang"], "dev", "lang [list|support|status|doctor|detect|run|security]", "Native guarded multi-language runtime manager for major open-source programming languages.", "host.exec"),
     cmd!("lspci", &[], "arch", "lspci", "List simulated PCIe devices.", "hw.read"),
     cmd!("pcie", &[], "arch", "pcie", "Show PCIe subsystem summary.", "hw.read"),
@@ -238,7 +238,7 @@ mod tests {
         assert_eq!(lookup("emac").map(|cmd| cmd.name), Some("emacs"));
         assert_eq!(lookup("phase1-emacs").map(|cmd| cmd.name), Some("emacs"));
         assert_eq!(lookup("phase1emacs").map(|cmd| cmd.name), Some("emacs"));
-        assert_eq!(lookup("pemacs").map(|cmd| cmd.name), Some("emacs"));
+        assert_eq!(lookup("pemacs").map(|cmd| cmd.name), Some("emacs"));\n        assert_eq!(lookup("channels").map(|cmd| cmd.name), Some("repo"));\n        assert_eq!(lookup("branches").map(|cmd| cmd.name), Some("repo"));\n        assert_eq!(lookup("doctrine").map(|cmd| cmd.name), Some("repo"));
     }
 
     #[test]
@@ -261,7 +261,7 @@ mod tests {
         assert_eq!(canonical_name("map"), Some("roadmap"));
         assert_eq!(canonical_name("wasi"), Some("wasm"));
         assert_eq!(canonical_name("edit"), Some("avim"));
-        assert_eq!(canonical_name("runlang"), Some("lang"));
+        assert_eq!(canonical_name("runlang"), Some("lang"));\n        assert_eq!(canonical_name("channels"), Some("repo"));
     }
 
     #[test]
@@ -292,7 +292,7 @@ mod tests {
         assert!(map.contains("wasm"));
         assert!(map.contains("avim"));
         assert!(map.contains("lang"));
-        assert!(map.contains("dev"));
+        assert!(map.contains("dev"));\n        assert!(map.contains("repo"));
     }
 
     #[test]
@@ -341,7 +341,7 @@ mod tests {
         assert!(completions("v").contains(&"vim"));
         assert!(completions("la").contains(&"lang"));
         assert!(completions("de").contains(&"dev"));
-        assert!(completions("do").contains(&"dock"));
+        assert!(completions("do").contains(&"dock"));\n        assert!(completions("do").contains(&"doctrine"));\n        assert!(completions("re").contains(&"repo"));
         assert!(completions("ne").contains(&"nest"));
         assert!(completions("ne").contains(&"nests"));
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -72,7 +72,8 @@ pub const COMMANDS: &[CommandSpec] = &[
     cmd!("ned", &["nano", "vi"], "host", "ned <file>", "Edit a VFS file with a small line editor.", "fs.write"),
     cmd!("avim", &["vim", "edit"], "dev", "avim <file>", "Advanced VFS-only modal editor with search, undo, yank/paste, substitute, and a security-focused no-shell-escape design.", "fs.write"),
     cmd!("emacs", &["emac", "phase1-emacs", "phase1emacs", "pemacs"], "editor", "emacs <file>", "Phase1 eMacs editor: VFS-native advanced editor powered by AVIM Pro.", "fs.write"),
-    cmd!("dev", &["dock", "selfdev"], "dev", "dev [status|sync|branch|quick|test|commit|push|pr|merge|close|doctor]", "Phase1 self-development dock for working on Phase1 from inside Phase1.", "host.exec"),\n    cmd!("repo", &["channels", "branches", "doctrine"], "dev", "repo [status|base|edge|checkpoint]", "Show the Phase1 repository channel doctrine: frozen base, active edge/stable path, checkpoints, and feature branch targets.", "none"),
+    cmd!("dev", &["dock", "selfdev"], "dev", "dev [status|sync|branch|quick|test|commit|push|pr|merge|close|doctor]", "Phase1 self-development dock for working on Phase1 from inside Phase1.", "host.exec"),
+    cmd!("repo", &["channels", "branches", "doctrine"], "dev", "repo [status|base|edge|checkpoint]", "Show the Phase1 repository channel doctrine: frozen base, active edge/stable path, checkpoints, and feature branch targets.", "none"),
     cmd!("lang", &["language", "runlang"], "dev", "lang [list|support|status|doctor|detect|run|security]", "Native guarded multi-language runtime manager for major open-source programming languages.", "host.exec"),
     cmd!("lspci", &[], "arch", "lspci", "List simulated PCIe devices.", "hw.read"),
     cmd!("pcie", &[], "arch", "pcie", "Show PCIe subsystem summary.", "hw.read"),
@@ -238,7 +239,10 @@ mod tests {
         assert_eq!(lookup("emac").map(|cmd| cmd.name), Some("emacs"));
         assert_eq!(lookup("phase1-emacs").map(|cmd| cmd.name), Some("emacs"));
         assert_eq!(lookup("phase1emacs").map(|cmd| cmd.name), Some("emacs"));
-        assert_eq!(lookup("pemacs").map(|cmd| cmd.name), Some("emacs"));\n        assert_eq!(lookup("channels").map(|cmd| cmd.name), Some("repo"));\n        assert_eq!(lookup("branches").map(|cmd| cmd.name), Some("repo"));\n        assert_eq!(lookup("doctrine").map(|cmd| cmd.name), Some("repo"));
+        assert_eq!(lookup("pemacs").map(|cmd| cmd.name), Some("emacs"));
+        assert_eq!(lookup("channels").map(|cmd| cmd.name), Some("repo"));
+        assert_eq!(lookup("branches").map(|cmd| cmd.name), Some("repo"));
+        assert_eq!(lookup("doctrine").map(|cmd| cmd.name), Some("repo"));
     }
 
     #[test]
@@ -261,7 +265,8 @@ mod tests {
         assert_eq!(canonical_name("map"), Some("roadmap"));
         assert_eq!(canonical_name("wasi"), Some("wasm"));
         assert_eq!(canonical_name("edit"), Some("avim"));
-        assert_eq!(canonical_name("runlang"), Some("lang"));\n        assert_eq!(canonical_name("channels"), Some("repo"));
+        assert_eq!(canonical_name("runlang"), Some("lang"));
+        assert_eq!(canonical_name("channels"), Some("repo"));
     }
 
     #[test]
@@ -292,7 +297,8 @@ mod tests {
         assert!(map.contains("wasm"));
         assert!(map.contains("avim"));
         assert!(map.contains("lang"));
-        assert!(map.contains("dev"));\n        assert!(map.contains("repo"));
+        assert!(map.contains("dev"));
+        assert!(map.contains("repo"));
     }
 
     #[test]
@@ -341,7 +347,9 @@ mod tests {
         assert!(completions("v").contains(&"vim"));
         assert!(completions("la").contains(&"lang"));
         assert!(completions("de").contains(&"dev"));
-        assert!(completions("do").contains(&"dock"));\n        assert!(completions("do").contains(&"doctrine"));\n        assert!(completions("re").contains(&"repo"));
+        assert!(completions("do").contains(&"dock"));
+        assert!(completions("do").contains(&"doctrine"));
+        assert!(completions("re").contains(&"repo"));
         assert!(completions("ne").contains(&"nest"));
         assert!(completions("ne").contains(&"nests"));
     }


### PR DESCRIPTION
Adds a repo command that explains the stability-first repository model from inside Phase1: base/v4.2.0 as frozen stable base, edge/stable as active development path, checkpoint branches as verified milestones, and feature branches targeting edge/stable. Includes registry integration, aliases, tests, and docs.