### PR TITLE
Add Fyr Phase1 native language target

### DIFF
--- a/PHASE1_NATIVE_LANGUAGE.md
+++ b/PHASE1_NATIVE_LANGUAGE.md
@@ -1,0 +1,5 @@
+# Phase1 Native Language
+
+This document reserves a Phase1-native language target for future development.
+
+The first milestone is a specification, examples, and guard tests.

--- a/PHASE1_NATIVE_LANGUAGE.md
+++ b/PHASE1_NATIVE_LANGUAGE.md
@@ -1,5 +1,14 @@
 # Phase1 Native Language
 
-This document reserves a Phase1-native language target for future development.
+Name: Fyr
+Extension: .fyr
+Command: fyr
 
-The first milestone is a specification, examples, and guard tests.
+Fyr is the planned Phase1-native language target. It is reserved for stable Phase1 automation, virtual file system workflows, and future self-build scripts.
+
+Initial milestone:
+
+- language specification
+- examples
+- guard tests
+- later lexer and parser work

--- a/examples/fyr/hello.fyr
+++ b/examples/fyr/hello.fyr
@@ -1,0 +1,5 @@
+fn main() -> i32 {
+    let name = "Phase1";
+    print("Hello from " + name);
+    return 0;
+}

--- a/examples/fyr/self_check.fyr
+++ b/examples/fyr/self_check.fyr
@@ -1,0 +1,6 @@
+fn main() -> i32 {
+    let system = "Phase1";
+    let language = "Fyr";
+    print(system + " native language target: " + language);
+    return 0;
+}

--- a/tests/fyr_native_language.rs
+++ b/tests/fyr_native_language.rs
@@ -1,0 +1,18 @@
+use std::fs;
+
+#[test]
+fn fyr_language_spec_and_examples_exist() {
+    let spec = fs::read_to_string("PHASE1_NATIVE_LANGUAGE.md").expect("native language spec exists");
+    assert!(spec.contains("Name: Fyr"));
+    assert!(spec.contains("Extension: .fyr"));
+    assert!(spec.contains("Command: fyr"));
+    assert!(spec.contains("Phase1-native language target"));
+
+    let hello = fs::read_to_string("examples/fyr/hello.fyr").expect("fyr hello example exists");
+    assert!(hello.contains("fn main() -> i32"));
+    assert!(hello.contains("Hello from"));
+
+    let self_check = fs::read_to_string("examples/fyr/self_check.fyr").expect("fyr self check example exists");
+    assert!(self_check.contains("Phase1"));
+    assert!(self_check.contains("Fyr"));
+}


### PR DESCRIPTION
Adds the initial Fyr native language target for Phase1 with a specification document, example .fyr files, and a guard test. Fyr is reserved as the stable Phase1-owned language path for future VFS automation and self-construction work.