### PR TITLE
Add Phase1 dev cycle command

### DIFF
--- a/DEV_DOCK.md
+++ b/DEV_DOCK.md
@@ -8,6 +8,7 @@
 dev status
 dev sync
 dev docs
+dev cycle
 dev quick
 dev test
 dev checkpoint Docs guard edge stable
@@ -19,6 +20,10 @@ dev merge 123
 dev close 123
 dev doctor
 ```
+
+## Daily cycle
+
+Use `dev cycle` for the normal status, docs sync, and final git status loop without opening an editor or creating a checkpoint.
 
 ## Purpose
 

--- a/plugins/dev.py
+++ b/plugins/dev.py
@@ -38,6 +38,7 @@ dev branch <name>
 dev quick
 dev test
 dev docs
+dev cycle
 dev checkpoint <title>
 dev commit <message>
 dev push
@@ -179,6 +180,14 @@ def cmd_docs() -> int:
     return 0
 
 
+def cmd_cycle() -> int:
+    """Run the normal self-hosted status/docs/status loop without checkpointing."""
+    cmd_status()
+    cmd_docs()
+    run(["git", "status"], check=False)
+    return 0
+
+
 def cmd_checkpoint(args: list[str]) -> int:
     title = " ".join(args).strip() or "Checkpoint edge stable"
     slug = title.lower()
@@ -249,6 +258,7 @@ def main() -> int:
         "merge": lambda: cmd_merge(rest),
         "close": lambda: cmd_close(rest),
         "docs": lambda: cmd_docs(),
+        "cycle": lambda: cmd_cycle(),
         "checkpoint": lambda: cmd_checkpoint(rest),
         "doctor": lambda: cmd_doctor(),
     }

--- a/tests/dev_dock_self_hosted.rs
+++ b/tests/dev_dock_self_hosted.rs
@@ -6,6 +6,8 @@ use std::process::{Command, Stdio};
 fn dev_dock_exposes_self_hosted_workflow_commands() {
     let dev = fs::read_to_string("plugins/dev.py").expect("plugins/dev.py exists");
     assert!(dev.contains("dev docs"));
+    assert!(dev.contains("dev cycle"));
+    assert!(dev.contains("cmd_cycle"));
     assert!(dev.contains("dev checkpoint"));
     assert!(dev.contains("no changes"));
     assert!(dev.contains("scripts/update-docs.py"));
@@ -15,6 +17,7 @@ fn dev_dock_exposes_self_hosted_workflow_commands() {
 fn dev_dock_docs_explain_inside_phase1_workflow() {
     let docs = fs::read_to_string("DEV_DOCK.md").expect("DEV_DOCK.md exists");
     assert!(docs.contains("dev docs"));
+    assert!(docs.contains("dev cycle"));
     assert!(docs.contains("dev checkpoint"));
     assert!(docs.contains("inside Phase1"));
 }


### PR DESCRIPTION
Adds dev cycle as the safe inside-Phase1 daily loop for dev status, dev docs, and final git status without checkpointing or opening an editor.