### PR TITLE
Add Fyr test diagnostics

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1037,6 +1037,7 @@ fn fyr_test(shell: &mut Phase1Shell, args: &[String]) -> String {
     let mut tests = 0usize;
     let mut passed = 0usize;
     let mut failed = 0usize;
+    let mut out = format!("fyr test\npackage : {package}\n");
 
     for name in listing
         .lines()
@@ -1045,17 +1046,31 @@ fn fyr_test(shell: &mut Phase1Shell, args: &[String]) -> String {
     {
         tests += 1;
         let path = format!("{tests_dir}/{name}");
+
         match shell.kernel.sys_read(&path) {
-            Ok(source) if fyr_parse_source_ast(&source).is_ok() => passed += 1,
-            _ => failed += 1,
+            Ok(source) => match fyr_parse_source_ast(&source) {
+                Ok(_) => {
+                    passed += 1;
+                    out.push_str(&format!("test    : {path} ok\n"));
+                }
+                Err(err) => {
+                    failed += 1;
+                    out.push_str(&format!("test    : {path} failed: {err}\n"));
+                }
+            },
+            Err(err) => {
+                failed += 1;
+                out.push_str(&format!("test    : {path} failed: {err}\n"));
+            }
         }
     }
 
     let status = if failed == 0 { "ok" } else { "failed" };
 
-    format!(
-        "fyr test\npackage : {package}\ntests   : {tests}\npassed  : {passed}\nfailed  : {failed}\nstatus  : {status}\n"
-    )
+    out.push_str(&format!(
+        "tests   : {tests}\npassed  : {passed}\nfailed  : {failed}\nstatus  : {status}\n"
+    ));
+    out
 }
 
 fn fyr_self() -> String {

--- a/tests/fyr_test_runner.rs
+++ b/tests/fyr_test_runner.rs
@@ -74,3 +74,37 @@ fn fyr_test_reports_missing_package_manifest() {
         "{output}"
     );
 }
+
+#[test]
+fn fyr_test_reports_each_test_file() {
+    let output = run_phase1("fyr init app\nfyr test app\nexit\n");
+
+    assert!(
+        output.contains("test    : app/tests/smoke.fyr ok"),
+        "{output}"
+    );
+    assert!(output.contains("tests   : 1"), "{output}");
+    assert!(output.contains("passed  : 1"), "{output}");
+    assert!(output.contains("failed  : 0"), "{output}");
+    assert!(output.contains("status  : ok"), "{output}");
+}
+
+#[test]
+fn fyr_test_reports_failed_test_file_diagnostics() {
+    let output = run_phase1(
+        "fyr init app\necho 'print(\"missing entry\");' > app/tests/bad.fyr\nfyr test app\nexit\n",
+    );
+
+    assert!(
+        output.contains("test    : app/tests/bad.fyr failed: missing fn main entry point"),
+        "{output}"
+    );
+    assert!(
+        output.contains("test    : app/tests/smoke.fyr ok"),
+        "{output}"
+    );
+    assert!(output.contains("tests   : 2"), "{output}");
+    assert!(output.contains("passed  : 1"), "{output}");
+    assert!(output.contains("failed  : 1"), "{output}");
+    assert!(output.contains("status  : failed"), "{output}");
+}


### PR DESCRIPTION
Adds per-file diagnostics to the Fyr package test workflow.

Includes:
- test file names
- per-file ok/failed status
- parser error details for failed test files
- deterministic summary counts

Closes #106.

Validation:
- cargo test -p phase1 --test fyr_test_runner
- cargo test -p phase1 --test fyr_ast_module_resolver
- cargo test --workspace --all-targets