### PR TITLE
Add nested Phase1 inspect metadata

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2030,6 +2030,7 @@ fn nest_command(shell: &mut Phase1Shell, args: &[String]) -> String {
         Some("list") | Some("ls") => nest_list(shell),
         Some("enter") => nest_enter(shell, &args[1..]),
         Some("destroy") | Some("rm") => nest_destroy(shell, &args[1..]),
+        Some("inspect") | Some("info") => nest_inspect(shell, &args[1..]),
         Some("target") | Some("use") => {
             let Some(raw) = args.get(1).map(String::as_str) else {
                 return "usage: nest target <self|parent|root|level>\n".to_string();
@@ -2178,6 +2179,29 @@ fn nest_active_path(shell: &Phase1Shell) -> String {
     } else {
         format!("/nest/{active}")
     }
+}
+
+fn nest_inspect(shell: &Phase1Shell, args: &[String]) -> String {
+    let Some(name) = args.first().map(String::as_str) else {
+        return "usage: nest inspect <name>\n".to_string();
+    };
+
+    if !nest_name_is_valid(name) {
+        return "nest inspect: invalid nest name\n".to_string();
+    }
+
+    let children = nest_children(shell);
+    if !children.iter().any(|child| child == name) {
+        return format!("nest inspect: {name} not found\n");
+    }
+
+    let active = nest_active_name(shell) == name;
+    format!(
+        "nest inspect\nname    : {name}\nlevel   : {}/{}\nactive  : {}\npath    : /nest/{name}\nmode    : isolated\nhost    : inherited-safe-defaults\n",
+        nested_level() + 1,
+        nested_max(),
+        if active { "yes" } else { "no" }
+    )
 }
 
 fn nest_destroy(shell: &mut Phase1Shell, args: &[String]) -> String {

--- a/tests/nest_inspect.rs
+++ b/tests/nest_inspect.rs
@@ -1,0 +1,74 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str, level: &str, max: &str) -> String {
+    let exe = env!("CARGO_BIN_EXE_phase1");
+    let mut child = Command::new(exe)
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_MOBILE_MODE", "1")
+        .env("PHASE1_NESTED_LEVEL", level)
+        .env("PHASE1_NESTED_MAX", max)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write input");
+
+    let output = child.wait_with_output().expect("wait");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn nest_inspect_reports_child_metadata() {
+    let output = run_phase1("nest spawn demo\nnest inspect demo\nexit\n", "0", "3");
+
+    assert!(output.contains("nest inspect"), "{output}");
+    assert!(output.contains("name    : demo"), "{output}");
+    assert!(output.contains("level   : 1/3"), "{output}");
+    assert!(output.contains("active  : no"), "{output}");
+    assert!(output.contains("path    : /nest/demo"), "{output}");
+    assert!(output.contains("mode    : isolated"), "{output}");
+}
+
+#[test]
+fn nest_inspect_reports_active_child() {
+    let output = run_phase1(
+        "nest spawn demo\nnest enter demo\nnest inspect demo\nexit\n",
+        "0",
+        "3",
+    );
+
+    assert!(output.contains("name    : demo"), "{output}");
+    assert!(output.contains("active  : yes"), "{output}");
+}
+
+#[test]
+fn nest_inspect_reports_missing_child() {
+    let output = run_phase1("nest inspect missing\nexit\n", "0", "3");
+
+    assert!(
+        output.contains("nest inspect: missing not found"),
+        "{output}"
+    );
+}
+
+#[test]
+fn nest_inspect_rejects_invalid_names() {
+    let output = run_phase1("nest inspect ../escape\nexit\n", "0", "3");
+
+    assert!(
+        output.contains("nest inspect: invalid nest name"),
+        "{output}"
+    );
+}


### PR DESCRIPTION
Adds metadata inspection for nested Phase1 child contexts.

Implements:
- nest inspect <name>
- nest info <name> alias
- active child reporting
- missing-child guard
- invalid-name guard

Validation:
- cargo test -p phase1 --test nest_inspect
- cargo test -p phase1 --test nest_destroy
- cargo test -p phase1 --test nest_enter
- cargo test -p phase1 --test nest_spawn
- cargo test -p phase1 --test nest_status
- cargo test --workspace --all-targets

Refs #127