### PR TITLE
Add Fyr AST and module resolver

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -637,19 +637,13 @@ fn fyr_init(shell: &mut Phase1Shell, args: &[String]) -> String {
 }
 
 fn fyr_check(shell: &mut Phase1Shell, args: &[String]) -> String {
-    let Some(path) = args.first().map(String::as_str) else {
+    let Some(target) = args.first().map(String::as_str) else {
         return "usage: fyr check <file.fyr|package>\n".to_string();
     };
 
-    let source_path = fyr_source_target(path);
-    let source = match shell.kernel.sys_read(&source_path) {
-        Ok(source) => source,
-        Err(err) => return format!("fyr check: {err}\n"),
-    };
-
-    match fyr_check_source(&source) {
-        Ok(()) => format!("fyr check: ok {source_path}\n"),
-        Err(err) => format!("fyr check: {source_path}: {err}\n"),
+    match fyr_resolve_target(shell, target) {
+        Ok(resolved) => format!("fyr check: ok {}\n", resolved.source_path()),
+        Err(err) => format!("fyr check: {err}\n"),
     }
 }
 
@@ -658,76 +652,221 @@ fn fyr_build(shell: &mut Phase1Shell, args: &[String]) -> String {
         return "usage: fyr build <file.fyr|package>\n".to_string();
     };
 
-    let source_path = fyr_source_target(target);
-    let source = match shell.kernel.sys_read(&source_path) {
-        Ok(source) => source,
+    let resolved = match fyr_resolve_target(shell, target) {
+        Ok(resolved) => resolved,
         Err(err) => return format!("fyr build: {err}\n"),
     };
 
-    if let Err(err) = fyr_check_source(&source) {
-        return format!("fyr build: {source_path}: {err}\n");
-    }
-
-    let package = if target.ends_with(".fyr") {
-        target
-            .rsplit('/')
-            .next()
-            .unwrap_or(target)
-            .trim_end_matches(".fyr")
-            .to_string()
-    } else {
-        target.trim_end_matches('/').to_string()
-    };
-
+    let summary = resolved.ast_summary();
     format!(
-        "fyr build\npackage : {package}\nsource  : {source_path}\nbackend : seed/interpreted\nhost    : none\nstatus  : dry-run artifact ready\n"
+        "fyr build\npackage : {}\nsource  : {}\nast     : functions={} prints={} returns={}\nbackend : seed/interpreted\nhost    : none\nstatus  : dry-run artifact ready\n",
+        resolved.package_name(),
+        resolved.source_path(),
+        summary.functions,
+        summary.prints,
+        summary.returns,
     )
 }
 
-fn fyr_source_target(raw: &str) -> String {
-    let target = raw.trim().trim_end_matches('/');
-    if target.ends_with(".fyr") {
-        target.to_string()
-    } else {
-        format!("{target}/src/main.fyr")
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct FyrSourceAst {
+    functions: Vec<FyrFunctionAst>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct FyrFunctionAst {
+    name: String,
+    statements: Vec<FyrStatementAst>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum FyrStatementAst {
+    Print(String),
+    Return(i32),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct FyrAstSummary {
+    functions: usize,
+    prints: usize,
+    returns: usize,
+}
+
+enum FyrResolvedTarget {
+    Single {
+        source_path: String,
+        ast: FyrSourceAst,
+    },
+    Package {
+        package: String,
+        main_path: String,
+        ast: FyrSourceAst,
+    },
+}
+
+impl FyrResolvedTarget {
+    fn source_path(&self) -> &str {
+        match self {
+            Self::Single { source_path, .. } => source_path,
+            Self::Package { main_path, .. } => main_path,
+        }
+    }
+
+    fn package_name(&self) -> String {
+        match self {
+            Self::Single { source_path, .. } => source_path
+                .rsplit('/')
+                .next()
+                .unwrap_or(source_path)
+                .trim_end_matches(".fyr")
+                .to_string(),
+            Self::Package { package, .. } => package.clone(),
+        }
+    }
+
+    fn ast_summary(&self) -> FyrAstSummary {
+        match self {
+            Self::Single { ast, .. } | Self::Package { ast, .. } => fyr_ast_summary(ast),
+        }
     }
 }
 
-fn fyr_check_source(source: &str) -> Result<(), &'static str> {
-    let trimmed = source.trim();
-    if trimmed.is_empty() {
-        return Err("empty source");
+fn fyr_resolve_target(shell: &mut Phase1Shell, raw: &str) -> Result<FyrResolvedTarget, String> {
+    let target = raw.trim().trim_end_matches('/');
+
+    if target.ends_with(".fyr") {
+        let source = shell
+            .kernel
+            .sys_read(target)
+            .map_err(|err| err.to_string())?;
+        let ast = fyr_parse_source_ast(&source).map_err(|err| format!("{target}: {err}"))?;
+        return Ok(FyrResolvedTarget::Single {
+            source_path: target.to_string(),
+            ast,
+        });
     }
 
-    let body = fyr_main_body(trimmed)?;
+    let manifest = format!("{target}/fyr.toml");
+    if shell.kernel.sys_read(&manifest).is_err() {
+        return Err(format!("{target}: missing package manifest {manifest}"));
+    }
+
+    let main_path = format!("{target}/src/main.fyr");
+    let main_source = shell
+        .kernel
+        .sys_read(&main_path)
+        .map_err(|_| format!("{target}: missing package main {main_path}"))?;
+    let main_ast =
+        fyr_parse_source_ast(&main_source).map_err(|err| format!("{main_path}: {err}"))?;
+
+    let mut package_ast = FyrSourceAst {
+        functions: main_ast.functions,
+    };
+
+    let src_dir = format!("{target}/src");
+    let listing = shell.kernel.vfs.ls(Some(&src_dir), false);
+    for name in listing
+        .lines()
+        .map(str::trim)
+        .filter(|name| name.ends_with(".fyr") && *name != "main.fyr" && !name.contains(':'))
+    {
+        let path = format!("{src_dir}/{name}");
+        let source = shell
+            .kernel
+            .sys_read(&path)
+            .map_err(|err| format!("{path}: {err}"))?;
+        let module_ast = fyr_parse_source_ast(&source).map_err(|err| format!("{path}: {err}"))?;
+        package_ast.functions.extend(module_ast.functions);
+    }
+
+    let main_count = package_ast
+        .functions
+        .iter()
+        .filter(|function| function.name == "main")
+        .count();
+    if main_count > 1 {
+        return Err(format!("{target}: duplicate fn main"));
+    }
+    if main_count == 0 {
+        return Err(format!("{target}: missing fn main entry point"));
+    }
+
+    Ok(FyrResolvedTarget::Package {
+        package: target.to_string(),
+        main_path,
+        ast: package_ast,
+    })
+}
+
+fn fyr_parse_source_ast(source: &str) -> Result<FyrSourceAst, &'static str> {
+    let function = fyr_parse_main_function(source)?;
+    Ok(FyrSourceAst {
+        functions: vec![function],
+    })
+}
+
+fn fyr_ast_summary(ast: &FyrSourceAst) -> FyrAstSummary {
+    let mut summary = FyrAstSummary {
+        functions: ast.functions.len(),
+        prints: 0,
+        returns: 0,
+    };
+
+    for function in &ast.functions {
+        for statement in &function.statements {
+            match statement {
+                FyrStatementAst::Print(_) => summary.prints += 1,
+                FyrStatementAst::Return(_) => summary.returns += 1,
+            }
+        }
+    }
+
+    summary
+}
+
+fn fyr_parse_main_function(source: &str) -> Result<FyrFunctionAst, &'static str> {
+    let body = fyr_main_body(source)?;
+    let statements = fyr_parse_statements(body)?;
+    Ok(FyrFunctionAst {
+        name: "main".to_string(),
+        statements,
+    })
+}
+
+fn fyr_parse_statements(body: &str) -> Result<Vec<FyrStatementAst>, &'static str> {
+    let mut statements = Vec::new();
     let mut rest = body.trim();
-    let mut saw_print = false;
-    let mut saw_return = false;
 
     while !rest.is_empty() {
         rest = rest.trim_start();
 
         if rest.starts_with("print") {
-            saw_print = true;
-            rest = fyr_parse_print_statement(rest)?;
+            let (statement, next) = fyr_parse_print_statement_ast(rest)?;
+            statements.push(statement);
+            rest = next.trim_start();
         } else if rest.starts_with("return") {
-            saw_return = true;
-            rest = fyr_parse_return_statement(rest)?;
+            let (statement, next) = fyr_parse_return_statement_ast(rest)?;
+            statements.push(statement);
+            rest = next.trim_start();
         } else {
             return Err("expected print or return statement");
         }
-
-        rest = rest.trim_start();
     }
 
-    if !saw_print {
+    if !statements
+        .iter()
+        .any(|statement| matches!(statement, FyrStatementAst::Print(_)))
+    {
         return Err("seed checker requires at least one print literal");
     }
-    if !saw_return {
+    if !statements
+        .iter()
+        .any(|statement| matches!(statement, FyrStatementAst::Return(_)))
+    {
         return Err("missing return statement");
     }
 
-    Ok(())
+    Ok(statements)
 }
 
 fn fyr_main_body(source: &str) -> Result<&str, &'static str> {
@@ -752,7 +891,7 @@ fn fyr_main_body(source: &str) -> Result<&str, &'static str> {
     Ok(&body[..close])
 }
 
-fn fyr_parse_print_statement(statement: &str) -> Result<&str, &'static str> {
+fn fyr_parse_print_statement_ast(statement: &str) -> Result<(FyrStatementAst, &str), &'static str> {
     let Some(rest) = statement.strip_prefix("print") else {
         return Err("expected print statement");
     };
@@ -762,7 +901,7 @@ fn fyr_parse_print_statement(statement: &str) -> Result<&str, &'static str> {
         return Err("expected '(' after print");
     };
 
-    let (_, rest) = fyr_parse_string_literal_with_rest(rest)?;
+    let (message, rest) = fyr_parse_string_literal_with_rest(rest)?;
     let rest = rest.trim_start();
 
     let Some(rest) = rest.strip_prefix(')') else {
@@ -774,10 +913,12 @@ fn fyr_parse_print_statement(statement: &str) -> Result<&str, &'static str> {
         return Err("expected ';' after print statement");
     };
 
-    Ok(rest)
+    Ok((FyrStatementAst::Print(message), rest))
 }
 
-fn fyr_parse_return_statement(statement: &str) -> Result<&str, &'static str> {
+fn fyr_parse_return_statement_ast(
+    statement: &str,
+) -> Result<(FyrStatementAst, &str), &'static str> {
     let Some(rest) = statement.strip_prefix("return") else {
         return Err("expected return statement");
     };
@@ -799,12 +940,16 @@ fn fyr_parse_return_statement(statement: &str) -> Result<&str, &'static str> {
         return Err("expected integer return value");
     }
 
+    let value = rest[..end]
+        .parse::<i32>()
+        .map_err(|_| "expected integer return value")?;
     let rest = rest[end..].trim_start();
+
     let Some(rest) = rest.strip_prefix(';') else {
         return Err("expected ';' after return statement");
     };
 
-    Ok(rest)
+    Ok((FyrStatementAst::Return(value), rest))
 }
 
 fn fyr_parse_string_literal_with_rest(text: &str) -> Result<(String, &str), &'static str> {

--- a/tests/fyr_ast_module_resolver.rs
+++ b/tests/fyr_ast_module_resolver.rs
@@ -1,0 +1,102 @@
+use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn run_phase1(script: &str) -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let seq = RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let run_dir = std::env::temp_dir().join(format!(
+        "phase1-fyr-ast-{}-{nonce}-{seq}",
+        std::process::id()
+    ));
+
+    let _ = fs::remove_dir_all(&run_dir);
+    fs::create_dir_all(&run_dir).expect("create run dir");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .current_dir(&run_dir)
+        .env("PHASE1_NO_COLOR", "1")
+        .env("PHASE1_ASCII", "1")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_BLEEDING_EDGE", "1")
+        .env("PHASE1_MOBILE_MODE", "0")
+        .env("PHASE1_DEVICE_MODE", "desktop")
+        .env_remove("PHASE1_THEME")
+        .env_remove("PHASE1_ALLOW_HOST_TOOLS")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{script}").as_bytes())
+        .expect("write script");
+
+    let output = child.wait_with_output().expect("wait phase1");
+    let _ = fs::remove_dir_all(&run_dir);
+
+    let mut combined = String::new();
+    combined.push_str(&String::from_utf8_lossy(&output.stdout));
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success(), "phase1 failed:\n{combined}");
+    combined
+}
+
+#[test]
+fn fyr_package_check_requires_manifest_and_main() {
+    let output = run_phase1("mkdir app\nmkdir app/src\nfyr check app\nexit\n");
+
+    assert!(
+        output.contains("fyr check: app: missing package manifest app/fyr.toml"),
+        "{output}"
+    );
+}
+
+#[test]
+fn fyr_package_build_reports_ast_summary() {
+    let output = run_phase1("fyr init app\nfyr check app\nfyr build app\nexit\n");
+
+    assert!(
+        output.contains("fyr check: ok app/src/main.fyr"),
+        "{output}"
+    );
+    assert!(output.contains("fyr build"), "{output}");
+    assert!(output.contains("package : app"), "{output}");
+    assert!(output.contains("source  : app/src/main.fyr"), "{output}");
+    assert!(
+        output.contains("ast     : functions=1 prints=1 returns=1"),
+        "{output}"
+    );
+    assert!(output.contains("backend : seed/interpreted"), "{output}");
+    assert!(output.contains("host    : none"), "{output}");
+}
+
+#[test]
+fn fyr_package_check_detects_duplicate_main() {
+    let output = run_phase1(
+        "fyr init app\necho 'fn main() -> i32 { print(\"dup\"); return 0; }' > app/src/other.fyr\nfyr check app\nexit\n",
+    );
+
+    assert!(output.contains("duplicate fn main"), "{output}");
+}
+
+#[test]
+fn fyr_single_file_check_still_works() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { print(\"single\"); return 0; }' > single.fyr\nfyr check single.fyr\nfyr build single.fyr\nexit\n",
+    );
+
+    assert!(output.contains("fyr check: ok single.fyr"), "{output}");
+    assert!(output.contains("source  : single.fyr"), "{output}");
+}


### PR DESCRIPTION
Adds a small Fyr AST model and VFS package/module resolution.

Includes:
- AST summary for functions, print statements, and return statements
- package checks for fyr.toml and src/main.fyr
- duplicate fn main detection across package source files
- preservation of single-file check/build/run behavior

Closes #103.

Validation:
- cargo test -p phase1 --test fyr_ast_module_resolver
- cargo test -p phase1 --test fyr_parser_diagnostics
- cargo test -p phase1 --test fyr_runtime_toolchain
- cargo test --workspace --all-targets