### PR TITLE
Add Fyr authoring commands

### DIFF
--- a/PHASE1_NATIVE_LANGUAGE.md
+++ b/PHASE1_NATIVE_LANGUAGE.md
@@ -55,3 +55,15 @@ Hello, hacker!
 - Lexer and parser design.
 - VFS-safe standard library modules.
 - WASI-lite or compiler target decision.
+
+
+## Authoring commands
+
+```text
+fyr new hello_hacker
+fyr cat hello_hacker.fyr
+fyr run hello_hacker.fyr
+fyr self
+```
+
+These commands let Phase1 create, inspect, and run Fyr files from inside the Phase1 shell without manually echoing source code.

--- a/docs/fyr/ROADMAP.md
+++ b/docs/fyr/ROADMAP.md
@@ -15,7 +15,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 | --- | --- | --- | --- |
 | F0 — Identity | Establish the language name, file extension, command, and visual mark. | `assets/fyr-flame.svg`, README reference, native language spec, roadmap. | Active |
 | F1 — Seed runner | Let Phase1 run simple `.fyr` programs from the VFS. | `fyr status`, `fyr spec`, `fyr run`, print literal support, guard tests. | Active |
-| F2 — Authoring loop | Make Fyr usable without manually echoing source code. | `fyr new <name>`, `fyr cat <file>`, starter templates, safer VFS writes. | Next |
+| F2 — Authoring loop | Make Fyr usable without manually echoing source code. | `fyr new <name>`, `fyr cat <file>`, `fyr self`, starter templates, safer VFS writes. | Active |
 | F3 — Core syntax | Define stable parser behavior inspired by C, Rust, and Python. | Lexer, parser, function blocks, variables, return values, comments, diagnostics. | Planned |
 | F4 — Safe runtime | Execute useful scripts without exposing the host. | VFS reads/writes, command metadata, bounded runtime, redacted errors, deterministic tests. | Planned |
 | F5 — Phase1 self-workflows | Use Fyr to help Phase1 inspect, copy, construct, and validate itself. | `fyr self`, repository manifest readers, docs sync helpers, checkpoint helpers. | Planned |

--- a/scripts/dev/add-fyr-authoring.py
+++ b/scripts/dev/add-fyr-authoring.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROOT = Path.cwd()
+
+
+def replace_once(text, old, new, label):
+    if old not in text:
+        raise SystemExit("missing patch anchor: " + label)
+    return text.replace(old, new, 1)
+
+
+main_path = ROOT / "src/main.rs"
+main = main_path.read_text()
+
+main = replace_once(
+    main,
+    '        Some("spec") => fyr_spec(),\n        Some("run") => fyr_run(shell, &args[1..]),',
+    '        Some("spec") => fyr_spec(),\n        Some("new") => fyr_new(shell, &args[1..]),\n        Some("cat") => fyr_cat(shell, &args[1..]),\n        Some("self") => fyr_self(),\n        Some("run") => fyr_run(shell, &args[1..]),',
+    "fyr command dispatch",
+)
+
+main = main.replace(
+    "status    : command stub active; interpreter seed supports print literals",
+    "status    : authoring loop active; interpreter seed supports print literals",
+)
+
+insert = r'''
+fn fyr_new(shell: &mut Phase1Shell, args: &[String]) -> String {
+    let Some(path) = args.first().and_then(|raw| fyr_file_name(raw)) else {
+        return "usage: fyr new <name>\n".to_string();
+    };
+
+    if shell.kernel.sys_read(&path).is_ok() {
+        return format!("fyr new: {path} already exists\n");
+    }
+
+    let source = "fn main() -> i32 { print(\"Hello, hacker!\"); return 0; }\n";
+    match shell.kernel.sys_write(&path, source, false) {
+        Ok(()) => format!("fyr new: created {path}\n"),
+        Err(err) => format!("fyr new: {err}\n"),
+    }
+}
+
+fn fyr_cat(shell: &mut Phase1Shell, args: &[String]) -> String {
+    let Some(path) = args.first().and_then(|raw| fyr_file_name(raw)) else {
+        return "usage: fyr cat <file.fyr>\n".to_string();
+    };
+
+    match shell.kernel.sys_read(&path) {
+        Ok(mut source) => {
+            if !source.ends_with('\n') {
+                source.push('\n');
+            }
+            source
+        }
+        Err(err) => format!("fyr cat: {err}\n"),
+    }
+}
+
+fn fyr_self() -> String {
+    "fyr self\nstatus : online\nvfs    : available\nrunner : print literal seed\nnext   : lexer, parser, VFS-safe standard library\n".to_string()
+}
+
+fn fyr_file_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let base = trimmed.strip_suffix(".fyr").unwrap_or(trimmed);
+    if base
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-'))
+    {
+        Some(format!("{base}.fyr"))
+    } else {
+        None
+    }
+}
+
+'''
+
+if "fn fyr_new(shell: &mut Phase1Shell" not in main:
+    main = replace_once(
+        main,
+        "fn fyr_run(shell: &mut Phase1Shell, args: &[String]) -> String {",
+        insert + "fn fyr_run(shell: &mut Phase1Shell, args: &[String]) -> String {",
+        "fyr run function",
+    )
+
+main = main.replace(
+    "usage:\\n  fyr status\\n  fyr spec\\n  fyr run <file.fyr>",
+    "usage:\\n  fyr status\\n  fyr spec\\n  fyr new <name>\\n  fyr cat <file.fyr>\\n  fyr self\\n  fyr run <file.fyr>",
+)
+
+main_path.write_text(main)
+
+registry_path = ROOT / "src/registry.rs"
+registry = registry_path.read_text()
+registry = registry.replace(
+    "fyr [status|spec|run <file.fyr>]",
+    "fyr [status|spec|new|cat|self|run <file.fyr>]",
+)
+registry_path.write_text(registry)
+
+spec_path = ROOT / "PHASE1_NATIVE_LANGUAGE.md"
+spec = spec_path.read_text()
+if "## Authoring commands" not in spec:
+    spec += """
+
+## Authoring commands
+
+```text
+fyr new hello_hacker
+fyr cat hello_hacker.fyr
+fyr run hello_hacker.fyr
+fyr self
+```
+
+These commands let Phase1 create, inspect, and run Fyr files from inside the Phase1 shell without manually echoing source code.
+"""
+spec_path.write_text(spec)
+
+roadmap_path = ROOT / "docs/fyr/ROADMAP.md"
+roadmap = roadmap_path.read_text()
+roadmap = roadmap.replace(
+    "| F2 — Authoring loop | Make Fyr usable without manually echoing source code. | `fyr new <name>`, `fyr cat <file>`, starter templates, safer VFS writes. | Next |",
+    "| F2 — Authoring loop | Make Fyr usable without manually echoing source code. | `fyr new <name>`, `fyr cat <file>`, `fyr self`, starter templates, safer VFS writes. | Active |",
+)
+roadmap_path.write_text(roadmap)
+
+test_path = ROOT / "tests/fyr_authoring_commands.rs"
+test_path.write_text('''use std::fs;
+
+#[test]
+fn fyr_authoring_commands_are_wired() {
+    let main = fs::read_to_string("src/main.rs").expect("main source exists");
+    assert!(main.contains("Some(\\\"new\\\") => fyr_new(shell, &args[1..])"));
+    assert!(main.contains("Some(\\\"cat\\\") => fyr_cat(shell, &args[1..])"));
+    assert!(main.contains("Some(\\\"self\\\") => fyr_self()"));
+    assert!(main.contains("fn fyr_new(shell: &mut Phase1Shell"));
+    assert!(main.contains("fn fyr_cat(shell: &mut Phase1Shell"));
+    assert!(main.contains("fn fyr_self()"));
+    assert!(main.contains("fn fyr_file_name(raw: &str)"));
+    assert!(main.contains("sys_write(&path, source, false)"));
+
+    let registry = fs::read_to_string("src/registry.rs").expect("registry source exists");
+    assert!(registry.contains("fyr [status|spec|new|cat|self|run <file.fyr>]"));
+
+    let spec = fs::read_to_string("PHASE1_NATIVE_LANGUAGE.md").expect("Fyr spec exists");
+    assert!(spec.contains("fyr new hello_hacker"));
+    assert!(spec.contains("fyr cat hello_hacker.fyr"));
+    assert!(spec.contains("fyr self"));
+}
+''')
+
+print("fyr authoring patch applied")

--- a/scripts/dev/add-fyr-authoring.py
+++ b/scripts/dev/add-fyr-authoring.py
@@ -136,9 +136,9 @@ test_path.write_text('''use std::fs;
 #[test]
 fn fyr_authoring_commands_are_wired() {
     let main = fs::read_to_string("src/main.rs").expect("main source exists");
-    assert!(main.contains("Some(\\\"new\\\") => fyr_new(shell, &args[1..])"));
-    assert!(main.contains("Some(\\\"cat\\\") => fyr_cat(shell, &args[1..])"));
-    assert!(main.contains("Some(\\\"self\\\") => fyr_self()"));
+    assert!(main.contains("Some(\"new\") => fyr_new(shell, &args[1..])"));
+    assert!(main.contains("Some(\"cat\") => fyr_cat(shell, &args[1..])"));
+    assert!(main.contains("Some(\"self\") => fyr_self()"));
     assert!(main.contains("fn fyr_new(shell: &mut Phase1Shell"));
     assert!(main.contains("fn fyr_cat(shell: &mut Phase1Shell"));
     assert!(main.contains("fn fyr_self()"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -553,6 +553,9 @@ fn fyr_command(shell: &mut Phase1Shell, args: &[String]) -> String {
     match args.first().map(String::as_str) {
         None | Some("status") => fyr_status(),
         Some("spec") => fyr_spec(),
+        Some("new") => fyr_new(shell, &args[1..]),
+        Some("cat") => fyr_cat(shell, &args[1..]),
+        Some("self") => fyr_self(),
         Some("run") => fyr_run(shell, &args[1..]),
         Some("help") | Some("-h") | Some("--help") => fyr_help(),
         Some(other) => format!("fyr: unknown action {other}\n{}", fyr_help()),
@@ -560,13 +563,66 @@ fn fyr_command(shell: &mut Phase1Shell, args: &[String]) -> String {
 }
 
 fn fyr_status() -> String {
-    "fyr native language\nname      : Fyr\nextension : .fyr\ncommand   : fyr\nstatus    : command stub active; interpreter seed supports print literals\npurpose   : Phase1-owned language path for self-construction and VFS automation\n".to_string()
+    "fyr native language\nname      : Fyr\nextension : .fyr\ncommand   : fyr\nstatus    : authoring loop active; interpreter seed supports print literals\npurpose   : Phase1-owned language path for self-construction and VFS automation\n".to_string()
 }
 
 fn fyr_spec() -> String {
     match fs::read_to_string("PHASE1_NATIVE_LANGUAGE.md") {
         Ok(spec) => spec,
         Err(err) => format!("fyr: could not read PHASE1_NATIVE_LANGUAGE.md: {err}\n"),
+    }
+}
+
+fn fyr_new(shell: &mut Phase1Shell, args: &[String]) -> String {
+    let Some(path) = args.first().and_then(|raw| fyr_file_name(raw)) else {
+        return "usage: fyr new <name>\n".to_string();
+    };
+
+    if shell.kernel.sys_read(&path).is_ok() {
+        return format!("fyr new: {path} already exists\n");
+    }
+
+    let source = "fn main() -> i32 { print(\"Hello, hacker!\"); return 0; }\n";
+    match shell.kernel.sys_write(&path, source, false) {
+        Ok(()) => format!("fyr new: created {path}\n"),
+        Err(err) => format!("fyr new: {err}\n"),
+    }
+}
+
+fn fyr_cat(shell: &mut Phase1Shell, args: &[String]) -> String {
+    let Some(path) = args.first().and_then(|raw| fyr_file_name(raw)) else {
+        return "usage: fyr cat <file.fyr>\n".to_string();
+    };
+
+    match shell.kernel.sys_read(&path) {
+        Ok(mut source) => {
+            if !source.ends_with('\n') {
+                source.push('\n');
+            }
+            source
+        }
+        Err(err) => format!("fyr cat: {err}\n"),
+    }
+}
+
+fn fyr_self() -> String {
+    "fyr self\nstatus : online\nvfs    : available\nrunner : print literal seed\nnext   : lexer, parser, VFS-safe standard library\n".to_string()
+}
+
+fn fyr_file_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let base = trimmed.strip_suffix(".fyr").unwrap_or(trimmed);
+    if base
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-'))
+    {
+        Some(format!("{base}.fyr"))
+    } else {
+        None
     }
 }
 
@@ -642,7 +698,7 @@ fn parse_fyr_string_literal(text: &str) -> Option<String> {
 }
 
 fn fyr_help() -> String {
-    "phase1 fyr command\n\nusage:\n  fyr status\n  fyr spec\n  fyr run <file.fyr>\n\nexample:\n  echo 'fn main() -> i32 { print(\"Hello, hacker!\"); return 0; }' > hello_hacker.fyr\n  fyr run hello_hacker.fyr\n".to_string()
+    "phase1 fyr command\n\nusage:\n  fyr status\n  fyr spec\n  fyr new <name>\n  fyr cat <file.fyr>\n  fyr self\n  fyr run <file.fyr>\n\nexample:\n  echo 'fn main() -> i32 { print(\"Hello, hacker!\"); return 0; }' > hello_hacker.fyr\n  fyr run hello_hacker.fyr\n".to_string()
 }
 
 fn repo_command(args: &[String]) -> String {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -74,7 +74,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     cmd!("emacs", &["emac", "phase1-emacs", "phase1emacs", "pemacs"], "editor", "emacs <file>", "Phase1 eMacs editor: VFS-native advanced editor powered by AVIM Pro.", "fs.write"),
     cmd!("dev", &["dock", "selfdev"], "dev", "dev [status|sync|branch|quick|test|commit|push|pr|merge|close|doctor]", "Phase1 self-development dock for working on Phase1 from inside Phase1.", "host.exec"),
     cmd!("repo", &["channels", "branches", "doctrine"], "dev", "repo [status|base|edge|checkpoint]", "Show the Phase1 repository channel doctrine: frozen base, active edge/stable path, checkpoints, and feature branch targets.", "none"),
-    cmd!("fyr", &["phase1lang", "forge"], "dev", "fyr [status|spec|run <file.fyr>]", "Phase1-native language target for self-construction and VFS automation.", "none"),
+    cmd!("fyr", &["phase1lang", "forge"], "dev", "fyr [status|spec|new|cat|self|run <file.fyr>]", "Phase1-native language target for self-construction and VFS automation.", "none"),
     cmd!("lang", &["language", "runlang"], "dev", "lang [list|support|status|doctor|detect|run|security]", "Native guarded multi-language runtime manager for major open-source programming languages.", "host.exec"),
     cmd!("lspci", &[], "arch", "lspci", "List simulated PCIe devices.", "hw.read"),
     cmd!("pcie", &[], "arch", "pcie", "Show PCIe subsystem summary.", "hw.read"),

--- a/tests/fyr_authoring_commands.rs
+++ b/tests/fyr_authoring_commands.rs
@@ -1,0 +1,22 @@
+use std::fs;
+
+#[test]
+fn fyr_authoring_commands_are_wired() {
+    let main = fs::read_to_string("src/main.rs").expect("main source exists");
+    assert!(main.contains("Some(\"new\") => fyr_new(shell, &args[1..])"));
+    assert!(main.contains("Some(\"cat\") => fyr_cat(shell, &args[1..])"));
+    assert!(main.contains("Some(\"self\") => fyr_self()"));
+    assert!(main.contains("fn fyr_new(shell: &mut Phase1Shell"));
+    assert!(main.contains("fn fyr_cat(shell: &mut Phase1Shell"));
+    assert!(main.contains("fn fyr_self()"));
+    assert!(main.contains("fn fyr_file_name(raw: &str)"));
+    assert!(main.contains("sys_write(&path, source, false)"));
+
+    let registry = fs::read_to_string("src/registry.rs").expect("registry source exists");
+    assert!(registry.contains("fyr [status|spec|new|cat|self|run <file.fyr>]"));
+
+    let spec = fs::read_to_string("PHASE1_NATIVE_LANGUAGE.md").expect("Fyr spec exists");
+    assert!(spec.contains("fyr new hello_hacker"));
+    assert!(spec.contains("fyr cat hello_hacker.fyr"));
+    assert!(spec.contains("fyr self"));
+}


### PR DESCRIPTION
Adds fyr new, fyr cat, and fyr self so Phase1 can create, inspect, and run Fyr files from inside the Phase1 shell without manually echoing source code.