### PR TITLE
Add docs sync guard tests

### DIFF
--- a/tests/docs_sync_guard.rs
+++ b/tests/docs_sync_guard.rs
@@ -1,0 +1,44 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+#[test]
+fn docs_sync_script_and_outputs_are_present() {
+    let script = read("scripts/update-docs.py");
+    assert!(script.contains("base/v4.2.0"));
+    assert!(script.contains("edge/stable"));
+    assert!(script.contains("upsert(\"README.md\", \"repo-model\""));
+    assert!(script.contains("docs/wiki/Repository-Model.md"));
+    assert!(script.contains("docs/wiki/Current-Status.md"));
+}
+
+#[test]
+fn generated_docs_preserve_stable_base_and_edge_path() {
+    let docs = [
+        "README.md",
+        "REPO_DOCTRINE.md",
+        "EDGE_STABLE_CHECKPOINT.md",
+        "FEATURE_STATUS.md",
+        "EDGE.md",
+        "WIKI_ROADMAP.md",
+        "docs/wiki/Repository-Model.md",
+        "docs/wiki/Current-Status.md",
+    ];
+
+    for path in docs {
+        let body = read(path);
+        assert!(body.contains("base/v4.2.0"), "{path} lost the frozen stable base");
+        assert!(body.contains("edge/stable"), "{path} lost the active edge path");
+    }
+}
+
+#[test]
+fn generated_docs_have_managed_blocks() {
+    let readme = read("README.md");
+    assert!(readme.contains("<!-- phase1:auto:repo-model:start -->"));
+    assert!(readme.contains("<!-- phase1:auto:repo-model:end -->"));
+    assert!(readme.contains("<!-- phase1:auto:current-status:start -->"));
+    assert!(readme.contains("<!-- phase1:auto:current-status:end -->"));
+}

--- a/tests/docs_sync_guard.rs
+++ b/tests/docs_sync_guard.rs
@@ -29,8 +29,14 @@ fn generated_docs_preserve_stable_base_and_edge_path() {
 
     for path in docs {
         let body = read(path);
-        assert!(body.contains("base/v4.2.0"), "{path} lost the frozen stable base");
-        assert!(body.contains("edge/stable"), "{path} lost the active edge path");
+        assert!(
+            body.contains("base/v4.2.0"),
+            "{path} lost the frozen stable base"
+        );
+        assert!(
+            body.contains("edge/stable"),
+            "{path} lost the active edge path"
+        );
     }
 }
 


### PR DESCRIPTION
Adds automated guard tests for the README/docs/wiki sync system. Verifies the docs sync script is present, generated docs preserve base/v4.2.0 as the frozen stable base, edge/stable as the active path, and README managed blocks stay intact.