### PR TITLE
Add Fyr inclusive comparisons

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1285,77 +1285,64 @@ fn fyr_parse_print_statement_ast(statement: &str) -> Result<(FyrStatementAst, &s
 fn fyr_parse_assert_statement_ast(
     statement: &str,
 ) -> Result<(FyrStatementAst, &str), &'static str> {
-    let Some(rest) = statement.strip_prefix("assert") else {
+    let Some(rest) = statement.strip_prefix("assert(") else {
         return Err("expected assert statement");
     };
 
-    let rest = rest.trim_start();
-    let Some(rest) = rest.strip_prefix('(') else {
-        return Err("expected '(' after assert");
+    let Some((assertion, rest)) = rest.split_once(");") else {
+        return Err("expected ');' after assert statement");
     };
 
-    let (assertion, rest) = fyr_parse_assertion_with_rest(rest)?;
-    let rest = rest.trim_start();
+    let assertion = assertion.trim();
 
-    let Some(rest) = rest.strip_prefix(')') else {
-        return Err("expected ')' after assert expression");
-    };
-
-    let rest = rest.trim_start();
-    let Some(rest) = rest.strip_prefix(';') else {
-        return Err("expected ';' after assert statement");
-    };
-
-    Ok((FyrStatementAst::Assert(assertion), rest))
-}
-
-fn fyr_parse_assertion_with_rest(text: &str) -> Result<(FyrAssertionAst, &str), &'static str> {
-    let rest = text.trim_start();
-
-    if let Some(next) = rest.strip_prefix("true") {
+    if assertion == "true" {
         return Ok((
-            FyrAssertionAst {
+            FyrStatementAst::Assert(FyrAssertionAst {
                 value: true,
-                label: "true".to_string(),
-            },
-            next,
+                label: assertion.to_string(),
+            }),
+            rest,
         ));
     }
 
-    if let Some(next) = rest.strip_prefix("false") {
+    if assertion == "false" {
         return Ok((
-            FyrAssertionAst {
+            FyrStatementAst::Assert(FyrAssertionAst {
                 value: false,
-                label: "false".to_string(),
-            },
-            next,
+                label: assertion.to_string(),
+            }),
+            rest,
         ));
     }
 
-    let (left, rest) = fyr_parse_integer_with_rest(rest)?;
-    let rest = rest.trim_start();
+    for op in [">=", "<=", "==", "!=", ">", "<"] {
+        if let Some((left, right)) = assertion.split_once(op) {
+            let left = fyr_eval_integer_expression(left.trim(), &[])
+                .map_err(|_| "expected integer value")?;
+            let right = fyr_eval_integer_expression(right.trim(), &[])
+                .map_err(|_| "expected integer value")?;
 
-    let operators: [(&str, fn(i32, i32) -> bool); 4] = [
-        ("==", |left, right| left == right),
-        ("!=", |left, right| left != right),
-        (">", |left, right| left > right),
-        ("<", |left, right| left < right),
-    ];
+            let value = match op {
+                ">=" => left >= right,
+                "<=" => left <= right,
+                "==" => left == right,
+                "!=" => left != right,
+                ">" => left > right,
+                "<" => left < right,
+                _ => unreachable!(),
+            };
 
-    for (operator, compare) in operators {
-        if let Some(rest) = rest.strip_prefix(operator) {
-            let (right, rest) = fyr_parse_integer_with_rest(rest)?;
             return Ok((
-                FyrAssertionAst {
-                    value: compare(left, right),
-                    label: format!("{left} {operator} {right}"),
-                },
+                FyrStatementAst::Assert(FyrAssertionAst {
+                    value,
+                    label: assertion.to_string(),
+                }),
                 rest,
             ));
         }
     }
 
-    Err("expected boolean literal or integer comparison")
+    Err("expected boolean assertion")
 }
 
 fn fyr_parse_assert_eq_statement_ast(

--- a/tests/fyr_inclusive_comparisons.rs
+++ b/tests/fyr_inclusive_comparisons.rs
@@ -1,0 +1,67 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str) -> String {
+    let exe = env!("CARGO_BIN_EXE_phase1");
+    let mut child = Command::new(exe)
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_MOBILE_MODE", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write input");
+
+    let output = child.wait_with_output().expect("wait");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn fyr_supports_greater_than_or_equal_assertions() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { let answer = 42; assert(answer >= 42); assert(answer >= 40); return answer; }' > cmp.fyr\nfyr check cmp.fyr\nfyr build cmp.fyr\nexit\n",
+    );
+
+    assert!(output.contains("fyr check: ok cmp.fyr"), "{output}");
+    assert!(
+        output.contains("status  : dry-run artifact ready"),
+        "{output}"
+    );
+}
+
+#[test]
+fn fyr_supports_less_than_or_equal_assertions() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { let answer = 42; assert(answer <= 42); assert(answer <= 50); return answer; }' > cmp.fyr\nfyr check cmp.fyr\nfyr build cmp.fyr\nexit\n",
+    );
+
+    assert!(output.contains("fyr check: ok cmp.fyr"), "{output}");
+    assert!(
+        output.contains("status  : dry-run artifact ready"),
+        "{output}"
+    );
+}
+
+#[test]
+fn fyr_reports_failed_inclusive_comparison() {
+    let output = run_phase1(
+        "fyr init app\necho 'fn main() -> i32 { let answer = 42; assert(answer <= 41); return answer; }' > app/tests/cmp_fail.fyr\nfyr test app\nexit\n",
+    );
+
+    assert!(
+        output.contains("test    : app/tests/cmp_fail.fyr failed: assertion failed: 42 <= 41"),
+        "{output}"
+    );
+    assert!(output.contains("status  : failed"), "{output}");
+}


### PR DESCRIPTION
Adds >= and <= comparison assertions to Fyr.

Supports:
- assert(answer >= 42);
- assert(answer <= 42);
- failed inclusive comparison diagnostics

Validation:
- cargo test -p phase1 --test fyr_inclusive_comparisons
- cargo test -p phase1 --test fyr_test_runner
- cargo test -p phase1 --test fyr_unary_minus
- cargo test --workspace --all-targets