### PR TITLE
Pass Phase1 plugin args into dev dock

### DIFF
--- a/plugins/dev.py
+++ b/plugins/dev.py
@@ -227,9 +227,21 @@ def cmd_doctor() -> int:
     return 0
 
 
+def phase1_plugin_args() -> list[str]:
+    if len(sys.argv) > 1:
+        return sys.argv[1:]
+    data: dict[str, str] = {}
+    if not sys.stdin.isatty():
+        for line in sys.stdin:
+            if "=" in line:
+                key, value = line.rstrip("\n").split("=", 1)
+                data[key] = value
+    return shlex.split(data.get("ARGS", ""))
+
+
 def main() -> int:
     assert_repo()
-    args = sys.argv[1:]
+    args = phase1_plugin_args()
     if not args or args[0] in {"help", "-h", "--help"}:
         print(help_text())
         return 0

--- a/tests/dev_dock_self_hosted.rs
+++ b/tests/dev_dock_self_hosted.rs
@@ -1,4 +1,6 @@
 use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
 
 #[test]
 fn dev_dock_exposes_self_hosted_workflow_commands() {
@@ -15,4 +17,29 @@ fn dev_dock_docs_explain_inside_phase1_workflow() {
     assert!(docs.contains("dev docs"));
     assert!(docs.contains("dev checkpoint"));
     assert!(docs.contains("inside Phase1"));
+}
+
+#[test]
+fn dev_plugin_reads_phase1_context_args_from_stdin() {
+    let mut child = Command::new("python3")
+        .arg("plugins/dev.py")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn dev plugin");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(b"COMMAND=dev\nARGS=definitely-missing\nUSER=root\nCWD=/\nVERSION=test\n")
+        .expect("write plugin context");
+
+    let output = child.wait_with_output().expect("plugin output");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("dev: unknown action: definitely-missing"),
+        "{}",
+        stdout
+    );
 }


### PR DESCRIPTION
Fixes Dev Dock command dispatch from inside Phase1 by reading Phase1 plugin context ARGS from stdin when sys.argv is empty. This makes dev docs and dev checkpoint work from inside Phase1 instead of falling back to help text.