### PR TITLE
Add Fyr let bindings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -808,8 +808,187 @@ fn fyr_resolve_target(shell: &mut Phase1Shell, raw: &str) -> Result<FyrResolvedT
     })
 }
 
+fn fyr_expand_let_bindings(source: &str) -> Result<String, &'static str> {
+    if !source.contains("let ") {
+        return Ok(source.to_string());
+    }
+
+    let Some((body_start, body_end)) = fyr_main_body_bounds(source) else {
+        return Ok(source.to_string());
+    };
+
+    let body = &source[body_start..body_end];
+    let mut bindings: Vec<(String, String)> = Vec::new();
+    let mut rewritten_body = String::new();
+
+    for statement in fyr_split_seed_statements(body)? {
+        let statement = statement.trim();
+        if statement.is_empty() {
+            continue;
+        }
+
+        if let Some(rest) = statement.strip_prefix("let ") {
+            let Some((name, value)) = rest.split_once('=') else {
+                return Err("expected '=' in let binding");
+            };
+
+            let name = name.trim();
+            if !fyr_is_identifier(name) {
+                return Err("invalid let binding name");
+            }
+
+            let value = value
+                .trim()
+                .parse::<i32>()
+                .map_err(|_| "expected integer let binding value")?;
+
+            bindings.push((name.to_string(), value.to_string()));
+            continue;
+        }
+
+        let mut expanded = statement.to_string();
+        for (name, value) in &bindings {
+            expanded = fyr_replace_identifier_outside_strings(&expanded, name, value);
+        }
+
+        rewritten_body.push_str(&expanded);
+        rewritten_body.push_str("; ");
+    }
+
+    let mut out = String::new();
+    out.push_str(&source[..body_start]);
+    out.push_str(&rewritten_body);
+    out.push_str(&source[body_end..]);
+    Ok(out)
+}
+
+fn fyr_main_body_bounds(source: &str) -> Option<(usize, usize)> {
+    let fn_start = source.find("fn main")?;
+    let open = fn_start + source[fn_start..].find('{')?;
+    let close = source.rfind('}')?;
+
+    if close <= open {
+        return None;
+    }
+
+    Some((open + 1, close))
+}
+
+fn fyr_split_seed_statements(body: &str) -> Result<Vec<String>, &'static str> {
+    let mut statements = Vec::new();
+    let mut current = String::new();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for ch in body.chars() {
+        if in_string {
+            current.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => {
+                in_string = true;
+                current.push(ch);
+            }
+            ';' => {
+                statements.push(current.trim().to_string());
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    if !current.trim().is_empty() {
+        return Err("expected ';' after statement");
+    }
+
+    Ok(statements)
+}
+
+fn fyr_is_identifier(raw: &str) -> bool {
+    let mut chars = raw.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return false;
+    }
+
+    if !chars.all(fyr_identifier_char) {
+        return false;
+    }
+
+    !matches!(
+        raw,
+        "fn" | "main" | "print" | "assert" | "assert_eq" | "return" | "let" | "i32"
+    )
+}
+
+fn fyr_identifier_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || ch == '_'
+}
+
+fn fyr_replace_identifier_outside_strings(input: &str, name: &str, value: &str) -> String {
+    let mut out = String::new();
+    let mut token = String::new();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    let flush_token = |token: &mut String, out: &mut String| {
+        if token.is_empty() {
+            return;
+        }
+
+        if token == name {
+            out.push_str(value);
+        } else {
+            out.push_str(token);
+        }
+
+        token.clear();
+    };
+
+    for ch in input.chars() {
+        if in_string {
+            out.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if ch == '"' {
+            flush_token(&mut token, &mut out);
+            in_string = true;
+            out.push(ch);
+        } else if fyr_identifier_char(ch) {
+            token.push(ch);
+        } else {
+            flush_token(&mut token, &mut out);
+            out.push(ch);
+        }
+    }
+
+    flush_token(&mut token, &mut out);
+    out
+}
+
 fn fyr_parse_source_ast(source: &str) -> Result<FyrSourceAst, &'static str> {
-    let function = fyr_parse_main_function(source)?;
+    let expanded_source = fyr_expand_let_bindings(source)?;
+    let function = fyr_parse_main_function(&expanded_source)?;
     Ok(FyrSourceAst {
         functions: vec![function],
     })

--- a/tests/fyr_let_bindings.rs
+++ b/tests/fyr_let_bindings.rs
@@ -1,0 +1,68 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str) -> String {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .env("PHASE1_BLEEDING_EDGE", "1")
+        .env("PHASE1_DEVICE_MODE", "desktop")
+        .env("PHASE1_MOBILE_MODE", "0")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env_remove("PHASE1_THEME")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    let booted_input = format!("\n{input}");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(booted_input.as_bytes())
+        .expect("write input");
+
+    let output = child.wait_with_output().expect("phase1 output");
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn fyr_let_bindings_work_in_single_file_check_and_build() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { let answer = 42; assert(answer == 42); return answer; }' > vars.fyr\nfyr check vars.fyr\nfyr build vars.fyr\nexit\n",
+    );
+
+    assert!(output.contains("fyr check: ok vars.fyr"), "{output}");
+    assert!(output.contains("source  : vars.fyr"), "{output}");
+    assert!(
+        output.contains("status  : dry-run artifact ready"),
+        "{output}"
+    );
+}
+
+#[test]
+fn fyr_let_bindings_work_in_package_tests() {
+    let output = run_phase1(
+        "fyr init app\necho 'fn main() -> i32 { let x = 7; assert_eq(x, 7); assert(x > 3); return x; }' > app/tests/vars.fyr\nfyr test app\nexit\n",
+    );
+
+    assert!(
+        output.contains("test    : app/tests/vars.fyr ok"),
+        "{output}"
+    );
+    assert!(output.contains("passed  : 2"), "{output}");
+    assert!(output.contains("failed  : 0"), "{output}");
+    assert!(output.contains("status  : ok"), "{output}");
+}
+
+#[test]
+fn fyr_let_binding_rejects_non_integer_values() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { let x = nope; assert(x == 1); return 0; }' > bad.fyr\nfyr check bad.fyr\nexit\n",
+    );
+
+    assert!(
+        output.contains("expected integer let binding value"),
+        "{output}"
+    );
+}


### PR DESCRIPTION
Adds the first Fyr variable binding surface.

Supports:
- let <name> = <integer>;
- using bindings in assert(...)
- using bindings in assert_eq(...)
- using bindings in return statements

Validation:
- cargo test -p phase1 --test fyr_let_bindings
- cargo test -p phase1 --test fyr_test_runner
- cargo test -p phase1 --test fyr_parser_diagnostics
- cargo test --workspace --all-targets