### PR TITLE
Add Fyr syntax color command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -556,6 +556,7 @@ fn fyr_command(shell: &mut Phase1Shell, args: &[String]) -> String {
         Some("new") => fyr_new(shell, &args[1..]),
         Some("init") => fyr_init(shell, &args[1..]),
         Some("cat") => fyr_cat(shell, &args[1..]),
+        Some("color") | Some("highlight") => fyr_color(shell, &args[1..]),
         Some("check") => fyr_check(shell, &args[1..]),
         Some("build") => fyr_build(shell, &args[1..]),
         Some("test") => fyr_test(shell, &args[1..]),
@@ -1178,6 +1179,101 @@ fn fyr_package_name(raw: &str) -> Option<String> {
     } else {
         None
     }
+}
+
+fn fyr_color(shell: &mut Phase1Shell, args: &[String]) -> String {
+    let Some(target) = args.first().map(String::as_str) else {
+        return "usage: fyr color <file.fyr>\n".to_string();
+    };
+
+    let target = target.trim();
+    match shell.kernel.sys_read(target) {
+        Ok(source) => fyr_colorize_source(&source),
+        Err(_) => format!("fyr color: no such file: {target}\n"),
+    }
+}
+
+fn fyr_colorize_source(source: &str) -> String {
+    let mut out = String::new();
+
+    for line in source.lines() {
+        let mut chars = line.chars().peekable();
+
+        while let Some(ch) = chars.next() {
+            if ch == '"' {
+                let mut literal = String::from("\"");
+                let mut escaped = false;
+
+                for next in chars.by_ref() {
+                    literal.push(next);
+                    if escaped {
+                        escaped = false;
+                    } else if next == '\\' {
+                        escaped = true;
+                    } else if next == '"' {
+                        break;
+                    }
+                }
+
+                out.push_str("\x1b[35m");
+                out.push_str(&literal);
+                out.push_str("\x1b[0m");
+                continue;
+            }
+
+            if ch.is_ascii_digit() {
+                let mut number = ch.to_string();
+                while let Some(next) = chars.peek() {
+                    if next.is_ascii_digit() {
+                        number.push(*next);
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+
+                out.push_str("\x1b[33m");
+                out.push_str(&number);
+                out.push_str("\x1b[0m");
+                continue;
+            }
+
+            if ch.is_ascii_alphabetic() || ch == '_' {
+                let mut word = ch.to_string();
+                while let Some(next) = chars.peek() {
+                    if next.is_ascii_alphanumeric() || *next == '_' {
+                        word.push(*next);
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+
+                let color = match word.as_str() {
+                    "fn" | "return" => Some("\x1b[36m"),
+                    "print" | "assert" | "assert_eq" => Some("\x1b[32m"),
+                    "true" | "false" | "i32" => Some("\x1b[34m"),
+                    _ => None,
+                };
+
+                if let Some(color) = color {
+                    out.push_str(color);
+                    out.push_str(&word);
+                    out.push_str("\x1b[0m");
+                } else {
+                    out.push_str(&word);
+                }
+
+                continue;
+            }
+
+            out.push(ch);
+        }
+
+        out.push('\n');
+    }
+
+    out
 }
 
 fn fyr_cat(shell: &mut Phase1Shell, args: &[String]) -> String {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -74,7 +74,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     cmd!("emacs", &["emac", "phase1-emacs", "phase1emacs", "pemacs"], "editor", "emacs <file>", "Phase1 eMacs editor: VFS-native advanced editor powered by AVIM Pro.", "fs.write"),
     cmd!("dev", &["dock", "selfdev"], "dev", "dev [status|sync|branch|quick|test|commit|push|pr|merge|close|doctor]", "Phase1 self-development dock for working on Phase1 from inside Phase1.", "host.exec"),
     cmd!("repo", &["channels", "branches", "doctrine"], "dev", "repo [status|base|edge|checkpoint]", "Show the Phase1 repository channel doctrine: frozen base, active edge/stable path, checkpoints, and feature branch targets.", "none"),
-    cmd!("fyr", &["phase1lang", "forge"], "dev", "fyr [status|spec|new|init|cat|check|build|test|self|run <file.fyr>]", "Phase1-native language target for self-construction and VFS automation.", "none"),
+    cmd!("fyr", &["phase1lang", "forge"], "dev", "fyr [status|spec|new|init|cat|color|check|build|test|self|run <file.fyr>]", "Phase1-native language target for self-construction and VFS automation.", "none"),
     cmd!("lang", &["language", "runlang"], "dev", "lang [list|support|status|doctor|detect|run|security]", "Native guarded multi-language runtime manager for major open-source programming languages.", "host.exec"),
     cmd!("lspci", &[], "arch", "lspci", "List simulated PCIe devices.", "hw.read"),
     cmd!("pcie", &[], "arch", "pcie", "Show PCIe subsystem summary.", "hw.read"),

--- a/tests/fyr_authoring_commands.rs
+++ b/tests/fyr_authoring_commands.rs
@@ -6,6 +6,7 @@ fn fyr_authoring_commands_are_wired() {
     assert!(main.contains("Some(\"new\") => fyr_new(shell, &args[1..])"));
     assert!(main.contains("Some(\"init\") => fyr_init(shell, &args[1..])"));
     assert!(main.contains("Some(\"cat\") => fyr_cat(shell, &args[1..])"));
+    assert!(main.contains("Some(\"color\") | Some(\"highlight\") => fyr_color(shell, &args[1..])"));
     assert!(main.contains("Some(\"check\") => fyr_check(shell, &args[1..])"));
     assert!(main.contains("Some(\"build\") => fyr_build(shell, &args[1..])"));
     assert!(main.contains("Some(\"test\") => fyr_test(shell, &args[1..])"));
@@ -21,9 +22,8 @@ fn fyr_authoring_commands_are_wired() {
     assert!(main.contains("sys_write(&path, source, false)"));
 
     let registry = fs::read_to_string("src/registry.rs").expect("registry source exists");
-    assert!(
-        registry.contains("fyr [status|spec|new|init|cat|check|build|test|self|run <file.fyr>]")
-    );
+    assert!(registry
+        .contains("fyr [status|spec|new|init|cat|color|check|build|test|self|run <file.fyr>]"));
 
     let spec = fs::read_to_string("PHASE1_NATIVE_LANGUAGE.md").expect("Fyr spec exists");
     assert!(spec.contains("fyr new hello_hacker"));

--- a/tests/fyr_color_coding.rs
+++ b/tests/fyr_color_coding.rs
@@ -1,0 +1,54 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str) -> String {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .env("PHASE1_BLEEDING_EDGE", "1")
+        .env("PHASE1_DEVICE_MODE", "desktop")
+        .env("PHASE1_MOBILE_MODE", "0")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env_remove("PHASE1_THEME")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    let booted_input = format!("\n{input}");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(booted_input.as_bytes())
+        .expect("write input");
+
+    let output = child.wait_with_output().expect("phase1 output");
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn fyr_color_highlights_core_language_tokens() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { print(\"hi\"); assert(1 == 1); return 0; }' > color.fyr\nfyr color color.fyr\nexit\n",
+    );
+
+    assert!(
+        output.contains("\u{1b}["),
+        "expected ANSI color output:\n{output}"
+    );
+    assert!(output.contains("fn"), "{output}");
+    assert!(output.contains("main"), "{output}");
+    assert!(output.contains("print"), "{output}");
+    assert!(output.contains("\"hi\""), "{output}");
+    assert!(output.contains("return"), "{output}");
+}
+
+#[test]
+fn fyr_color_reports_missing_file() {
+    let output = run_phase1("fyr color missing.fyr\nexit\n");
+
+    assert!(
+        output.contains("fyr color: no such file: missing.fyr"),
+        "{output}"
+    );
+}


### PR DESCRIPTION
Adds a VFS-only Fyr syntax color command for Phase1.

Implements:
- fyr color <file.fyr>
- fyr highlight alias
- ANSI highlighting for Fyr keywords, builtins, strings, numbers, and booleans
- missing-file diagnostics

Validation:
- cargo test -p phase1 --test fyr_color_coding
- cargo test -p phase1 --test fyr_authoring_commands
- cargo test --workspace --all-targets