### PR TITLE
Add nested Phase1 spawn metadata

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2026,6 +2026,8 @@ fn repo_help() -> String {
 fn nest_command(shell: &mut Phase1Shell, args: &[String]) -> String {
     match args.first().map(String::as_str) {
         None | Some("status") => nest_status(shell),
+        Some("spawn") => nest_spawn(shell, &args[1..]),
+        Some("list") | Some("ls") => nest_list(shell),
         Some("target") | Some("use") => {
             let Some(raw) = args.get(1).map(String::as_str) else {
                 return "usage: nest target <self|parent|root|level>\n".to_string();
@@ -2065,6 +2067,88 @@ fn nest_command(shell: &mut Phase1Shell, args: &[String]) -> String {
         Some("help") | Some("-h") | Some("--help") => nest_help(),
         Some(other) => format!("nest: unknown action '{other}'\n{}", nest_help()),
     }
+}
+
+fn nest_spawn(shell: &mut Phase1Shell, args: &[String]) -> String {
+    let Some(name) = args.first().map(String::as_str) else {
+        return "usage: nest spawn <name>\n".to_string();
+    };
+
+    let level = nested_level();
+    let max = nested_max();
+
+    if level >= max {
+        return format!("nest spawn: max depth reached {level}/{max}\n");
+    }
+
+    if !nest_name_is_valid(name) {
+        return "nest spawn: invalid nest name\n".to_string();
+    }
+
+    let mut children = nest_children(shell);
+    if children.iter().any(|child| child == name) {
+        return format!("nest spawn: {name} already exists\n");
+    }
+
+    let _ = shell.kernel.vfs.mkdir("/nest");
+    let _ = shell.kernel.vfs.mkdir(&format!("/nest/{name}"));
+
+    children.push(name.to_string());
+    nest_store_children(shell, &children);
+
+    format!(
+        "nest spawn: created {name}\nlevel   : {}/{}\nmode    : isolated\nroot    : /nest/{name}\nhost    : inherited-safe-defaults\n",
+        level + 1,
+        max
+    )
+}
+
+fn nest_list(shell: &Phase1Shell) -> String {
+    let children = nest_children(shell);
+    let level = nested_level();
+    let max = nested_max();
+
+    if children.is_empty() {
+        return "nest list\nchildren: none\n".to_string();
+    }
+
+    let mut out = "nest list\n".to_string();
+    for child in children {
+        out.push_str(&format!(
+            "{child}\nlevel   : {}/{}\nmode    : isolated\nroot    : /nest/{child}\n",
+            level + 1,
+            max
+        ));
+    }
+    out
+}
+
+fn nest_children(shell: &Phase1Shell) -> Vec<String> {
+    shell
+        .env
+        .get("PHASE1_NEST_CHILDREN")
+        .map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|item| !item.is_empty())
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn nest_store_children(shell: &mut Phase1Shell, children: &[String]) {
+    shell
+        .env
+        .insert("PHASE1_NEST_CHILDREN".to_string(), children.join(","));
+}
+
+fn nest_name_is_valid(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 32
+        && name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
 }
 
 fn nest_status(_shell: &Phase1Shell) -> String {

--- a/tests/nest_spawn.rs
+++ b/tests/nest_spawn.rs
@@ -1,0 +1,69 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str, level: &str, max: &str) -> String {
+    let exe = env!("CARGO_BIN_EXE_phase1");
+    let mut child = Command::new(exe)
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_MOBILE_MODE", "1")
+        .env("PHASE1_NESTED_LEVEL", level)
+        .env("PHASE1_NESTED_MAX", max)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write input");
+
+    let output = child.wait_with_output().expect("wait");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn nest_spawn_creates_named_child_context() {
+    let output = run_phase1("nest spawn demo\nnest list\nexit\n", "0", "2");
+
+    assert!(output.contains("nest spawn: created demo"), "{output}");
+    assert!(output.contains("nest list"), "{output}");
+    assert!(output.contains("demo"), "{output}");
+    assert!(output.contains("level   : 1/2"), "{output}");
+    assert!(output.contains("mode    : isolated"), "{output}");
+}
+
+#[test]
+fn nest_spawn_rejects_duplicate_child_context() {
+    let output = run_phase1("nest spawn demo\nnest spawn demo\nexit\n", "0", "2");
+
+    assert!(output.contains("nest spawn: created demo"), "{output}");
+    assert!(
+        output.contains("nest spawn: demo already exists"),
+        "{output}"
+    );
+}
+
+#[test]
+fn nest_spawn_rejects_invalid_names() {
+    let output = run_phase1("nest spawn ../escape\nexit\n", "0", "2");
+
+    assert!(output.contains("nest spawn: invalid nest name"), "{output}");
+}
+
+#[test]
+fn nest_spawn_respects_depth_cap() {
+    let output = run_phase1("nest spawn too-deep\nexit\n", "2", "2");
+
+    assert!(
+        output.contains("nest spawn: max depth reached 2/2"),
+        "{output}"
+    );
+}


### PR DESCRIPTION
Adds metadata-only nested Phase1 child contexts.

Implements:
- nest spawn <name>
- nest list
- duplicate-name guard
- invalid-name guard
- max-depth guard
- VFS /nest/<name> placeholder roots

Validation:
- cargo test -p phase1 --test nest_spawn
- cargo test -p phase1 --test nest_status
- cargo test --workspace --all-targets

Refs #127