### PR TITLE
Add self hosted Phase1 dev workflow

### DIFF
--- a/DEV_DOCK.md
+++ b/DEV_DOCK.md
@@ -1,31 +1,35 @@
 # Phase1 Dev Dock
 
-dev lets Phase1 work on itself from inside Phase1.
+`dev` lets Phase1 work on itself from inside Phase1.
 
-## Start
+## Inside Phase1 workflow
 
-Run Phase1 with guarded host tools:
-
-PHASE1_SAFE_MODE=1 PHASE1_ALLOW_HOST_TOOLS=1 cargo run
-
-## Commands inside Phase1
-
+```text
 dev status
 dev sync
-dev branch feature/example
+dev docs
 dev quick
 dev test
+dev checkpoint Docs guard edge stable
+dev branch feature/example
 dev commit Add example feature
 dev push
 dev pr Add example feature
 dev merge 123
 dev close 123
 dev doctor
+```
+
+## Purpose
+
+- Work on Phase1 from inside Phase1.
+- Run docs sync without opening an editor.
+- Create checkpoint PRs only when there are actual changes.
+- Keep `base/v4.2.0` frozen as the stable base.
+- Keep `edge/stable` as the active development path.
 
 ## Safety
 
 - Uses guarded host tools.
 - Safe mode can stay enabled.
-- Intended for Phase1 self-development.
-- Avoids staging runtime files like phase1.history, phase1.state, phase1.log, and phase1.learn.
-- Keeps normal copy/paste development workflows inside Phase1.
+- Avoids staging runtime files like `phase1.history`, `phase1.state`, `phase1.log`, and `phase1.learn`.

--- a/plugins/dev.py
+++ b/plugins/dev.py
@@ -37,6 +37,8 @@ dev sync
 dev branch <name>
 dev quick
 dev test
+dev docs
+dev checkpoint <title>
 dev commit <message>
 dev push
 dev pr <title>
@@ -80,7 +82,7 @@ def cmd_status() -> int:
 
 
 def cmd_sync() -> int:
-    run(["git", "checkout", "master"])
+    run(["git", "checkout", "edge/stable"])
     run(["git", "pull", "--ff-only"])
     return 0
 
@@ -145,7 +147,7 @@ def cmd_pr(args: list[str]) -> int:
         "--body",
         f"{title}. Created from inside Phase1 Dev Dock.",
         "--base",
-        "master",
+        "edge/stable",
         "--head",
         branch,
     ])
@@ -157,7 +159,7 @@ def cmd_merge(args: list[str]) -> int:
         print("dev merge <number>")
         return 2
     run(["gh", "pr", "merge", args[0], "--squash"])
-    run(["git", "checkout", "master"])
+    run(["git", "checkout", "edge/stable"])
     run(["git", "pull", "--ff-only"])
     return 0
 
@@ -168,6 +170,53 @@ def cmd_close(args: list[str]) -> int:
         return 2
     run(["gh", "pr", "close", args[0]])
     return 0
+
+
+
+def cmd_docs() -> int:
+    run(["python3", "scripts/update-docs.py"])
+    run(["cargo", "fmt", "--all", "--", "--check"])
+    return 0
+
+
+def cmd_checkpoint(args: list[str]) -> int:
+    title = " ".join(args).strip() or "Checkpoint edge stable"
+    slug = title.lower()
+    for ch in " /_:.":
+        slug = slug.replace(ch, "-")
+    slug = "".join(ch for ch in slug if ch.isalnum() or ch == "-").strip("-") or "edge-stable"
+    branch = f"checkpoint/{slug}"
+
+    for cmd in [
+        ["git", "fetch", "origin"],
+        ["git", "checkout", "edge/stable"],
+        ["git", "pull", "--ff-only"],
+        ["git", "checkout", "-B", branch],
+        ["python3", "scripts/update-docs.py"],
+        ["cargo", "fmt", "--all", "--", "--check"],
+        ["cargo", "test", "--workspace", "--all-targets"],
+    ]:
+        code = run(cmd)
+        if code != 0:
+            return code
+
+    run(["git", "add", "README.md", "REPO_DOCTRINE.md", "EDGE.md", "EDGE_STABLE_CHECKPOINT.md", "FEATURE_STATUS.md", "WIKI_ROADMAP.md", "docs/wiki", "scripts/update-docs.py"])
+
+    changed = subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=ROOT).returncode != 0
+    if not changed:
+        print("dev checkpoint: no changes; edge/stable is already current, no PR needed")
+        return 0
+
+    code = run(["git", "commit", "-m", title])
+    if code != 0:
+        return code
+
+    code = run(["git", "push", "-u", "origin", branch])
+    if code != 0:
+        return code
+
+    return run(["gh", "pr", "create", "--title", title, "--body", "Automated Phase1 checkpoint created from inside Phase1.", "--base", "edge/stable", "--head", branch])
+
 
 
 def cmd_doctor() -> int:
@@ -198,6 +247,8 @@ def main() -> int:
         "pr": lambda: cmd_pr(rest),
         "merge": lambda: cmd_merge(rest),
         "close": lambda: cmd_close(rest),
+        "docs": lambda: cmd_docs(),
+        "checkpoint": lambda: cmd_checkpoint(rest),
         "doctor": lambda: cmd_doctor(),
     }
 

--- a/tests/dev_dock_self_hosted.rs
+++ b/tests/dev_dock_self_hosted.rs
@@ -1,0 +1,18 @@
+use std::fs;
+
+#[test]
+fn dev_dock_exposes_self_hosted_workflow_commands() {
+    let dev = fs::read_to_string("plugins/dev.py").expect("plugins/dev.py exists");
+    assert!(dev.contains("dev docs"));
+    assert!(dev.contains("dev checkpoint"));
+    assert!(dev.contains("no changes"));
+    assert!(dev.contains("scripts/update-docs.py"));
+}
+
+#[test]
+fn dev_dock_docs_explain_inside_phase1_workflow() {
+    let docs = fs::read_to_string("DEV_DOCK.md").expect("DEV_DOCK.md exists");
+    assert!(docs.contains("dev docs"));
+    assert!(docs.contains("dev checkpoint"));
+    assert!(docs.contains("inside Phase1"));
+}


### PR DESCRIPTION
Adds inside-Phase1 dev docs and dev checkpoint workflow support so routine docs sync, validation, checkpoint creation, and no-op checkpoint detection can happen from Phase1 without dropping back to direct host commands.