### PR TITLE
Add Fyr multiplication and division expressions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -837,8 +837,13 @@ fn fyr_expand_let_bindings(source: &str) -> Result<String, &'static str> {
                 return Err("invalid let binding name");
             }
 
-            let value = fyr_eval_integer_expression(value.trim(), &bindings)
-                .map_err(|_| "expected integer let binding value")?;
+            let value = fyr_eval_integer_expression(value.trim(), &bindings).map_err(|err| {
+                if err == "division by zero" {
+                    err
+                } else {
+                    "expected integer let binding value"
+                }
+            })?;
 
             bindings.push((name.to_string(), value));
             continue;
@@ -918,7 +923,7 @@ fn fyr_eval_integer_expression(raw: &str, bindings: &[(String, i32)]) -> Result<
         return Err("expected integer expression");
     }
 
-    for (idx, ch) in expr.char_indices() {
+    for (idx, ch) in expr.char_indices().rev() {
         if idx == 0 || !matches!(ch, '+' | '-') {
             continue;
         }
@@ -929,7 +934,7 @@ fn fyr_eval_integer_expression(raw: &str, bindings: &[(String, i32)]) -> Result<
             return Err("expected integer expression");
         }
 
-        let left = fyr_eval_integer_term(left, bindings)?;
+        let left = fyr_eval_integer_expression(left, bindings)?;
         let right = fyr_eval_integer_term(right, bindings)?;
         return match ch {
             '+' => Ok(left + right),
@@ -943,19 +948,55 @@ fn fyr_eval_integer_expression(raw: &str, bindings: &[(String, i32)]) -> Result<
 
 fn fyr_eval_integer_term(raw: &str, bindings: &[(String, i32)]) -> Result<i32, &'static str> {
     let term = raw.trim();
+    if term.is_empty() {
+        return Err("expected integer expression");
+    }
 
-    if let Ok(value) = term.parse::<i32>() {
+    for (idx, ch) in term.char_indices().rev() {
+        if idx == 0 || !matches!(ch, '*' | '/') {
+            continue;
+        }
+
+        let left = term[..idx].trim();
+        let right = term[idx + ch.len_utf8()..].trim();
+        if left.is_empty() || right.is_empty() {
+            return Err("expected integer expression");
+        }
+
+        let left = fyr_eval_integer_term(left, bindings)?;
+        let right = fyr_eval_integer_factor(right, bindings)?;
+
+        return match ch {
+            '*' => Ok(left * right),
+            '/' => {
+                if right == 0 {
+                    Err("division by zero")
+                } else {
+                    Ok(left / right)
+                }
+            }
+            _ => unreachable!(),
+        };
+    }
+
+    fyr_eval_integer_factor(term, bindings)
+}
+
+fn fyr_eval_integer_factor(raw: &str, bindings: &[(String, i32)]) -> Result<i32, &'static str> {
+    let factor = raw.trim();
+
+    if let Ok(value) = factor.parse::<i32>() {
         return Ok(value);
     }
 
-    if !fyr_is_identifier(term) {
+    if !fyr_is_identifier(factor) {
         return Err("expected integer expression");
     }
 
     bindings
         .iter()
         .rev()
-        .find_map(|(name, value)| (name == term).then_some(*value))
+        .find_map(|(name, value)| (name == factor).then_some(*value))
         .ok_or("unknown let binding")
 }
 

--- a/tests/fyr_mul_div_expressions.rs
+++ b/tests/fyr_mul_div_expressions.rs
@@ -1,0 +1,84 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str) -> String {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .env("PHASE1_TEST_MODE", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("phase1 output");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn fyr_let_bindings_support_multiplication_expression() {
+    let output = run_phase1(
+        "fyr init app\n\
+echo 'fn main() -> i32 { let base = 21; let answer = base * 2; assert(answer == 42); return answer; }' > app/tests/math_mul.fyr\n\
+fyr check app\n\
+fyr test app\n\
+exit\n",
+    );
+
+    assert!(
+        output.contains("fyr check: ok app/src/main.fyr"),
+        "{output}"
+    );
+    assert!(
+        output.contains("test    : app/tests/math_mul.fyr ok"),
+        "{output}"
+    );
+    assert!(output.contains("status  : ok"), "{output}");
+}
+
+#[test]
+fn fyr_let_bindings_support_division_expression() {
+    let output = run_phase1(
+        "fyr init app\n\
+echo 'fn main() -> i32 { let total = 84; let answer = total / 2; assert_eq(answer, 42); return answer; }' > app/tests/math_div.fyr\n\
+fyr check app\n\
+fyr test app\n\
+exit\n",
+    );
+
+    assert!(
+        output.contains("fyr check: ok app/src/main.fyr"),
+        "{output}"
+    );
+    assert!(
+        output.contains("test    : app/tests/math_div.fyr ok"),
+        "{output}"
+    );
+    assert!(output.contains("status  : ok"), "{output}");
+}
+
+#[test]
+fn fyr_division_by_zero_reports_diagnostic() {
+    let output = run_phase1(
+        "fyr init app\n\
+echo 'fn main() -> i32 { let total = 84; let answer = total / 0; assert(answer == 42); return answer; }' > app/tests/math_bad_div.fyr\n\
+fyr test app\n\
+exit\n",
+    );
+
+    assert!(
+        output.contains("test    : app/tests/math_bad_div.fyr failed: division by zero"),
+        "{output}"
+    );
+    assert!(output.contains("status  : failed"), "{output}");
+}


### PR DESCRIPTION
Adds multiplication and division support to Fyr integer let expressions.

Supports:
- let answer = base * 2;
- let answer = total / 2;
- division-by-zero diagnostics

Validation:
- cargo test -p phase1 --test fyr_mul_div_expressions
- cargo test -p phase1 --test fyr_arithmetic_expressions
- cargo test -p phase1 --test fyr_let_bindings
- cargo test -p phase1 --test fyr_test_runner
- cargo test --workspace --all-targets