### PR TITLE
Add Fyr brand image and roadmap

### DIFF
--- a/PHASE1_NATIVE_LANGUAGE.md
+++ b/PHASE1_NATIVE_LANGUAGE.md
@@ -1,14 +1,57 @@
 # Phase1 Native Language
 
+<p align="center">
+  <img src="assets/fyr-flame.svg" alt="Fyr flame mark with fyr written inside the flame" width="520">
+</p>
+
 Name: Fyr
 Extension: .fyr
 Command: fyr
+Roadmap: [`docs/fyr/ROADMAP.md`](docs/fyr/ROADMAP.md)
+Visual mark: [`assets/fyr-flame.svg`](assets/fyr-flame.svg)
 
-Fyr is the planned Phase1-native language target. It is reserved for stable Phase1 automation, virtual file system workflows, and future self-build scripts.
+Fyr is the planned Phase1-native language target. It is reserved for stable Phase1 automation, virtual file system workflows, future self-build scripts, and operator-owned tooling that should not stop working because an outside language changes direction.
 
-Initial milestone:
+Fyr is modeled after three familiar ideas:
+
+- C-style direct control and explicit entry points.
+- Rust-style safety posture, guarded capabilities, and predictable ownership boundaries.
+- Python-style readability and fast scripting flow.
+
+## Current milestone
 
 - language specification
 - examples
 - guard tests
-- later lexer and parser work
+- `fyr status`
+- `fyr spec`
+- seed `fyr run <file.fyr>` support for print literals
+- README/post flame mark
+- dedicated language roadmap
+
+## First working example
+
+```fyr
+fn main() -> i32 { print("Hello, hacker!"); return 0; }
+```
+
+Inside Phase1:
+
+```text
+fyr run hello_hacker.fyr
+```
+
+Expected output:
+
+```text
+Hello, hacker!
+```
+
+## Next milestones
+
+- `fyr new <name>` for starter program creation.
+- `fyr cat <file>` for native inspection from Phase1.
+- `fyr self` for Phase1 self-check and construction workflows.
+- Lexer and parser design.
+- VFS-safe standard library modules.
+- WASI-lite or compiler target decision.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
   ·
   <a href="FEATURE_STATUS.md">Feature status</a>
   ·
+  <a href="PHASE1_NATIVE_LANGUAGE.md">Fyr language</a>
+  ·
   <a href="LEARNING.md">Learning system</a>
   ·
   <a href="QUALITY.md">Quality</a>
@@ -32,8 +34,15 @@
   <img alt="Previous stable" src="https://img.shields.io/badge/previous%20stable-v4.1.0-7f8cff">
   <img alt="Edge" src="https://img.shields.io/badge/edge-v4.3.0--dev-00d8ff">
   <img alt="Rust" src="https://img.shields.io/badge/language-Rust-ff8a00">
+  <img alt="Fyr" src="https://img.shields.io/badge/native%20language-Fyr-ff5a00">
   <img alt="Security" src="https://img.shields.io/badge/safe%20mode-default%20on-39ff88">
   <img alt="License" src="https://img.shields.io/badge/license-GPL--3.0-8a5cff">
+</p>
+
+<p align="center">
+  <a href="PHASE1_NATIVE_LANGUAGE.md">
+    <img src="assets/fyr-flame.svg" alt="Fyr flame mark with fyr written inside the flame" width="520">
+  </a>
 </p>
 
 ## What is Phase1?
@@ -50,6 +59,25 @@ Phase1 is built around a simple public promise:
 
 The project image is modern, neon, technical, and disciplined: advanced visuals, conservative security claims, repeatable validation, and clear separation between stable releases and experimental edge work.
 
+## Fyr native language
+
+Fyr is the Phase1-native language target for VFS automation, self-construction, and operator-owned scripts. It is designed around C-style explicit control, Rust-style safety posture, and Python-style readability while staying owned by Phase1.
+
+Start with [`PHASE1_NATIVE_LANGUAGE.md`](PHASE1_NATIVE_LANGUAGE.md), then follow the dedicated [`Fyr roadmap`](docs/fyr/ROADMAP.md). The README/post flame mark lives at [`assets/fyr-flame.svg`](assets/fyr-flame.svg).
+
+First working script inside Phase1:
+
+```text
+echo 'fn main() -> i32 { print("Hello, hacker!"); return 0; }' > hello_hacker.fyr
+fyr run hello_hacker.fyr
+```
+
+Expected output:
+
+```text
+Hello, hacker!
+```
+
 ## Core capabilities
 
 | Area | What Phase1 provides |
@@ -57,6 +85,7 @@ The project image is modern, neon, technical, and disciplined: advanced visuals,
 | Operator console | A command-first interface with boot flow, dashboard, prompt, help, manual pages, and autocomplete. |
 | Virtual OS model | Simulated kernel, VFS, process table, `/proc`, `/dev`, `/var/log`, architecture and system inspection commands. |
 | Safe execution model | Safe mode on by default, host tools gated behind explicit trust, command capability metadata, and secret redaction. |
+| Fyr native language | Phase1-owned `.fyr` language path with initial command runner and roadmap for self-construction workflows. |
 | Learning system | `phase1-learn` stores local sanitized memory, imports history, learns notes/rules, and suggests next actions. |
 | Website and wiki | Public GitHub Pages site, browser terminal demo, docs hub, tutorials, and roadmap material. |
 | Storage and runtimes | Guarded storage/Git helper, Rust workflows, and a roadmap for broader programming-language support. |

--- a/assets/fyr-flame.svg
+++ b/assets/fyr-flame.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Fyr flame mark for the Phase1 native language</title>
+  <desc id="desc">A neon fire flame with the word fyr written inside, designed for README and social posting.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#070816"/>
+      <stop offset="55%" stop-color="#11152c"/>
+      <stop offset="100%" stop-color="#05050d"/>
+    </linearGradient>
+    <linearGradient id="flame" x1="0.25" x2="0.85" y1="0.95" y2="0.05">
+      <stop offset="0%" stop-color="#ff2e2e"/>
+      <stop offset="38%" stop-color="#ff8a00"/>
+      <stop offset="70%" stop-color="#ffe15a"/>
+      <stop offset="100%" stop-color="#39ff88"/>
+    </linearGradient>
+    <linearGradient id="inner" x1="0" x2="1" y1="1" y2="0">
+      <stop offset="0%" stop-color="#ff3b3b"/>
+      <stop offset="45%" stop-color="#ffb000"/>
+      <stop offset="100%" stop-color="#ffffff"/>
+    </linearGradient>
+    <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="10" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 1  0 0.65 0 0 0.25  0 0 0.15 0 0  0 0 0 0.9 0" result="glow"/>
+      <feMerge>
+        <feMergeNode in="glow"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="14" stdDeviation="18" flood-color="#000000" flood-opacity="0.45"/>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="630" rx="44" fill="url(#bg)"/>
+  <path d="M68 86h1064v458H68z" fill="none" stroke="#1879c8" stroke-width="5" opacity="0.75"/>
+  <path d="M92 112h1016v410H92z" fill="none" stroke="#39ff88" stroke-width="2" opacity="0.16"/>
+
+  <g filter="url(#softShadow)">
+    <path filter="url(#glow)" fill="url(#flame)" d="M604 80c74 91 19 149 111 242 43 44 66 93 63 147-5 93-84 153-178 153-99 0-180-64-180-159 0-67 43-116 86-165 45-51 82-101 98-218z"/>
+    <path fill="url(#inner)" opacity="0.92" d="M612 216c45 56 4 95 52 145 24 25 35 53 33 84-3 51-45 83-97 83-55 0-99-35-99-88 0-37 24-64 48-91 25-28 45-56 63-133z"/>
+  </g>
+
+  <text x="600" y="435" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="150" font-weight="900" letter-spacing="-10" fill="#070816">fyr</text>
+  <text x="600" y="428" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="150" font-weight="900" letter-spacing="-10" fill="#ffffff">fyr</text>
+  <text x="600" y="138" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="38" font-weight="800" fill="#39ff88">Phase1 Native Language</text>
+  <text x="600" y="554" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="30" fill="#7fd7ff">C-shaped control · Rust-shaped safety · Python-shaped flow</text>
+</svg>

--- a/assets/fyr-flame.svg
+++ b/assets/fyr-flame.svg
@@ -1,47 +1,45 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
-  <title id="title">Fyr flame mark for the Phase1 native language</title>
-  <desc id="desc">A neon fire flame with the word fyr written inside, designed for README and social posting.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" role="img" aria-labelledby="title desc">
+  <title id="title">Fyr flame mark</title>
+  <desc id="desc">A standalone flame symbol with fyr written inside.</desc>
   <defs>
-    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
-      <stop offset="0%" stop-color="#070816"/>
-      <stop offset="55%" stop-color="#11152c"/>
-      <stop offset="100%" stop-color="#05050d"/>
+    <radialGradient id="ember" cx="50%" cy="56%" r="62%">
+      <stop offset="0%" stop-color="#ffef9a"/>
+      <stop offset="36%" stop-color="#ff8a00"/>
+      <stop offset="72%" stop-color="#ff3030"/>
+      <stop offset="100%" stop-color="#5b0b16"/>
+    </radialGradient>
+    <linearGradient id="flame" x1="0.18" x2="0.85" y1="0.95" y2="0.06">
+      <stop offset="0%" stop-color="#ff2424"/>
+      <stop offset="42%" stop-color="#ff7a00"/>
+      <stop offset="74%" stop-color="#ffd84d"/>
+      <stop offset="100%" stop-color="#fff4bf"/>
     </linearGradient>
-    <linearGradient id="flame" x1="0.25" x2="0.85" y1="0.95" y2="0.05">
-      <stop offset="0%" stop-color="#ff2e2e"/>
-      <stop offset="38%" stop-color="#ff8a00"/>
-      <stop offset="70%" stop-color="#ffe15a"/>
-      <stop offset="100%" stop-color="#39ff88"/>
+    <linearGradient id="inner" x1="0.3" x2="0.78" y1="0.9" y2="0.1">
+      <stop offset="0%" stop-color="#ff3b1f"/>
+      <stop offset="52%" stop-color="#ffbe2e"/>
+      <stop offset="100%" stop-color="#fff7cc"/>
     </linearGradient>
-    <linearGradient id="inner" x1="0" x2="1" y1="1" y2="0">
-      <stop offset="0%" stop-color="#ff3b3b"/>
-      <stop offset="45%" stop-color="#ffb000"/>
-      <stop offset="100%" stop-color="#ffffff"/>
-    </linearGradient>
-    <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
-      <feGaussianBlur stdDeviation="10" result="blur"/>
-      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 1  0 0.65 0 0 0.25  0 0 0.15 0 0  0 0 0 0.9 0" result="glow"/>
+    <filter id="glow" x="-35%" y="-35%" width="170%" height="170%">
+      <feGaussianBlur stdDeviation="22" result="blur"/>
+      <feColorMatrix in="blur" type="matrix" values="1 0 0 0 1  0 0.58 0 0 0.2  0 0 0.08 0 0  0 0 0 0.95 0" result="colored"/>
       <feMerge>
-        <feMergeNode in="glow"/>
+        <feMergeNode in="colored"/>
         <feMergeNode in="SourceGraphic"/>
       </feMerge>
     </filter>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="18" flood-color="#000000" flood-opacity="0.45"/>
+    <filter id="shadow" x="-25%" y="-25%" width="150%" height="150%">
+      <feDropShadow dx="0" dy="28" stdDeviation="26" flood-color="#000000" flood-opacity="0.45"/>
     </filter>
   </defs>
 
-  <rect width="1200" height="630" rx="44" fill="url(#bg)"/>
-  <path d="M68 86h1064v458H68z" fill="none" stroke="#1879c8" stroke-width="5" opacity="0.75"/>
-  <path d="M92 112h1016v410H92z" fill="none" stroke="#39ff88" stroke-width="2" opacity="0.16"/>
+  <rect width="1024" height="1024" rx="180" fill="#080915"/>
+  <circle cx="512" cy="574" r="336" fill="url(#ember)" opacity="0.18"/>
 
-  <g filter="url(#softShadow)">
-    <path filter="url(#glow)" fill="url(#flame)" d="M604 80c74 91 19 149 111 242 43 44 66 93 63 147-5 93-84 153-178 153-99 0-180-64-180-159 0-67 43-116 86-165 45-51 82-101 98-218z"/>
-    <path fill="url(#inner)" opacity="0.92" d="M612 216c45 56 4 95 52 145 24 25 35 53 33 84-3 51-45 83-97 83-55 0-99-35-99-88 0-37 24-64 48-91 25-28 45-56 63-133z"/>
+  <g filter="url(#shadow)">
+    <path filter="url(#glow)" fill="url(#flame)" d="M518 74c74 91 84 168 59 237-13 36-4 68 34 100 78 66 126 145 119 238-10 141-120 237-254 237-148 0-270-99-270-243 0-98 59-171 119-241 74-86 155-163 193-328z"/>
+    <path fill="url(#inner)" opacity="0.96" d="M512 320c44 58 45 107 20 151-15 27-6 53 24 79 42 38 67 81 63 134-5 75-65 125-139 125-81 0-148-55-148-134 0-54 32-94 68-138 43-53 82-104 112-217z"/>
   </g>
 
-  <text x="600" y="435" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="150" font-weight="900" letter-spacing="-10" fill="#070816">fyr</text>
-  <text x="600" y="428" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="150" font-weight="900" letter-spacing="-10" fill="#ffffff">fyr</text>
-  <text x="600" y="138" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="38" font-weight="800" fill="#39ff88">Phase1 Native Language</text>
-  <text x="600" y="554" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="30" fill="#7fd7ff">C-shaped control · Rust-shaped safety · Python-shaped flow</text>
+  <text x="512" y="646" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="206" font-weight="900" letter-spacing="-12" fill="#220409" opacity="0.86">fyr</text>
+  <text x="512" y="632" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace" font-size="206" font-weight="900" letter-spacing="-12" fill="#fff8e6">fyr</text>
 </svg>

--- a/docs/fyr/ROADMAP.md
+++ b/docs/fyr/ROADMAP.md
@@ -1,0 +1,53 @@
+# Fyr language roadmap
+
+Fyr is the Phase1-native language path for VFS automation, self-construction, and stable operator scripts. The language is intentionally small at first: it should be easy to read like Python, explicit like C, and safe-by-default like Rust.
+
+## Current foundation
+
+- `PHASE1_NATIVE_LANGUAGE.md` names Fyr, reserves `.fyr`, and defines `fyr` as the command surface.
+- `examples/fyr/hello.fyr` and `examples/fyr/self_check.fyr` document the first source shape.
+- `fyr status`, `fyr spec`, and seed `fyr run <file.fyr>` support are wired into Phase1.
+- The seed runner can execute simple print string literals from `.fyr` files stored in the Phase1 VFS.
+
+## Roadmap
+
+| Stage | Goal | Deliverables | Status |
+| --- | --- | --- | --- |
+| F0 — Identity | Establish the language name, file extension, command, and visual mark. | `assets/fyr-flame.svg`, README reference, native language spec, roadmap. | Active |
+| F1 — Seed runner | Let Phase1 run simple `.fyr` programs from the VFS. | `fyr status`, `fyr spec`, `fyr run`, print literal support, guard tests. | Active |
+| F2 — Authoring loop | Make Fyr usable without manually echoing source code. | `fyr new <name>`, `fyr cat <file>`, starter templates, safer VFS writes. | Next |
+| F3 — Core syntax | Define stable parser behavior inspired by C, Rust, and Python. | Lexer, parser, function blocks, variables, return values, comments, diagnostics. | Planned |
+| F4 — Safe runtime | Execute useful scripts without exposing the host. | VFS reads/writes, command metadata, bounded runtime, redacted errors, deterministic tests. | Planned |
+| F5 — Phase1 self-workflows | Use Fyr to help Phase1 inspect, copy, construct, and validate itself. | `fyr self`, repository manifest readers, docs sync helpers, checkpoint helpers. | Planned |
+| F6 — Standard library | Provide a small Phase1-owned standard library. | `vfs`, `text`, `json-lite`, `audit`, `process`, `package`, and `doc` modules. | Planned |
+| F7 — Compiler path | Decide whether Fyr remains interpreted, lowers to Rust, or targets WASI-lite. | Compiler design note, WASI-lite strategy, packaging contract. | Planned |
+
+## Design rules
+
+- Keep Fyr source readable on mobile terminals.
+- Keep host access explicit and guarded.
+- Prefer deterministic behavior over clever behavior.
+- Make every language feature testable inside Phase1.
+- Never require Python, C, or Rust syntax changes to keep Phase1 scripts alive.
+
+## First working example
+
+```fyr
+fn main() -> i32 { print("Hello, hacker!"); return 0; }
+```
+
+Run inside Phase1:
+
+```text
+fyr run hello_hacker.fyr
+```
+
+Expected output:
+
+```text
+Hello, hacker!
+```
+
+## Visual reference
+
+The Fyr README/post image lives at [`assets/fyr-flame.svg`](../../assets/fyr-flame.svg). It uses a flame symbol with `fyr` written inside the flame for a clear language identity.

--- a/tests/fyr_brand_roadmap.rs
+++ b/tests/fyr_brand_roadmap.rs
@@ -24,5 +24,8 @@ fn fyr_brand_and_roadmap_are_documented() {
     let svg = fs::read_to_string("assets/fyr-flame.svg").expect("Fyr flame image exists");
     assert!(svg.contains("Fyr flame mark"));
     assert!(svg.contains(">fyr<"));
-    assert!(svg.contains("Phase1 Native Language"));
+    assert!(svg.contains("standalone flame symbol"));
+    assert!(!svg.contains("Phase1 Native Language"));
+    assert!(!svg.contains("C-shaped control"));
+    assert!(!svg.contains("README and social posting"));
 }

--- a/tests/fyr_brand_roadmap.rs
+++ b/tests/fyr_brand_roadmap.rs
@@ -1,0 +1,28 @@
+use std::fs;
+
+#[test]
+fn fyr_brand_and_roadmap_are_documented() {
+    let readme = fs::read_to_string("README.md").expect("README exists");
+    assert!(readme.contains("assets/fyr-flame.svg"));
+    assert!(readme.contains("PHASE1_NATIVE_LANGUAGE.md"));
+    assert!(readme.contains("docs/fyr/ROADMAP.md"));
+    assert!(readme.contains("fyr run hello_hacker.fyr"));
+
+    let spec = fs::read_to_string("PHASE1_NATIVE_LANGUAGE.md").expect("Fyr spec exists");
+    assert!(spec.contains("Name: Fyr"));
+    assert!(spec.contains("Extension: .fyr"));
+    assert!(spec.contains("Visual mark: [`assets/fyr-flame.svg`]"));
+    assert!(spec.contains("Roadmap: [`docs/fyr/ROADMAP.md`]"));
+
+    let roadmap = fs::read_to_string("docs/fyr/ROADMAP.md").expect("Fyr roadmap exists");
+    assert!(roadmap.contains("Fyr language roadmap"));
+    assert!(roadmap.contains("F0 — Identity"));
+    assert!(roadmap.contains("F1 — Seed runner"));
+    assert!(roadmap.contains("F2 — Authoring loop"));
+    assert!(roadmap.contains("F7 — Compiler path"));
+
+    let svg = fs::read_to_string("assets/fyr-flame.svg").expect("Fyr flame image exists");
+    assert!(svg.contains("Fyr flame mark"));
+    assert!(svg.contains(">fyr<"));
+    assert!(svg.contains("Phase1 Native Language"));
+}


### PR DESCRIPTION
Adds the Fyr flame SVG brand image for README/social use, updates the README and native language spec with Fyr references, adds a dedicated Fyr language roadmap covering identity through compiler path milestones, and adds a guard test to keep the Fyr docs and visual reference wired.