### PR TITLE
Add Fyr unary minus expressions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1023,6 +1023,14 @@ fn fyr_find_top_level_operator(
 fn fyr_eval_integer_factor(raw: &str, bindings: &[(String, i32)]) -> Result<i32, &'static str> {
     let factor = raw.trim();
 
+    if let Some(inner) = factor.strip_prefix('-') {
+        let inner = inner.trim();
+        if inner.is_empty() {
+            return Err("expected integer expression");
+        }
+        return fyr_eval_integer_factor(inner, bindings).map(|value| -value);
+    }
+
     if factor.starts_with('(') {
         let inner = fyr_parenthesized_inner(factor)?;
         return fyr_eval_integer_expression(inner, bindings);
@@ -1383,28 +1391,34 @@ fn fyr_parse_assert_eq_statement_ast(
 }
 
 fn fyr_parse_integer_with_rest(text: &str) -> Result<(i32, &str), &'static str> {
-    let rest = text.trim_start();
+    let raw = text.trim_start();
     let mut end = 0usize;
-    let mut saw_digit = false;
+    let mut seen_digit = false;
 
-    for (idx, ch) in rest.char_indices() {
-        if ch.is_ascii_digit() {
-            saw_digit = true;
-            end = idx + ch.len_utf8();
-        } else {
-            break;
+    for (idx, ch) in raw.char_indices() {
+        if idx == 0 && ch == '-' {
+            end = ch.len_utf8();
+            continue;
         }
+
+        if ch.is_ascii_digit() {
+            seen_digit = true;
+            end = idx + ch.len_utf8();
+            continue;
+        }
+
+        break;
     }
 
-    if !saw_digit {
+    if !seen_digit {
         return Err("expected integer value");
     }
 
-    let value = rest[..end]
+    let value = raw[..end]
         .parse::<i32>()
         .map_err(|_| "expected integer value")?;
 
-    Ok((value, &rest[end..]))
+    Ok((value, &raw[end..]))
 }
 
 fn fyr_eval_test_ast(ast: &FyrSourceAst) -> Result<(), String> {
@@ -1432,31 +1446,12 @@ fn fyr_parse_return_statement_ast(
         return Err("expected return statement");
     };
 
-    let rest = rest.trim_start();
-    let mut end = 0usize;
-    let mut saw_digit = false;
-
-    for (idx, ch) in rest.char_indices() {
-        if ch.is_ascii_digit() {
-            saw_digit = true;
-            end = idx + ch.len_utf8();
-        } else {
-            break;
-        }
-    }
-
-    if !saw_digit {
-        return Err("expected integer return value");
-    }
-
-    let value = rest[..end]
-        .parse::<i32>()
-        .map_err(|_| "expected integer return value")?;
-    let rest = rest[end..].trim_start();
-
-    let Some(rest) = rest.strip_prefix(';') else {
+    let Some((raw_value, rest)) = rest.split_once(';') else {
         return Err("expected ';' after return statement");
     };
+
+    let value = fyr_eval_integer_expression(raw_value.trim(), &[])
+        .map_err(|_| "expected integer return value")?;
 
     Ok((FyrStatementAst::Return(value), rest))
 }

--- a/tests/fyr_unary_minus.rs
+++ b/tests/fyr_unary_minus.rs
@@ -1,0 +1,67 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str) -> String {
+    let exe = env!("CARGO_BIN_EXE_phase1");
+    let mut child = Command::new(exe)
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_MOBILE_MODE", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write input");
+
+    let output = child.wait_with_output().expect("wait");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn fyr_supports_negative_integer_literal() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { let answer = -42; assert(answer == -42); return answer; }' > neg.fyr\nfyr check neg.fyr\nfyr build neg.fyr\nexit\n",
+    );
+
+    assert!(output.contains("fyr check: ok neg.fyr"), "{output}");
+    assert!(
+        output.contains("status  : dry-run artifact ready"),
+        "{output}"
+    );
+}
+
+#[test]
+fn fyr_supports_unary_minus_for_binding() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { let base = 42; let answer = -base; assert(answer == -42); return answer; }' > neg.fyr\nfyr check neg.fyr\nfyr build neg.fyr\nexit\n",
+    );
+
+    assert!(output.contains("fyr check: ok neg.fyr"), "{output}");
+    assert!(
+        output.contains("status  : dry-run artifact ready"),
+        "{output}"
+    );
+}
+
+#[test]
+fn fyr_supports_unary_minus_parenthesized_expression() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { let answer = -(40 + 2); assert(answer == -42); return answer; }' > neg.fyr\nfyr check neg.fyr\nfyr build neg.fyr\nexit\n",
+    );
+
+    assert!(output.contains("fyr check: ok neg.fyr"), "{output}");
+    assert!(
+        output.contains("status  : dry-run artifact ready"),
+        "{output}"
+    );
+}


### PR DESCRIPTION
Adds unary minus support to Fyr integer expressions.

Supports:
- negative integer literals
- unary minus for let bindings
- unary minus for parenthesized expressions
- negative integers in assertions and returns

Validation:
- cargo test -p phase1 --test fyr_unary_minus
- cargo test -p phase1 --test fyr_parenthesized_expressions
- cargo test -p phase1 --test fyr_mul_div_expressions
- cargo test -p phase1 --test fyr_arithmetic_expressions
- cargo test -p phase1 --test fyr_let_bindings
- cargo test -p phase1 --test fyr_test_runner
- cargo test --workspace --all-targets