### PR TITLE
Add Fyr parser diagnostics

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -698,19 +698,148 @@ fn fyr_check_source(source: &str) -> Result<(), &'static str> {
     if trimmed.is_empty() {
         return Err("empty source");
     }
-    if !trimmed.contains("fn main") {
-        return Err("missing fn main entry point");
+
+    let body = fyr_main_body(trimmed)?;
+    let mut rest = body.trim();
+    let mut saw_print = false;
+    let mut saw_return = false;
+
+    while !rest.is_empty() {
+        rest = rest.trim_start();
+
+        if rest.starts_with("print") {
+            saw_print = true;
+            rest = fyr_parse_print_statement(rest)?;
+        } else if rest.starts_with("return") {
+            saw_return = true;
+            rest = fyr_parse_return_statement(rest)?;
+        } else {
+            return Err("expected print or return statement");
+        }
+
+        rest = rest.trim_start();
     }
-    if !trimmed.contains("print(") {
+
+    if !saw_print {
         return Err("seed checker requires at least one print literal");
     }
-    if !trimmed.contains("return") {
+    if !saw_return {
         return Err("missing return statement");
     }
-    if parse_fyr_string_literal(trimmed).is_none() {
-        return Err("missing valid string literal");
-    }
+
     Ok(())
+}
+
+fn fyr_main_body(source: &str) -> Result<&str, &'static str> {
+    let Some(fn_pos) = source.find("fn") else {
+        return Err("missing fn main entry point");
+    };
+
+    let source = source[fn_pos..].trim_start();
+    let Some(rest) = source.strip_prefix("fn main() -> i32") else {
+        return Err("missing fn main entry point");
+    };
+
+    let rest = rest.trim_start();
+    let Some(body) = rest.strip_prefix('{') else {
+        return Err("expected '{' after fn main signature");
+    };
+
+    let Some(close) = body.rfind('}') else {
+        return Err("expected '}' after fn main body");
+    };
+
+    Ok(&body[..close])
+}
+
+fn fyr_parse_print_statement(statement: &str) -> Result<&str, &'static str> {
+    let Some(rest) = statement.strip_prefix("print") else {
+        return Err("expected print statement");
+    };
+
+    let rest = rest.trim_start();
+    let Some(rest) = rest.strip_prefix('(') else {
+        return Err("expected '(' after print");
+    };
+
+    let (_, rest) = fyr_parse_string_literal_with_rest(rest)?;
+    let rest = rest.trim_start();
+
+    let Some(rest) = rest.strip_prefix(')') else {
+        return Err("expected ')' after print literal");
+    };
+
+    let rest = rest.trim_start();
+    let Some(rest) = rest.strip_prefix(';') else {
+        return Err("expected ';' after print statement");
+    };
+
+    Ok(rest)
+}
+
+fn fyr_parse_return_statement(statement: &str) -> Result<&str, &'static str> {
+    let Some(rest) = statement.strip_prefix("return") else {
+        return Err("expected return statement");
+    };
+
+    let rest = rest.trim_start();
+    let mut end = 0usize;
+    let mut saw_digit = false;
+
+    for (idx, ch) in rest.char_indices() {
+        if ch.is_ascii_digit() {
+            saw_digit = true;
+            end = idx + ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    if !saw_digit {
+        return Err("expected integer return value");
+    }
+
+    let rest = rest[end..].trim_start();
+    let Some(rest) = rest.strip_prefix(';') else {
+        return Err("expected ';' after return statement");
+    };
+
+    Ok(rest)
+}
+
+fn fyr_parse_string_literal_with_rest(text: &str) -> Result<(String, &str), &'static str> {
+    let text = text.trim_start();
+    let Some(inner) = text.strip_prefix('"') else {
+        return Err("expected string literal");
+    };
+
+    let mut out = String::new();
+    let mut escaped = false;
+
+    for (idx, ch) in inner.char_indices() {
+        if escaped {
+            match ch {
+                'n' => out.push('\n'),
+                't' => out.push('\t'),
+                '"' => out.push('"'),
+                '\\' => out.push('\\'),
+                other => out.push(other),
+            }
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' => escaped = true,
+            '"' => {
+                let rest = &inner[idx + ch.len_utf8()..];
+                return Ok((out, rest));
+            }
+            other => out.push(other),
+        }
+    }
+
+    Err("unterminated string literal")
 }
 
 fn fyr_package_name(raw: &str) -> Option<String> {

--- a/tests/fyr_parser_diagnostics.rs
+++ b/tests/fyr_parser_diagnostics.rs
@@ -1,0 +1,106 @@
+use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn run_phase1(script: &str) -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let seq = RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let run_dir = std::env::temp_dir().join(format!(
+        "phase1-fyr-parser-{}-{nonce}-{seq}",
+        std::process::id()
+    ));
+
+    let _ = fs::remove_dir_all(&run_dir);
+    fs::create_dir_all(&run_dir).expect("create run dir");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .current_dir(&run_dir)
+        .env("PHASE1_NO_COLOR", "1")
+        .env("PHASE1_ASCII", "1")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_BLEEDING_EDGE", "1")
+        .env("PHASE1_MOBILE_MODE", "0")
+        .env("PHASE1_DEVICE_MODE", "desktop")
+        .env_remove("PHASE1_THEME")
+        .env_remove("PHASE1_ALLOW_HOST_TOOLS")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{script}").as_bytes())
+        .expect("write script");
+
+    let output = child.wait_with_output().expect("wait phase1");
+    let _ = fs::remove_dir_all(&run_dir);
+
+    let mut combined = String::new();
+    combined.push_str(&String::from_utf8_lossy(&output.stdout));
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success(), "phase1 failed:\n{combined}");
+    combined
+}
+
+#[test]
+fn fyr_parser_accepts_multiple_print_literals() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { print(\"one\"); print(\"two\"); return 0; }' > multi.fyr\nfyr check multi.fyr\nfyr run multi.fyr\nexit\n",
+    );
+
+    assert!(output.contains("fyr check: ok multi.fyr"), "{output}");
+    assert!(output.contains("one"), "{output}");
+    assert!(output.contains("two"), "{output}");
+}
+
+#[test]
+fn fyr_parser_reports_missing_main() {
+    let output =
+        run_phase1("echo 'print(\"missing entry\");' > bad.fyr\nfyr check bad.fyr\nexit\n");
+
+    assert!(
+        output.contains("fyr check: bad.fyr: missing fn main entry point"),
+        "{output}"
+    );
+}
+
+#[test]
+fn fyr_parser_reports_unterminated_string() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { print(\"unterminated); return 0; }' > bad.fyr\nfyr check bad.fyr\nexit\n",
+    );
+
+    assert!(output.contains("unterminated string literal"), "{output}");
+}
+
+#[test]
+fn fyr_parser_reports_missing_semicolon() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { print(\"oops\") return 0; }' > bad.fyr\nfyr check bad.fyr\nexit\n",
+    );
+
+    assert!(
+        output.contains("expected ';' after print statement"),
+        "{output}"
+    );
+}
+
+#[test]
+fn fyr_parser_reports_invalid_return_value() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { print(\"oops\"); return nope; }' > bad.fyr\nfyr check bad.fyr\nexit\n",
+    );
+
+    assert!(output.contains("expected integer return value"), "{output}");
+}


### PR DESCRIPTION
Adds parser-backed diagnostics for the Fyr seed language.

Supports:
- fn main() -> i32
- print("literal");
- return <integer>;

Closes #101.

Validation:
- cargo test -p phase1 --test fyr_parser_diagnostics
- cargo test -p phase1 --test fyr_runtime_toolchain
- cargo test --workspace --all-targets