### PR TITLE
Restore boot card rectangular alignment

### DIFF
--- a/src/boot_ui_static.rs
+++ b/src/boot_ui_static.rs
@@ -592,10 +592,11 @@ fn print_boot_card(
     outln("");
     outln(&card_top(config, width));
     outln(&card_line(config, width, &console_title(config)));
+    outln(&card_line(config, width, &boot_greeting_line(config)));
     outln(&card_line(
         config,
         width,
-        &boot_greeting_line(config, boot_stamp),
+        &boot_time_line(config, boot_stamp),
     ));
     outln(&card_rule(config, width));
     for row in skyline_rows(config) {
@@ -631,13 +632,17 @@ fn print_boot_card(
     outln("");
 }
 
-fn boot_greeting_line(config: BootConfig, boot_stamp: &str) -> String {
+fn boot_greeting_line(config: BootConfig) -> String {
     let greeting = "こんにちは、ハッカー！";
     if config.color && !config.ascii_mode {
-        format!("{BOLD}{RED}{greeting}{RESET} | boot {boot_stamp}")
+        format!("{BOLD}{RED}{greeting}{RESET}")
     } else {
-        format!("{greeting} | boot {boot_stamp}")
+        greeting.to_string()
     }
+}
+
+fn boot_time_line(config: BootConfig, boot_stamp: &str) -> String {
+    tint(config, &format!("boot {boot_stamp}"))
 }
 
 fn skyline_rows(config: BootConfig) -> Vec<String> {
@@ -649,10 +654,7 @@ fn skyline_rows(config: BootConfig) -> Vec<String> {
     vec![
         tint(config, "neural sync :: kernel PHASE1"),
         format!("mesh encrypted :: {mode}"),
-        format!(
-            "ui device {} :: kern/vfs/proc/net/audit/lang",
-            device_mode(config).name()
-        ),
+        format!("ui device {} :: kern/vfs/proc", device_mode(config).name()),
     ]
 }
 
@@ -1127,19 +1129,61 @@ fn card_section(config: BootConfig, width: usize, label: &str) -> String {
 }
 
 fn card_line(config: BootConfig, width: usize, text: &str) -> String {
-    let content_width = width.saturating_sub(2);
-    let visible = visible_cell_width(text);
-    let pad = content_width.saturating_sub(visible);
+    let inner = width;
+    let fitted = fit_cell_text(text, inner);
+    let pad = inner.saturating_sub(visible_cell_width(&fitted));
     let padding = " ".repeat(pad);
+
     if config.color && !config.ascii_mode {
-        let colors = palette(active_theme_for_config(config));
-        format!(
-            "{}│{}{}{}│{}",
-            colors.border, text, padding, colors.border, RESET
-        )
+        let border = palette(active_theme_for_config(config)).border;
+        format!("{border}│{RESET}{fitted}{padding}{border}│{RESET}")
     } else {
-        format!("|{}{}|", text, padding)
+        format!("|{fitted}{padding}|")
     }
+}
+
+fn fit_cell_text(text: &str, width: usize) -> String {
+    if visible_cell_width(text) <= width {
+        return text.to_string();
+    }
+
+    let ellipsis = "…";
+    let ellipsis_width = visible_cell_width(ellipsis);
+    let limit = width.saturating_sub(ellipsis_width);
+    let mut out = String::new();
+    let mut cells = 0;
+    let mut in_escape = false;
+
+    for ch in text.chars() {
+        if in_escape {
+            out.push(ch);
+            if ch == 'm' {
+                in_escape = false;
+            }
+            continue;
+        }
+
+        if ch == char::from(27) {
+            in_escape = true;
+            out.push(ch);
+            continue;
+        }
+
+        let ch_width = char_cell_width(ch);
+        if cells + ch_width > limit {
+            break;
+        }
+
+        out.push(ch);
+        cells += ch_width;
+    }
+
+    if text.contains(RESET) && !out.ends_with(RESET) {
+        out.push_str(RESET);
+    }
+
+    out.push_str(ellipsis);
+    out
 }
 
 fn visible_cell_width(text: &str) -> usize {

--- a/tests/boot_greeting.rs
+++ b/tests/boot_greeting.rs
@@ -3,9 +3,18 @@ use std::fs;
 #[test]
 fn boot_screen_uses_japanese_hacker_greeting() {
     let boot = fs::read_to_string("src/boot_ui_static.rs").expect("boot ui source exists");
+
     assert!(boot.contains("こんにちは、ハッカー！"));
-    assert!(boot.contains("boot_greeting_line(config, boot_stamp)"));
-    assert!(boot.contains("visible_cell_width"));
-    assert!(boot.contains("is_wide_cell"));
+    assert!(boot.contains("boot_greeting_line(config)"));
+    assert!(boot.contains("boot_time_line(config, boot_stamp)"));
+    assert!(boot.contains("let inner = width;"));
+    assert!(boot.contains("fit_cell_text(text, inner)"));
+    assert!(boot.contains("visible_cell_width(&fitted)"));
+    assert!(boot.contains("ui device {} :: kern/vfs/proc"));
+
+    assert!(!boot.contains("width.saturating_sub(2)"));
+    assert!(!boot.contains("boot_greeting_line(config, boot_stamp)"));
+    assert!(!boot.contains("greeting}{RESET} | boot"));
+    assert!(!boot.contains("greeting} | boot"));
     assert!(!boot.contains("node TOKYO-01 | boot"));
 }


### PR DESCRIPTION
Fixes boot card frame symmetry by treating card width as the inner content width for every row, fitting text before padding, moving boot time onto its own line, and shortening the device capability row so the right border aligns in all modes.