### PR TITLE
Add nested Phase1 destroy metadata

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2029,6 +2029,7 @@ fn nest_command(shell: &mut Phase1Shell, args: &[String]) -> String {
         Some("spawn") => nest_spawn(shell, &args[1..]),
         Some("list") | Some("ls") => nest_list(shell),
         Some("enter") => nest_enter(shell, &args[1..]),
+        Some("destroy") | Some("rm") => nest_destroy(shell, &args[1..]),
         Some("target") | Some("use") => {
             let Some(raw) = args.get(1).map(String::as_str) else {
                 return "usage: nest target <self|parent|root|level>\n".to_string();
@@ -2177,6 +2178,37 @@ fn nest_active_path(shell: &Phase1Shell) -> String {
     } else {
         format!("/nest/{active}")
     }
+}
+
+fn nest_destroy(shell: &mut Phase1Shell, args: &[String]) -> String {
+    let Some(name) = args.first().map(String::as_str) else {
+        return "usage: nest destroy <name>\n".to_string();
+    };
+
+    if !nest_name_is_valid(name) {
+        return "nest destroy: invalid nest name\n".to_string();
+    }
+
+    let mut children = nest_children(shell);
+    let Some(index) = children.iter().position(|child| child == name) else {
+        return format!("nest destroy: {name} not found\n");
+    };
+
+    children.remove(index);
+    nest_store_children(shell, &children);
+
+    let was_active = nest_active_name(shell) == name;
+    if was_active {
+        shell.env.remove("PHASE1_NEST_ACTIVE");
+        shell.env.remove("PHASE1_NEST_ACTIVE_LEVEL");
+        return format!(
+            "nest destroy: removed {name}\nactive  : root\nlevel   : {}/{}\npath    : /\n",
+            nested_level(),
+            nested_max()
+        );
+    }
+
+    format!("nest destroy: removed {name}\n")
 }
 
 fn nest_enter(shell: &mut Phase1Shell, args: &[String]) -> String {

--- a/tests/nest_destroy.rs
+++ b/tests/nest_destroy.rs
@@ -1,0 +1,78 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str, level: &str, max: &str) -> String {
+    let exe = env!("CARGO_BIN_EXE_phase1");
+    let mut child = Command::new(exe)
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_MOBILE_MODE", "1")
+        .env("PHASE1_NESTED_LEVEL", level)
+        .env("PHASE1_NESTED_MAX", max)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write input");
+
+    let output = child.wait_with_output().expect("wait");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn nest_destroy_removes_child_context() {
+    let output = run_phase1(
+        "nest spawn demo\nnest destroy demo\nnest list\nexit\n",
+        "0",
+        "2",
+    );
+
+    assert!(output.contains("nest spawn: created demo"), "{output}");
+    assert!(output.contains("nest destroy: removed demo"), "{output}");
+    assert!(output.contains("children: none"), "{output}");
+}
+
+#[test]
+fn nest_destroy_reports_missing_child_context() {
+    let output = run_phase1("nest destroy missing\nexit\n", "0", "2");
+
+    assert!(
+        output.contains("nest destroy: missing not found"),
+        "{output}"
+    );
+}
+
+#[test]
+fn nest_destroy_rejects_invalid_names() {
+    let output = run_phase1("nest destroy ../escape\nexit\n", "0", "2");
+
+    assert!(
+        output.contains("nest destroy: invalid nest name"),
+        "{output}"
+    );
+}
+
+#[test]
+fn nest_destroy_active_context_returns_to_root() {
+    let output = run_phase1(
+        "nest spawn demo\nnest enter demo\nnest destroy demo\nnest status\nexit\n",
+        "0",
+        "2",
+    );
+
+    assert!(output.contains("nest enter: demo"), "{output}");
+    assert!(output.contains("nest destroy: removed demo"), "{output}");
+    assert!(output.contains("active  : root"), "{output}");
+    assert!(output.contains("level   : 0/2"), "{output}");
+    assert!(output.contains("path    : /"), "{output}");
+}


### PR DESCRIPTION
Adds metadata-only nested Phase1 context removal.

Implements:
- nest destroy <name>
- nest rm <name> alias
- missing-child guard
- invalid-name guard
- active-context reset to root

Validation:
- cargo test -p phase1 --test nest_destroy
- cargo test -p phase1 --test nest_enter
- cargo test -p phase1 --test nest_spawn
- cargo test -p phase1 --test nest_status
- cargo test --workspace --all-targets

Refs #127