### PR TITLE
Record Fyr toolchain checkpoint

### DIFF
--- a/docs/fyr/CHECKPOINT_v4_4_0.md
+++ b/docs/fyr/CHECKPOINT_v4_4_0.md
@@ -1,0 +1,35 @@
+# Fyr toolchain checkpoint — v4.4.0-dev
+
+This checkpoint records the current Phase1-owned Fyr toolchain surface.
+
+## Implemented
+
+- `fyr init <package>`
+- `fyr check <file.fyr|package>`
+- `fyr build <file.fyr|package>`
+- `fyr test <package>`
+- `fyr color <file.fyr>`
+- `fyr highlight <file.fyr>` alias
+- package manifest validation
+- package source/module discovery
+- duplicate `fn main` diagnostics
+- parser diagnostics for missing main, unterminated strings, missing semicolons, and invalid returns
+- test assertions:
+  - `assert(true);`
+  - `assert(false);`
+  - `assert_eq(1, 1);`
+  - integer comparisons with `==`, `!=`, `>`, `<`
+- ANSI color output for Fyr keywords, builtins, strings, numbers, and booleans
+
+## Boundary
+
+Fyr remains VFS-only and host-independent. The current build command is still a dry-run interpreted artifact path; it does not invoke Cargo or host tools.
+
+## Next direction
+
+- richer expressions
+- variables and bindings
+- functions beyond `main`
+- real package graph metadata
+- Fyr-to-Fyr build artifacts
+- eventual Phase1 self-construction path

--- a/tests/fyr_toolchain_checkpoint.rs
+++ b/tests/fyr_toolchain_checkpoint.rs
@@ -1,0 +1,25 @@
+use std::fs;
+
+#[test]
+fn fyr_toolchain_checkpoint_documents_current_surface() {
+    let doc =
+        fs::read_to_string("docs/fyr/CHECKPOINT_v4_4_0.md").expect("checkpoint doc should exist");
+
+    for expected in [
+        "fyr init <package>",
+        "fyr check <file.fyr|package>",
+        "fyr build <file.fyr|package>",
+        "fyr test <package>",
+        "fyr color <file.fyr>",
+        "fyr highlight <file.fyr>",
+        "assert_eq(1, 1);",
+        "integer comparisons",
+        "VFS-only and host-independent",
+        "does not invoke Cargo or host tools",
+    ] {
+        assert!(
+            doc.contains(expected),
+            "missing checkpoint line: {expected}"
+        );
+    }
+}


### PR DESCRIPTION
Records the current Fyr-owned toolchain checkpoint for v4.4.0-dev.

Covers:
- init/check/build/test/color
- package/module resolver
- parser diagnostics
- assertion support
- syntax color command
- VFS-only host-independent boundary

Validation:
- cargo test -p phase1 --test fyr_toolchain_checkpoint
- cargo test -p phase1 --test fyr_color_coding
- cargo test -p phase1 --test fyr_test_runner
- cargo test --workspace --all-targets