### PR TITLE
Add Fyr boolean assertion operators

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1293,26 +1293,103 @@ fn fyr_parse_assert_statement_ast(
         return Err("expected ');' after assert statement");
     };
 
+    Ok((
+        FyrStatementAst::Assert(fyr_parse_assertion_ast(assertion)?),
+        rest,
+    ))
+}
+
+fn fyr_parse_assertion_ast(assertion: &str) -> Result<FyrAssertionAst, &'static str> {
+    let assertion = assertion.trim();
+
+    if assertion.is_empty() {
+        return Err("expected boolean assertion");
+    }
+
+    if let Some(parts) = fyr_split_assertion_chain(assertion, "||") {
+        let mut labels = Vec::new();
+        let mut value = false;
+
+        for part in parts {
+            let parsed = fyr_parse_assertion_ast(part)?;
+            value |= parsed.value;
+            labels.push(parsed.label);
+        }
+
+        return Ok(FyrAssertionAst {
+            value,
+            label: labels.join(" || "),
+        });
+    }
+
+    if let Some(parts) = fyr_split_assertion_chain(assertion, "&&") {
+        let mut labels = Vec::new();
+        let mut value = true;
+
+        for part in parts {
+            let parsed = fyr_parse_assertion_ast(part)?;
+            value &= parsed.value;
+            labels.push(parsed.label);
+        }
+
+        return Ok(FyrAssertionAst {
+            value,
+            label: labels.join(" && "),
+        });
+    }
+
+    fyr_parse_atomic_assertion_ast(assertion)
+}
+
+fn fyr_split_assertion_chain<'a>(assertion: &'a str, op: &str) -> Option<Vec<&'a str>> {
+    let mut parts = Vec::new();
+    let mut start = 0usize;
+    let mut depth = 0i32;
+    let mut i = 0usize;
+
+    while i < assertion.len() {
+        let rest = &assertion[i..];
+        let ch = rest.chars().next().expect("char");
+
+        match ch {
+            '(' => depth += 1,
+            ')' if depth > 0 => depth -= 1,
+            _ => {}
+        }
+
+        if depth == 0 && rest.starts_with(op) {
+            parts.push(&assertion[start..i]);
+            i += op.len();
+            start = i;
+            continue;
+        }
+
+        i += ch.len_utf8();
+    }
+
+    if parts.is_empty() {
+        None
+    } else {
+        parts.push(&assertion[start..]);
+        Some(parts)
+    }
+}
+
+fn fyr_parse_atomic_assertion_ast(assertion: &str) -> Result<FyrAssertionAst, &'static str> {
     let assertion = assertion.trim();
 
     if assertion == "true" {
-        return Ok((
-            FyrStatementAst::Assert(FyrAssertionAst {
-                value: true,
-                label: assertion.to_string(),
-            }),
-            rest,
-        ));
+        return Ok(FyrAssertionAst {
+            value: true,
+            label: assertion.to_string(),
+        });
     }
 
     if assertion == "false" {
-        return Ok((
-            FyrStatementAst::Assert(FyrAssertionAst {
-                value: false,
-                label: assertion.to_string(),
-            }),
-            rest,
-        ));
+        return Ok(FyrAssertionAst {
+            value: false,
+            label: assertion.to_string(),
+        });
     }
 
     for op in [">=", "<=", "==", "!=", ">", "<"] {
@@ -1332,13 +1409,10 @@ fn fyr_parse_assert_statement_ast(
                 _ => unreachable!(),
             };
 
-            return Ok((
-                FyrStatementAst::Assert(FyrAssertionAst {
-                    value,
-                    label: assertion.to_string(),
-                }),
-                rest,
-            ));
+            return Ok(FyrAssertionAst {
+                value,
+                label: format!("{left} {op} {right}"),
+            });
         }
     }
 

--- a/tests/fyr_boolean_operators.rs
+++ b/tests/fyr_boolean_operators.rs
@@ -1,0 +1,69 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str) -> String {
+    let exe = env!("CARGO_BIN_EXE_phase1");
+    let mut child = Command::new(exe)
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_MOBILE_MODE", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write input");
+
+    let output = child.wait_with_output().expect("wait");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn fyr_supports_boolean_and_assertions() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { let answer = 42; assert(answer >= 40 && answer <= 50); return answer; }' > bool.fyr\nfyr check bool.fyr\nfyr build bool.fyr\nexit\n",
+    );
+
+    assert!(output.contains("fyr check: ok bool.fyr"), "{output}");
+    assert!(
+        output.contains("status  : dry-run artifact ready"),
+        "{output}"
+    );
+}
+
+#[test]
+fn fyr_supports_boolean_or_assertions() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { let answer = 42; assert(answer < 0 || answer == 42); return answer; }' > bool.fyr\nfyr check bool.fyr\nfyr build bool.fyr\nexit\n",
+    );
+
+    assert!(output.contains("fyr check: ok bool.fyr"), "{output}");
+    assert!(
+        output.contains("status  : dry-run artifact ready"),
+        "{output}"
+    );
+}
+
+#[test]
+fn fyr_reports_failed_boolean_and_assertion() {
+    let output = run_phase1(
+        "fyr init app\necho 'fn main() -> i32 { let answer = 42; assert(answer >= 40 && answer < 40); return answer; }' > app/tests/bool_fail.fyr\nfyr test app\nexit\n",
+    );
+
+    assert!(
+        output.contains(
+            "test    : app/tests/bool_fail.fyr failed: assertion failed: 42 >= 40 && 42 < 40"
+        ),
+        "{output}"
+    );
+    assert!(output.contains("status  : failed"), "{output}");
+}


### PR DESCRIPTION
Adds compound boolean assertion operators to Fyr.

Supports:
- assert(a && b);
- assert(a || b);
- compound assertion failure diagnostics

Validation:
- cargo test -p phase1 --test fyr_boolean_operators
- cargo test -p phase1 --test fyr_inclusive_comparisons
- cargo test -p phase1 --test fyr_test_runner
- cargo test -p phase1 --test fyr_unary_minus
- cargo test --workspace --all-targets