### PR TITLE
Add Fyr grouped boolean assertions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1300,7 +1300,7 @@ fn fyr_parse_assert_statement_ast(
 }
 
 fn fyr_parse_assertion_ast(assertion: &str) -> Result<FyrAssertionAst, &'static str> {
-    let assertion = assertion.trim();
+    let assertion = fyr_strip_wrapping_assertion_parens(assertion.trim());
 
     if assertion.is_empty() {
         return Err("expected boolean assertion");
@@ -1339,13 +1339,6 @@ fn fyr_parse_assertion_ast(assertion: &str) -> Result<FyrAssertionAst, &'static 
     }
 
     if let Some(inner) = assertion.strip_prefix('!') {
-        let inner = inner.trim();
-        let inner = if inner.starts_with('(') && inner.ends_with(')') && inner.len() >= 2 {
-            &inner[1..inner.len() - 1]
-        } else {
-            inner
-        };
-
         let parsed = fyr_parse_assertion_ast(inner)?;
         return Ok(FyrAssertionAst {
             value: !parsed.value,
@@ -1354,6 +1347,44 @@ fn fyr_parse_assertion_ast(assertion: &str) -> Result<FyrAssertionAst, &'static 
     }
 
     fyr_parse_atomic_assertion_ast(assertion)
+}
+
+fn fyr_strip_wrapping_assertion_parens(assertion: &str) -> &str {
+    let mut current = assertion.trim();
+
+    loop {
+        if !(current.starts_with('(') && current.ends_with(')')) {
+            return current;
+        }
+
+        let mut depth = 0i32;
+        let mut wraps_entire_expression = true;
+
+        for (idx, ch) in current.char_indices() {
+            match ch {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 && idx != current.len() - 1 {
+                        wraps_entire_expression = false;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+
+            if depth < 0 {
+                wraps_entire_expression = false;
+                break;
+            }
+        }
+
+        if !wraps_entire_expression || depth != 0 {
+            return current;
+        }
+
+        current = current[1..current.len() - 1].trim();
+    }
 }
 
 fn fyr_split_assertion_chain<'a>(assertion: &'a str, op: &str) -> Option<Vec<&'a str>> {

--- a/tests/fyr_boolean_grouping.rs
+++ b/tests/fyr_boolean_grouping.rs
@@ -1,0 +1,67 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str) -> String {
+    let exe = env!("CARGO_BIN_EXE_phase1");
+    let mut child = Command::new(exe)
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_MOBILE_MODE", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write input");
+
+    let output = child.wait_with_output().expect("wait");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn fyr_supports_grouped_boolean_assertions() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { let answer = 42; assert((answer >= 40 && answer <= 50) || answer == 0); return answer; }' > group.fyr\nfyr check group.fyr\nfyr build group.fyr\nexit\n",
+    );
+
+    assert!(output.contains("fyr check: ok group.fyr"), "{output}");
+    assert!(
+        output.contains("status  : dry-run artifact ready"),
+        "{output}"
+    );
+}
+
+#[test]
+fn fyr_supports_nested_grouped_boolean_assertions() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { let answer = 42; assert((answer == 42) && !(answer < 0 || answer > 100)); return answer; }' > group.fyr\nfyr check group.fyr\nfyr build group.fyr\nexit\n",
+    );
+
+    assert!(output.contains("fyr check: ok group.fyr"), "{output}");
+    assert!(
+        output.contains("status  : dry-run artifact ready"),
+        "{output}"
+    );
+}
+
+#[test]
+fn fyr_reports_failed_grouped_boolean_assertion() {
+    let output = run_phase1(
+        "fyr init app\necho 'fn main() -> i32 { let answer = 42; assert((answer < 0 || answer > 100) && answer == 42); return answer; }' > app/tests/group_fail.fyr\nfyr test app\nexit\n",
+    );
+
+    assert!(
+        output.contains("test    : app/tests/group_fail.fyr failed: assertion failed: 42 < 0 || 42 > 100 && 42 == 42"),
+        "{output}"
+    );
+    assert!(output.contains("status  : failed"), "{output}");
+}


### PR DESCRIPTION
Adds grouped boolean assertion support to Fyr.

Supports:
- assert((a && b) || c);
- assert((a) && !(b || c));
- grouped boolean failure diagnostics

Validation:
- cargo test -p phase1 --test fyr_boolean_grouping
- cargo test -p phase1 --test fyr_not_operator
- cargo test -p phase1 --test fyr_boolean_operators
- cargo test -p phase1 --test fyr_inclusive_comparisons
- cargo test --workspace --all-targets