### PR TITLE
Add Fyr parenthesized expressions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -837,13 +837,14 @@ fn fyr_expand_let_bindings(source: &str) -> Result<String, &'static str> {
                 return Err("invalid let binding name");
             }
 
-            let value = fyr_eval_integer_expression(value.trim(), &bindings).map_err(|err| {
-                if err == "division by zero" {
-                    err
-                } else {
-                    "expected integer let binding value"
+            let value = match fyr_eval_integer_expression(value.trim(), &bindings) {
+                Ok(value) => value,
+                Err("division by zero") => return Err("division by zero"),
+                Err("expected ')' in integer expression") => {
+                    return Err("expected ')' in integer expression")
                 }
-            })?;
+                Err(_) => return Err("expected integer let binding value"),
+            };
 
             bindings.push((name.to_string(), value));
             continue;
@@ -923,11 +924,7 @@ fn fyr_eval_integer_expression(raw: &str, bindings: &[(String, i32)]) -> Result<
         return Err("expected integer expression");
     }
 
-    for (idx, ch) in expr.char_indices().rev() {
-        if idx == 0 || !matches!(ch, '+' | '-') {
-            continue;
-        }
-
+    if let Some((idx, ch)) = fyr_find_top_level_operator(expr, &['+', '-'])? {
         let left = expr[..idx].trim();
         let right = expr[idx + ch.len_utf8()..].trim();
         if left.is_empty() || right.is_empty() {
@@ -952,11 +949,7 @@ fn fyr_eval_integer_term(raw: &str, bindings: &[(String, i32)]) -> Result<i32, &
         return Err("expected integer expression");
     }
 
-    for (idx, ch) in term.char_indices().rev() {
-        if idx == 0 || !matches!(ch, '*' | '/') {
-            continue;
-        }
-
+    if let Some((idx, ch)) = fyr_find_top_level_operator(term, &['*', '/'])? {
         let left = term[..idx].trim();
         let right = term[idx + ch.len_utf8()..].trim();
         if left.is_empty() || right.is_empty() {
@@ -982,8 +975,53 @@ fn fyr_eval_integer_term(raw: &str, bindings: &[(String, i32)]) -> Result<i32, &
     fyr_eval_integer_factor(term, bindings)
 }
 
+fn fyr_find_top_level_operator(
+    expr: &str,
+    operators: &[char],
+) -> Result<Option<(usize, char)>, &'static str> {
+    let mut depth = 0i32;
+    let mut found = None;
+
+    for (idx, ch) in expr.char_indices() {
+        match ch {
+            '(' => {
+                depth += 1;
+                continue;
+            }
+            ')' => {
+                if depth == 0 {
+                    return Err("expected integer expression");
+                }
+                depth -= 1;
+                continue;
+            }
+            _ => {}
+        }
+
+        if depth == 0 && idx > 0 && operators.contains(&ch) {
+            let left = expr[..idx].trim();
+            let right = expr[idx + ch.len_utf8()..].trim();
+            if left.is_empty() || right.is_empty() {
+                return Err("expected integer expression");
+            }
+            found = Some((idx, ch));
+        }
+    }
+
+    if depth != 0 {
+        return Err("expected ')' in integer expression");
+    }
+
+    Ok(found)
+}
+
 fn fyr_eval_integer_factor(raw: &str, bindings: &[(String, i32)]) -> Result<i32, &'static str> {
     let factor = raw.trim();
+
+    if factor.starts_with('(') {
+        let inner = fyr_parenthesized_inner(factor)?;
+        return fyr_eval_integer_expression(inner, bindings);
+    }
 
     if let Ok(value) = factor.parse::<i32>() {
         return Ok(value);
@@ -998,6 +1036,28 @@ fn fyr_eval_integer_factor(raw: &str, bindings: &[(String, i32)]) -> Result<i32,
         .rev()
         .find_map(|(name, value)| (name == factor).then_some(*value))
         .ok_or("unknown let binding")
+}
+
+fn fyr_parenthesized_inner(raw: &str) -> Result<&str, &'static str> {
+    let mut depth = 0i32;
+
+    for (idx, ch) in raw.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    if idx + ch.len_utf8() == raw.len() {
+                        return Ok(&raw[1..idx]);
+                    }
+                    return Err("expected integer expression");
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Err("expected ')' in integer expression")
 }
 
 fn fyr_is_identifier(raw: &str) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -924,16 +924,18 @@ fn fyr_eval_integer_expression(raw: &str, bindings: &[(String, i32)]) -> Result<
         return Err("expected integer expression");
     }
 
-    if let Some((idx, ch)) = fyr_find_top_level_operator(expr, &['+', '-'])? {
+    if let Some((idx, op)) = fyr_find_top_level_operator(expr, &['+', '-'])? {
         let left = expr[..idx].trim();
-        let right = expr[idx + ch.len_utf8()..].trim();
+        let right = expr[idx + op.len_utf8()..].trim();
+
         if left.is_empty() || right.is_empty() {
             return Err("expected integer expression");
         }
 
         let left = fyr_eval_integer_expression(left, bindings)?;
         let right = fyr_eval_integer_term(right, bindings)?;
-        return match ch {
+
+        return match op {
             '+' => Ok(left + right),
             '-' => Ok(left - right),
             _ => unreachable!(),
@@ -949,9 +951,10 @@ fn fyr_eval_integer_term(raw: &str, bindings: &[(String, i32)]) -> Result<i32, &
         return Err("expected integer expression");
     }
 
-    if let Some((idx, ch)) = fyr_find_top_level_operator(term, &['*', '/'])? {
+    if let Some((idx, op)) = fyr_find_top_level_operator(term, &['*', '/'])? {
         let left = term[..idx].trim();
-        let right = term[idx + ch.len_utf8()..].trim();
+        let right = term[idx + op.len_utf8()..].trim();
+
         if left.is_empty() || right.is_empty() {
             return Err("expected integer expression");
         }
@@ -959,7 +962,7 @@ fn fyr_eval_integer_term(raw: &str, bindings: &[(String, i32)]) -> Result<i32, &
         let left = fyr_eval_integer_term(left, bindings)?;
         let right = fyr_eval_integer_factor(right, bindings)?;
 
-        return match ch {
+        return match op {
             '*' => Ok(left * right),
             '/' => {
                 if right == 0 {
@@ -1001,9 +1004,11 @@ fn fyr_find_top_level_operator(
         if depth == 0 && idx > 0 && operators.contains(&ch) {
             let left = expr[..idx].trim();
             let right = expr[idx + ch.len_utf8()..].trim();
+
             if left.is_empty() || right.is_empty() {
                 return Err("expected integer expression");
             }
+
             found = Some((idx, ch));
         }
     }

--- a/tests/fyr_parenthesized_expressions.rs
+++ b/tests/fyr_parenthesized_expressions.rs
@@ -1,0 +1,66 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str) -> String {
+    let exe = env!("CARGO_BIN_EXE_phase1");
+    let mut child = Command::new(exe)
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_MOBILE_MODE", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write input");
+
+    let output = child.wait_with_output().expect("wait");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn fyr_parentheses_group_addition_before_multiplication() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { let answer = (40 + 2) * 2; assert(answer == 84); return answer; }' > math.fyr\nfyr check math.fyr\nfyr build math.fyr\nexit\n",
+    );
+
+    assert!(output.contains("fyr check: ok math.fyr"), "{output}");
+    assert!(
+        output.contains("status  : dry-run artifact ready"),
+        "{output}"
+    );
+}
+
+#[test]
+fn fyr_parentheses_group_division_terms() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { let total = 84; let answer = total / (1 + 1); assert(answer == 42); return answer; }' > math.fyr\nfyr check math.fyr\nfyr build math.fyr\nexit\n",
+    );
+
+    assert!(output.contains("fyr check: ok math.fyr"), "{output}");
+    assert!(
+        output.contains("status  : dry-run artifact ready"),
+        "{output}"
+    );
+}
+
+#[test]
+fn fyr_unclosed_parenthesis_reports_diagnostic() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { let answer = (40 + 2; assert(answer == 42); return answer; }' > bad.fyr\nfyr check bad.fyr\nexit\n",
+    );
+
+    assert!(
+        output.contains("expected ')' in integer expression"),
+        "{output}"
+    );
+}


### PR DESCRIPTION
Adds parenthesized integer expression support to Fyr.

Supports:
- grouped addition before multiplication
- grouped terms in division
- unclosed parenthesis diagnostics

Validation:
- cargo test -p phase1 --test fyr_parenthesized_expressions
- cargo test -p phase1 --test fyr_mul_div_expressions
- cargo test -p phase1 --test fyr_arithmetic_expressions
- cargo test -p phase1 --test fyr_let_bindings
- cargo test -p phase1 --test fyr_test_runner
- cargo test --workspace --all-targets