### PR TITLE
Add red Japanese boot greeting

### DIFF
--- a/src/boot_ui_static.rs
+++ b/src/boot_ui_static.rs
@@ -595,7 +595,7 @@ fn print_boot_card(
     outln(&card_line(
         config,
         width,
-        &format!("node TOKYO-01 | boot {boot_stamp}"),
+        &boot_greeting_line(config, boot_stamp),
     ));
     outln(&card_rule(config, width));
     for row in skyline_rows(config) {
@@ -629,6 +629,15 @@ fn print_boot_card(
     }
     outln(&card_bottom(config, width));
     outln("");
+}
+
+fn boot_greeting_line(config: BootConfig, boot_stamp: &str) -> String {
+    let greeting = "こんにちは、ハッカー！";
+    if config.color && !config.ascii_mode {
+        format!("{BOLD}{RED}{greeting}{RESET} | boot {boot_stamp}")
+    } else {
+        format!("{greeting} | boot {boot_stamp}")
+    }
 }
 
 fn skyline_rows(config: BootConfig) -> Vec<String> {

--- a/tests/boot_greeting.rs
+++ b/tests/boot_greeting.rs
@@ -1,0 +1,9 @@
+use std::fs;
+
+#[test]
+fn boot_screen_uses_japanese_hacker_greeting() {
+    let boot = fs::read_to_string("src/boot_ui_static.rs").expect("boot ui source exists");
+    assert!(boot.contains("こんにちは、ハッカー！"));
+    assert!(boot.contains("boot_greeting_line(config, boot_stamp)"));
+    assert!(!boot.contains("node TOKYO-01 | boot"));
+}


### PR DESCRIPTION
Replaces the boot card node label with a bright red Japanese greeting: こんにちは、ハッカー！