### PR TITLE
Add nested Phase1 tree metadata

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2031,6 +2031,7 @@ fn nest_command(shell: &mut Phase1Shell, args: &[String]) -> String {
         Some("enter") => nest_enter(shell, &args[1..]),
         Some("destroy") | Some("rm") => nest_destroy(shell, &args[1..]),
         Some("inspect") | Some("info") => nest_inspect(shell, &args[1..]),
+        Some("tree") => nest_tree(shell),
         Some("target") | Some("use") => {
             let Some(raw) = args.get(1).map(String::as_str) else {
                 return "usage: nest target <self|parent|root|level>\n".to_string();
@@ -2179,6 +2180,36 @@ fn nest_active_path(shell: &Phase1Shell) -> String {
     } else {
         format!("/nest/{active}")
     }
+}
+
+fn nest_tree(shell: &Phase1Shell) -> String {
+    let children = nest_children(shell);
+    let active = nest_active_name(shell);
+    let level = nest_current_level(shell);
+    let max = nested_max();
+
+    let mut out = format!(
+        "nest tree\nroot{}\nlevel   : {level}/{max}\n",
+        if active == "root" { " *" } else { "" }
+    );
+
+    if children.is_empty() {
+        out.push_str("children: none\n");
+        return out;
+    }
+
+    out.push_str(&format!("active  : {active}\n"));
+
+    for child in children {
+        let marker = if active == child { " *" } else { "" };
+        out.push_str(&format!(
+            "|- {child}{marker}\n   level   : {}/{}\n   path    : /nest/{child}\n   mode    : isolated\n",
+            level + 1,
+            max
+        ));
+    }
+
+    out
 }
 
 fn nest_inspect(shell: &Phase1Shell, args: &[String]) -> String {
@@ -2343,12 +2374,7 @@ fn request_nest_exit_all(shell: &mut Phase1Shell) -> String {
 }
 
 fn nest_help() -> String {
-    "phase1 nest control\n\nusage:\n  nest status\n  nest target <self|parent|root|level>\n  nest exit self\n  nest exit all\n  exit all\n\nnotes:\n  target is an operator context marker for nested workflows\n  nest exit-all is an alias for nest exit all
-  nest exit-all is an alias for nest exit all
-  nest exit-all is an alias for nest exit all
-  nest exit-all is an alias for nest exit all
-  exit all writes a local Phase1 exit signal so parent shells unwind when they regain control\n"
-        .to_string()
+    "phase1 nest control\n\nusage:\n  nest status\n  nest spawn <name>\n  nest list\n  nest enter <name>\n  nest exit\n  nest destroy <name>\n  nest inspect <name>\n  nest tree\n  nest target <self|parent|root|level>\n  nest exit self\n  nest exit all\n  nest exit-all\n  exit all\n\nnotes:\n  target is an operator context marker for nested workflows\n  nest exit-all is an alias for nest exit all\n  exit all writes a local Phase1 exit signal so parent shells unwind when they regain control\n".to_string()
 }
 
 fn request_reboot(shell: &mut Phase1Shell) {

--- a/tests/nest_tree.rs
+++ b/tests/nest_tree.rs
@@ -1,0 +1,75 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str, level: &str, max: &str) -> String {
+    let exe = env!("CARGO_BIN_EXE_phase1");
+    let mut child = Command::new(exe)
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_MOBILE_MODE", "1")
+        .env("PHASE1_NESTED_LEVEL", level)
+        .env("PHASE1_NESTED_MAX", max)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write input");
+
+    let output = child.wait_with_output().expect("wait");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn nest_tree_reports_empty_root() {
+    let output = run_phase1("nest tree\nexit\n", "0", "3");
+
+    assert!(output.contains("nest tree"), "{output}");
+    assert!(output.contains("root"), "{output}");
+    assert!(output.contains("children: none"), "{output}");
+}
+
+#[test]
+fn nest_tree_reports_spawned_children() {
+    let output = run_phase1(
+        "nest spawn alpha\nnest spawn beta\nnest tree\nexit\n",
+        "0",
+        "3",
+    );
+
+    assert!(output.contains("nest tree"), "{output}");
+    assert!(output.contains("root"), "{output}");
+    assert!(output.contains("alpha"), "{output}");
+    assert!(output.contains("beta"), "{output}");
+    assert!(output.contains("level   : 1/3"), "{output}");
+    assert!(output.contains("path    : /nest/alpha"), "{output}");
+    assert!(output.contains("path    : /nest/beta"), "{output}");
+}
+
+#[test]
+fn nest_tree_marks_active_child_context() {
+    let output = run_phase1(
+        "nest spawn alpha\nnest spawn beta\nnest enter beta\nnest tree\nexit\n",
+        "0",
+        "3",
+    );
+
+    assert!(output.contains("beta *"), "{output}");
+    assert!(output.contains("active  : beta"), "{output}");
+}
+
+#[test]
+fn nest_help_lists_tree_command() {
+    let output = run_phase1("nest help\nexit\n", "0", "3");
+
+    assert!(output.contains("nest tree"), "{output}");
+}


### PR DESCRIPTION
Adds topology display for nested Phase1 metadata contexts.

Implements:
- nest tree
- empty root reporting
- child context tree output
- active child marker

Validation:
- cargo test -p phase1 --test nest_tree
- cargo test -p phase1 --test nest_inspect
- cargo test -p phase1 --test nest_destroy
- cargo test -p phase1 --test nest_enter
- cargo test -p phase1 --test nest_spawn
- cargo test -p phase1 --test nest_status
- cargo test --workspace --all-targets

Refs #127