### PR TITLE
Implement Fyr runtime toolchain commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -554,7 +554,10 @@ fn fyr_command(shell: &mut Phase1Shell, args: &[String]) -> String {
         None | Some("status") => fyr_status(),
         Some("spec") => fyr_spec(),
         Some("new") => fyr_new(shell, &args[1..]),
+        Some("init") => fyr_init(shell, &args[1..]),
         Some("cat") => fyr_cat(shell, &args[1..]),
+        Some("check") => fyr_check(shell, &args[1..]),
+        Some("build") => fyr_build(shell, &args[1..]),
         Some("self") => fyr_self(),
         Some("run") => fyr_run(shell, &args[1..]),
         Some("help") | Some("-h") | Some("--help") => fyr_help(),
@@ -563,7 +566,7 @@ fn fyr_command(shell: &mut Phase1Shell, args: &[String]) -> String {
 }
 
 fn fyr_status() -> String {
-    "fyr native language\nname      : Fyr\nextension : .fyr\ncommand   : fyr\nstatus    : authoring loop active; interpreter seed supports print literals\npurpose   : Phase1-owned language path for self-construction and VFS automation\n".to_string()
+    "fyr native language\nname      : Fyr\nextension : .fyr\ncommand   : fyr\nstatus    : toolchain bootstrap active; VFS-only init/check/build and print-literal run\npurpose   : Phase1-owned language path for self-construction and VFS automation\n".to_string()
 }
 
 fn fyr_spec() -> String {
@@ -586,6 +589,143 @@ fn fyr_new(shell: &mut Phase1Shell, args: &[String]) -> String {
     match shell.kernel.sys_write(&path, source, false) {
         Ok(()) => format!("fyr new: created {path}\n"),
         Err(err) => format!("fyr new: {err}\n"),
+    }
+}
+
+fn fyr_init(shell: &mut Phase1Shell, args: &[String]) -> String {
+    let Some(package) = args.first().and_then(|raw| fyr_package_name(raw)) else {
+        return "usage: fyr init <package>\n".to_string();
+    };
+
+    let root = package;
+    let src_dir = format!("{root}/src");
+    let tests_dir = format!("{root}/tests");
+    let manifest = format!("{root}/fyr.toml");
+    let main_file = format!("{root}/src/main.fyr");
+    let smoke_file = format!("{root}/tests/smoke.fyr");
+
+    for dir in [&root, &src_dir, &tests_dir] {
+        if let Err(err) = shell.kernel.vfs.mkdir(dir) {
+            let msg = err.to_string();
+            if !msg.contains("already exists") {
+                return format!("fyr init: {msg}\n");
+            }
+        }
+    }
+
+    let manifest_source = format!(
+        "name = \"{root}\"\nversion = \"0.1.0\"\nbackend = \"seed/interpreted\"\nhost = \"none\"\n"
+    );
+    let main_source = "fn main() -> i32 { print(\"Hello from Fyr package\"); return 0; }\n";
+    let smoke_source = "fn main() -> i32 { print(\"fyr smoke ok\"); return 0; }\n";
+
+    for (path, source) in [
+        (&manifest, manifest_source.as_str()),
+        (&main_file, main_source),
+        (&smoke_file, smoke_source),
+    ] {
+        if shell.kernel.sys_read(path).is_err() {
+            if let Err(err) = shell.kernel.sys_write(path, source, false) {
+                return format!("fyr init: {err}\n");
+            }
+        }
+    }
+
+    format!(
+        "fyr init: created package {root}\nmanifest: {manifest}\nmain    : {main_file}\ntests   : {smoke_file}\nhost    : none\n"
+    )
+}
+
+fn fyr_check(shell: &mut Phase1Shell, args: &[String]) -> String {
+    let Some(path) = args.first().map(String::as_str) else {
+        return "usage: fyr check <file.fyr|package>\n".to_string();
+    };
+
+    let source_path = fyr_source_target(path);
+    let source = match shell.kernel.sys_read(&source_path) {
+        Ok(source) => source,
+        Err(err) => return format!("fyr check: {err}\n"),
+    };
+
+    match fyr_check_source(&source) {
+        Ok(()) => format!("fyr check: ok {source_path}\n"),
+        Err(err) => format!("fyr check: {source_path}: {err}\n"),
+    }
+}
+
+fn fyr_build(shell: &mut Phase1Shell, args: &[String]) -> String {
+    let Some(target) = args.first().map(String::as_str) else {
+        return "usage: fyr build <file.fyr|package>\n".to_string();
+    };
+
+    let source_path = fyr_source_target(target);
+    let source = match shell.kernel.sys_read(&source_path) {
+        Ok(source) => source,
+        Err(err) => return format!("fyr build: {err}\n"),
+    };
+
+    if let Err(err) = fyr_check_source(&source) {
+        return format!("fyr build: {source_path}: {err}\n");
+    }
+
+    let package = if target.ends_with(".fyr") {
+        target
+            .rsplit('/')
+            .next()
+            .unwrap_or(target)
+            .trim_end_matches(".fyr")
+            .to_string()
+    } else {
+        target.trim_end_matches('/').to_string()
+    };
+
+    format!(
+        "fyr build\npackage : {package}\nsource  : {source_path}\nbackend : seed/interpreted\nhost    : none\nstatus  : dry-run artifact ready\n"
+    )
+}
+
+fn fyr_source_target(raw: &str) -> String {
+    let target = raw.trim().trim_end_matches('/');
+    if target.ends_with(".fyr") {
+        target.to_string()
+    } else {
+        format!("{target}/src/main.fyr")
+    }
+}
+
+fn fyr_check_source(source: &str) -> Result<(), &'static str> {
+    let trimmed = source.trim();
+    if trimmed.is_empty() {
+        return Err("empty source");
+    }
+    if !trimmed.contains("fn main") {
+        return Err("missing fn main entry point");
+    }
+    if !trimmed.contains("print(") {
+        return Err("seed checker requires at least one print literal");
+    }
+    if !trimmed.contains("return") {
+        return Err("missing return statement");
+    }
+    if parse_fyr_string_literal(trimmed).is_none() {
+        return Err("missing valid string literal");
+    }
+    Ok(())
+}
+
+fn fyr_package_name(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-'))
+    {
+        Some(trimmed.to_string())
+    } else {
+        None
     }
 }
 
@@ -698,7 +838,7 @@ fn parse_fyr_string_literal(text: &str) -> Option<String> {
 }
 
 fn fyr_help() -> String {
-    "phase1 fyr command\n\nusage:\n  fyr status\n  fyr spec\n  fyr new <name>\n  fyr cat <file.fyr>\n  fyr self\n  fyr run <file.fyr>\n\nexample:\n  echo 'fn main() -> i32 { print(\"Hello, hacker!\"); return 0; }' > hello_hacker.fyr\n  fyr run hello_hacker.fyr\n".to_string()
+    "phase1 fyr command\n\nusage:\n  fyr status\n  fyr spec\n  fyr new <name>\n  fyr init <package>\n  fyr cat <file.fyr>\n  fyr check <file.fyr|package>\n  fyr build <file.fyr|package>\n  fyr self\n  fyr run <file.fyr>\n\nexample:\n  echo 'fn main() -> i32 { print(\"Hello, hacker!\"); return 0; }' > hello_hacker.fyr\n  fyr run hello_hacker.fyr\n".to_string()
 }
 
 fn repo_command(args: &[String]) -> String {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -74,7 +74,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     cmd!("emacs", &["emac", "phase1-emacs", "phase1emacs", "pemacs"], "editor", "emacs <file>", "Phase1 eMacs editor: VFS-native advanced editor powered by AVIM Pro.", "fs.write"),
     cmd!("dev", &["dock", "selfdev"], "dev", "dev [status|sync|branch|quick|test|commit|push|pr|merge|close|doctor]", "Phase1 self-development dock for working on Phase1 from inside Phase1.", "host.exec"),
     cmd!("repo", &["channels", "branches", "doctrine"], "dev", "repo [status|base|edge|checkpoint]", "Show the Phase1 repository channel doctrine: frozen base, active edge/stable path, checkpoints, and feature branch targets.", "none"),
-    cmd!("fyr", &["phase1lang", "forge"], "dev", "fyr [status|spec|new|cat|self|run <file.fyr>]", "Phase1-native language target for self-construction and VFS automation.", "none"),
+    cmd!("fyr", &["phase1lang", "forge"], "dev", "fyr [status|spec|new|init|cat|check|build|self|run <file.fyr>]", "Phase1-native language target for self-construction and VFS automation.", "none"),
     cmd!("lang", &["language", "runlang"], "dev", "lang [list|support|status|doctor|detect|run|security]", "Native guarded multi-language runtime manager for major open-source programming languages.", "host.exec"),
     cmd!("lspci", &[], "arch", "lspci", "List simulated PCIe devices.", "hw.read"),
     cmd!("pcie", &[], "arch", "pcie", "Show PCIe subsystem summary.", "hw.read"),

--- a/tests/fyr_authoring_commands.rs
+++ b/tests/fyr_authoring_commands.rs
@@ -4,16 +4,22 @@ use std::fs;
 fn fyr_authoring_commands_are_wired() {
     let main = fs::read_to_string("src/main.rs").expect("main source exists");
     assert!(main.contains("Some(\"new\") => fyr_new(shell, &args[1..])"));
+    assert!(main.contains("Some(\"init\") => fyr_init(shell, &args[1..])"));
     assert!(main.contains("Some(\"cat\") => fyr_cat(shell, &args[1..])"));
+    assert!(main.contains("Some(\"check\") => fyr_check(shell, &args[1..])"));
+    assert!(main.contains("Some(\"build\") => fyr_build(shell, &args[1..])"));
     assert!(main.contains("Some(\"self\") => fyr_self()"));
     assert!(main.contains("fn fyr_new(shell: &mut Phase1Shell"));
+    assert!(main.contains("fn fyr_init(shell: &mut Phase1Shell"));
     assert!(main.contains("fn fyr_cat(shell: &mut Phase1Shell"));
+    assert!(main.contains("fn fyr_check(shell: &mut Phase1Shell"));
+    assert!(main.contains("fn fyr_build(shell: &mut Phase1Shell"));
     assert!(main.contains("fn fyr_self()"));
     assert!(main.contains("fn fyr_file_name(raw: &str)"));
     assert!(main.contains("sys_write(&path, source, false)"));
 
     let registry = fs::read_to_string("src/registry.rs").expect("registry source exists");
-    assert!(registry.contains("fyr [status|spec|new|cat|self|run <file.fyr>]"));
+    assert!(registry.contains("fyr [status|spec|new|init|cat|check|build|self|run <file.fyr>]"));
 
     let spec = fs::read_to_string("PHASE1_NATIVE_LANGUAGE.md").expect("Fyr spec exists");
     assert!(spec.contains("fyr new hello_hacker"));

--- a/tests/fyr_runtime_toolchain.rs
+++ b/tests/fyr_runtime_toolchain.rs
@@ -1,0 +1,95 @@
+use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn run_phase1(script: &str) -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let seq = RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let run_dir = std::env::temp_dir().join(format!(
+        "phase1-fyr-runtime-{}-{nonce}-{seq}",
+        std::process::id()
+    ));
+
+    let _ = fs::remove_dir_all(&run_dir);
+    fs::create_dir_all(&run_dir).expect("create run dir");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .current_dir(&run_dir)
+        .env("PHASE1_NO_COLOR", "1")
+        .env("PHASE1_ASCII", "1")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_BLEEDING_EDGE", "1")
+        .env("PHASE1_MOBILE_MODE", "0")
+        .env("PHASE1_DEVICE_MODE", "desktop")
+        .env_remove("PHASE1_THEME")
+        .env_remove("PHASE1_ALLOW_HOST_TOOLS")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{script}").as_bytes())
+        .expect("write script");
+
+    let output = child.wait_with_output().expect("wait phase1");
+    let _ = fs::remove_dir_all(&run_dir);
+
+    let mut combined = String::new();
+    combined.push_str(&String::from_utf8_lossy(&output.stdout));
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "phase1 failed:\n{combined}");
+    combined
+}
+
+#[test]
+fn fyr_init_check_build_and_run_are_host_independent() {
+    let output = run_phase1(
+        "fyr init hello\nfyr check hello\nfyr build hello\nfyr run hello/src/main.fyr\nexit\n",
+    );
+
+    assert!(
+        output.contains("fyr init: created package hello"),
+        "{output}"
+    );
+    assert!(
+        output.contains("fyr check: ok hello/src/main.fyr"),
+        "{output}"
+    );
+    assert!(output.contains("fyr build"), "{output}");
+    assert!(output.contains("package : hello"), "{output}");
+    assert!(output.contains("backend : seed/interpreted"), "{output}");
+    assert!(output.contains("host    : none"), "{output}");
+    assert!(
+        output.contains("status  : dry-run artifact ready"),
+        "{output}"
+    );
+    assert!(output.contains("Hello from Fyr package"), "{output}");
+    assert!(
+        !output.contains("cargo "),
+        "Fyr runtime toolchain must not invoke Cargo:\n{output}"
+    );
+}
+
+#[test]
+fn fyr_check_reports_seed_diagnostics() {
+    let output =
+        run_phase1("echo 'print(\"missing entry\");' > bad.fyr\nfyr check bad.fyr\nexit\n");
+
+    assert!(
+        output.contains("fyr check: bad.fyr: missing fn main entry point"),
+        "{output}"
+    );
+}


### PR DESCRIPTION
Implements the first Fyr-owned runtime toolchain commands: fyr init, fyr check, and dry-run fyr build.

These commands are VFS-only and host-independent.

Closes #97.

Validation:
- cargo test -p phase1 --test fyr_authoring_commands
- cargo test -p phase1 --test fyr_runtime_toolchain
- cargo test -p phase1 --test fyr_toolchain_bootstrap
- cargo test --workspace --all-targets