### PR TITLE
Add Fyr arithmetic let expressions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -818,7 +818,7 @@ fn fyr_expand_let_bindings(source: &str) -> Result<String, &'static str> {
     };
 
     let body = &source[body_start..body_end];
-    let mut bindings: Vec<(String, String)> = Vec::new();
+    let mut bindings: Vec<(String, i32)> = Vec::new();
     let mut rewritten_body = String::new();
 
     for statement in fyr_split_seed_statements(body)? {
@@ -837,18 +837,17 @@ fn fyr_expand_let_bindings(source: &str) -> Result<String, &'static str> {
                 return Err("invalid let binding name");
             }
 
-            let value = value
-                .trim()
-                .parse::<i32>()
+            let value = fyr_eval_integer_expression(value.trim(), &bindings)
                 .map_err(|_| "expected integer let binding value")?;
 
-            bindings.push((name.to_string(), value.to_string()));
+            bindings.push((name.to_string(), value));
             continue;
         }
 
         let mut expanded = statement.to_string();
         for (name, value) in &bindings {
-            expanded = fyr_replace_identifier_outside_strings(&expanded, name, value);
+            let value = value.to_string();
+            expanded = fyr_replace_identifier_outside_strings(&expanded, name, &value);
         }
 
         rewritten_body.push_str(&expanded);
@@ -911,6 +910,53 @@ fn fyr_split_seed_statements(body: &str) -> Result<Vec<String>, &'static str> {
     }
 
     Ok(statements)
+}
+
+fn fyr_eval_integer_expression(raw: &str, bindings: &[(String, i32)]) -> Result<i32, &'static str> {
+    let expr = raw.trim();
+    if expr.is_empty() {
+        return Err("expected integer expression");
+    }
+
+    for (idx, ch) in expr.char_indices() {
+        if idx == 0 || !matches!(ch, '+' | '-') {
+            continue;
+        }
+
+        let left = expr[..idx].trim();
+        let right = expr[idx + ch.len_utf8()..].trim();
+        if left.is_empty() || right.is_empty() {
+            return Err("expected integer expression");
+        }
+
+        let left = fyr_eval_integer_term(left, bindings)?;
+        let right = fyr_eval_integer_term(right, bindings)?;
+        return match ch {
+            '+' => Ok(left + right),
+            '-' => Ok(left - right),
+            _ => unreachable!(),
+        };
+    }
+
+    fyr_eval_integer_term(expr, bindings)
+}
+
+fn fyr_eval_integer_term(raw: &str, bindings: &[(String, i32)]) -> Result<i32, &'static str> {
+    let term = raw.trim();
+
+    if let Ok(value) = term.parse::<i32>() {
+        return Ok(value);
+    }
+
+    if !fyr_is_identifier(term) {
+        return Err("expected integer expression");
+    }
+
+    bindings
+        .iter()
+        .rev()
+        .find_map(|(name, value)| (name == term).then_some(*value))
+        .ok_or("unknown let binding")
 }
 
 fn fyr_is_identifier(raw: &str) -> bool {

--- a/tests/fyr_arithmetic_expressions.rs
+++ b/tests/fyr_arithmetic_expressions.rs
@@ -1,0 +1,68 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str) -> String {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .env("PHASE1_TEST_MODE", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("phase1 output");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn fyr_let_bindings_support_addition_expression() {
+    let output = run_phase1(
+        "fyr init app\n\
+echo 'fn main() -> i32 { let base = 40; let answer = base + 2; assert(answer == 42); return answer; }' > app/tests/math_add.fyr\n\
+fyr check app\n\
+fyr test app\n\
+exit\n",
+    );
+
+    assert!(
+        output.contains("fyr check: ok app/src/main.fyr"),
+        "{output}"
+    );
+    assert!(
+        output.contains("test    : app/tests/math_add.fyr ok"),
+        "{output}"
+    );
+    assert!(output.contains("status  : ok"), "{output}");
+}
+
+#[test]
+fn fyr_let_bindings_support_subtraction_expression() {
+    let output = run_phase1(
+        "fyr init app\n\
+echo 'fn main() -> i32 { let base = 50; let answer = base - 8; assert_eq(answer, 42); return answer; }' > app/tests/math_sub.fyr\n\
+fyr check app\n\
+fyr test app\n\
+exit\n",
+    );
+
+    assert!(
+        output.contains("fyr check: ok app/src/main.fyr"),
+        "{output}"
+    );
+    assert!(
+        output.contains("test    : app/tests/math_sub.fyr ok"),
+        "{output}"
+    );
+    assert!(output.contains("status  : ok"), "{output}");
+}


### PR DESCRIPTION
Adds simple integer arithmetic expressions to Fyr let bindings.

Supports:
- let answer = base + 2;
- let answer = base - 8;
- use of computed bindings in assert, assert_eq, and return paths

Validation:
- cargo test -p phase1 --test fyr_arithmetic_expressions
- cargo test -p phase1 --test fyr_let_bindings
- cargo test -p phase1 --test fyr_test_runner
- cargo test --workspace --all-targets