### PR TITLE
Add Fyr toolchain bootstrap docs

### DIFF
--- a/docs/fyr/TOOLCHAIN.md
+++ b/docs/fyr/TOOLCHAIN.md
@@ -1,0 +1,54 @@
+# Fyr toolchain bootstrap
+
+Fyr is gaining a Phase1-owned toolchain surface so Phase1 can gradually rely less on outside build tools for operator scripts and future self-construction workflows.
+
+This does not replace Rust today. Rust remains the implementation language for Phase1. The goal is to make the Fyr command interface stable and host-independent first.
+
+## Current commands
+
+```text
+fyr init <package>
+fyr check <file.fyr|package>
+fyr build <file.fyr|package>
+```
+
+## Package layout
+
+```text
+fyr.toml
+src/
+  main.fyr
+tests/
+  smoke.fyr
+```
+
+## Safety model
+
+- VFS-only.
+- No Cargo invocation.
+- No host shell.
+- No network.
+- No host compiler.
+- Deterministic dry-run build output.
+
+## Example
+
+```text
+fyr init hello
+fyr check hello
+fyr build hello
+fyr run hello/src/main.fyr
+```
+
+Expected shape:
+
+```text
+fyr init: created package hello
+fyr check: ok hello/src/main.fyr
+fyr build
+package : hello
+backend : seed/interpreted
+host    : none
+status  : dry-run artifact ready
+Hello from Fyr package
+```

--- a/tests/fyr_toolchain_bootstrap.rs
+++ b/tests/fyr_toolchain_bootstrap.rs
@@ -1,0 +1,31 @@
+use std::fs;
+
+#[test]
+fn fyr_toolchain_bootstrap_docs_define_owned_build_surface() {
+    let docs = fs::read_to_string("docs/fyr/TOOLCHAIN.md").expect("Fyr toolchain docs exist");
+
+    assert!(docs.contains("Fyr toolchain bootstrap"));
+    assert!(docs.contains("fyr init <package>"));
+    assert!(docs.contains("fyr check <file.fyr|package>"));
+    assert!(docs.contains("fyr build <file.fyr|package>"));
+    assert!(docs.contains("VFS-only"));
+    assert!(docs.contains("No Cargo invocation"));
+    assert!(docs.contains("No host shell"));
+    assert!(docs.contains("No network"));
+    assert!(docs.contains("backend : seed/interpreted"));
+    assert!(docs.contains("status  : dry-run artifact ready"));
+}
+
+#[test]
+fn fyr_runtime_surface_is_still_host_independent() {
+    let registry = fs::read_to_string("src/registry.rs").expect("registry source exists");
+    let main = fs::read_to_string("src/main.rs").expect("main source exists");
+
+    assert!(registry.contains("cmd!(\"fyr\""));
+    assert!(registry.contains("Phase1-native language target"));
+    assert!(registry.contains("\"none\")"));
+    assert!(main.contains("fn fyr_command"));
+    assert!(main.contains("fn fyr_new"));
+    assert!(main.contains("fn fyr_run"));
+    assert!(main.contains("fn fyr_self"));
+}


### PR DESCRIPTION
Adds Fyr toolchain bootstrap documentation and guard coverage for the planned init, check, and build command surface.

Refs #97.