### PR TITLE
Add Fyr command stub

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -549,7 +549,7 @@ fn theme_command(shell: &mut Phase1Shell, args: &[String]) -> String {
     out
 }
 
-fn fyr_command(shell: &Phase1Shell, args: &[String]) -> String {
+fn fyr_command(shell: &mut Phase1Shell, args: &[String]) -> String {
     match args.first().map(String::as_str) {
         None | Some("status") => fyr_status(),
         Some("spec") => fyr_spec(),
@@ -570,7 +570,7 @@ fn fyr_spec() -> String {
     }
 }
 
-fn fyr_run(shell: &Phase1Shell, args: &[String]) -> String {
+fn fyr_run(shell: &mut Phase1Shell, args: &[String]) -> String {
     let Some(path) = args.first() else {
         return "usage: fyr run <file.fyr>\n".to_string();
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -481,7 +481,10 @@ fn execute_one(
             let canonical = registry::canonical_name(cmd).unwrap_or(cmd);
             let known = registry::lookup(cmd).is_some()
                 || plugin_exists(shell, canonical)
-                || matches!(canonical, "avim" | "emacs" | "repo" | "lang" | "opslog");
+                || matches!(
+                    canonical,
+                    "avim" | "emacs" | "repo" | "lang" | "fyr" | "opslog"
+                );
             match canonical {
                 "help" => ui::print_help(),
                 "accounts" => print!("{}", accounts_report(shell)),
@@ -506,6 +509,7 @@ fn execute_one(
                 "avim" => avim::edit(&mut shell.kernel.vfs, args),
                 "emacs" => avim::edit(&mut shell.kernel.vfs, args),
                 "lang" => print!("{}", languages::run(shell, args)),
+                "fyr" => print!("{}", fyr_command(shell, args)),
                 "opslog" => print!("{}", ops_log::run(args)),
                 "bootcfg" => handle_bootcfg(boot_config, args),
                 "nest" => print!("{}", nest_command(shell, args)),
@@ -543,6 +547,102 @@ fn theme_command(shell: &mut Phase1Shell, args: &[String]) -> String {
         out.push_str(&format!("pack   : {}\n", linux_colors::summary(shell)));
     }
     out
+}
+
+fn fyr_command(shell: &Phase1Shell, args: &[String]) -> String {
+    match args.first().map(String::as_str) {
+        None | Some("status") => fyr_status(),
+        Some("spec") => fyr_spec(),
+        Some("run") => fyr_run(shell, &args[1..]),
+        Some("help") | Some("-h") | Some("--help") => fyr_help(),
+        Some(other) => format!("fyr: unknown action {other}\n{}", fyr_help()),
+    }
+}
+
+fn fyr_status() -> String {
+    "fyr native language\nname      : Fyr\nextension : .fyr\ncommand   : fyr\nstatus    : command stub active; interpreter seed supports print literals\npurpose   : Phase1-owned language path for self-construction and VFS automation\n".to_string()
+}
+
+fn fyr_spec() -> String {
+    match fs::read_to_string("PHASE1_NATIVE_LANGUAGE.md") {
+        Ok(spec) => spec,
+        Err(err) => format!("fyr: could not read PHASE1_NATIVE_LANGUAGE.md: {err}\n"),
+    }
+}
+
+fn fyr_run(shell: &Phase1Shell, args: &[String]) -> String {
+    let Some(path) = args.first() else {
+        return "usage: fyr run <file.fyr>\n".to_string();
+    };
+
+    if !path.ends_with(".fyr") {
+        return "fyr: expected a .fyr file\n".to_string();
+    }
+
+    let source = match shell.kernel.sys_read(path) {
+        Ok(source) => source,
+        Err(err) => return format!("fyr: {err}\n"),
+    };
+
+    let output = fyr_print_output(&source);
+    if output.is_empty() {
+        "fyr: interpreter planned; no printable output found\n".to_string()
+    } else {
+        output
+    }
+}
+
+fn fyr_print_output(source: &str) -> String {
+    let mut out = String::new();
+    let mut rest = source;
+
+    while let Some(pos) = rest.find("print(") {
+        rest = &rest[pos + "print(".len()..];
+
+        if let Some(message) = parse_fyr_string_literal(rest) {
+            out.push_str(&message);
+            out.push('\n');
+        }
+
+        let Some(close) = rest.find(')') else {
+            break;
+        };
+        rest = &rest[close + 1..];
+    }
+
+    out
+}
+
+fn parse_fyr_string_literal(text: &str) -> Option<String> {
+    let start = text.find('"')?;
+    let mut out = String::new();
+    let mut escaped = false;
+
+    for ch in text[start + 1..].chars() {
+        if escaped {
+            match ch {
+                'n' => out.push('\n'),
+                't' => out.push('\t'),
+                '"' => out.push('"'),
+                '\\' => out.push('\\'),
+                other => out.push(other),
+            }
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' => escaped = true,
+            '"' => return Some(out),
+            other => out.push(other),
+        }
+    }
+
+    None
+}
+
+fn fyr_help() -> String {
+    "phase1 fyr command\n\nusage:\n  fyr status\n  fyr spec\n  fyr run <file.fyr>\n\nexample:\n  echo 'fn main() -> i32 { print(\"Hello, hacker!\"); return 0; }' > hello_hacker.fyr\n  fyr run hello_hacker.fyr\n".to_string()
 }
 
 fn repo_command(args: &[String]) -> String {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -74,6 +74,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     cmd!("emacs", &["emac", "phase1-emacs", "phase1emacs", "pemacs"], "editor", "emacs <file>", "Phase1 eMacs editor: VFS-native advanced editor powered by AVIM Pro.", "fs.write"),
     cmd!("dev", &["dock", "selfdev"], "dev", "dev [status|sync|branch|quick|test|commit|push|pr|merge|close|doctor]", "Phase1 self-development dock for working on Phase1 from inside Phase1.", "host.exec"),
     cmd!("repo", &["channels", "branches", "doctrine"], "dev", "repo [status|base|edge|checkpoint]", "Show the Phase1 repository channel doctrine: frozen base, active edge/stable path, checkpoints, and feature branch targets.", "none"),
+    cmd!("fyr", &["phase1lang", "forge"], "dev", "fyr [status|spec|run <file.fyr>]", "Phase1-native language target for self-construction and VFS automation.", "none"),
     cmd!("lang", &["language", "runlang"], "dev", "lang [list|support|status|doctor|detect|run|security]", "Native guarded multi-language runtime manager for major open-source programming languages.", "host.exec"),
     cmd!("lspci", &[], "arch", "lspci", "List simulated PCIe devices.", "hw.read"),
     cmd!("pcie", &[], "arch", "pcie", "Show PCIe subsystem summary.", "hw.read"),
@@ -243,6 +244,7 @@ mod tests {
         assert_eq!(lookup("channels").map(|cmd| cmd.name), Some("repo"));
         assert_eq!(lookup("branches").map(|cmd| cmd.name), Some("repo"));
         assert_eq!(lookup("doctrine").map(|cmd| cmd.name), Some("repo"));
+        assert_eq!(lookup("phase1lang").map(|cmd| cmd.name), Some("fyr"));
     }
 
     #[test]
@@ -267,6 +269,7 @@ mod tests {
         assert_eq!(canonical_name("edit"), Some("avim"));
         assert_eq!(canonical_name("runlang"), Some("lang"));
         assert_eq!(canonical_name("channels"), Some("repo"));
+        assert_eq!(canonical_name("forge"), Some("fyr"));
     }
 
     #[test]
@@ -299,6 +302,7 @@ mod tests {
         assert!(map.contains("lang"));
         assert!(map.contains("dev"));
         assert!(map.contains("repo"));
+        assert!(map.contains("fyr"));
     }
 
     #[test]
@@ -336,6 +340,8 @@ mod tests {
         assert!(completions("st").contains(&"status"));
         assert!(completions("the").contains(&"theme"));
         assert!(completions("f").contains(&"find"));
+        assert!(completions("f").contains(&"fyr"));
+        assert!(completions("fo").contains(&"forge"));
         assert!(completions("g").contains(&"grep"));
         assert!(completions("u").contains(&"update"));
         assert!(completions("u").contains(&"upgrade"));

--- a/tests/fyr_command.rs
+++ b/tests/fyr_command.rs
@@ -4,8 +4,8 @@ use std::fs;
 fn fyr_command_stub_is_wired() {
     let main = fs::read_to_string("src/main.rs").expect("main source exists");
     assert!(main.contains("\"fyr\" => print!(\"{}\", fyr_command(shell, args))"));
-    assert!(main.contains("fn fyr_command(shell: &Phase1Shell"));
-    assert!(main.contains("fn fyr_run(shell: &Phase1Shell"));
+    assert!(main.contains("fn fyr_command(shell: &mut Phase1Shell"));
+    assert!(main.contains("fn fyr_run(shell: &mut Phase1Shell"));
     assert!(main.contains("fn fyr_print_output"));
     assert!(main.contains("Hello, hacker!"));
 

--- a/tests/fyr_command.rs
+++ b/tests/fyr_command.rs
@@ -1,0 +1,16 @@
+use std::fs;
+
+#[test]
+fn fyr_command_stub_is_wired() {
+    let main = fs::read_to_string("src/main.rs").expect("main source exists");
+    assert!(main.contains("\"fyr\" => print!(\"{}\", fyr_command(shell, args))"));
+    assert!(main.contains("fn fyr_command(shell: &Phase1Shell"));
+    assert!(main.contains("fn fyr_run(shell: &Phase1Shell"));
+    assert!(main.contains("fn fyr_print_output"));
+    assert!(main.contains("Hello, hacker!"));
+
+    let registry = fs::read_to_string("src/registry.rs").expect("registry source exists");
+    assert!(registry.contains("cmd!(\"fyr\""));
+    assert!(registry.contains("phase1lang"));
+    assert!(registry.contains("forge"));
+}


### PR DESCRIPTION
Adds the Phase1-native fyr command with status, spec, and a seed run mode that can execute print string literals from .fyr files in the Phase1 VFS.