### PR TITLE
Document Base1 image builder design

### DIFF
--- a/docs/os/BASE1_IMAGE_BUILDER.md
+++ b/docs/os/BASE1_IMAGE_BUILDER.md
@@ -1,0 +1,76 @@
+# Base1 image-builder design
+
+The Base1 image builder is the first practical engineering slice of the Phase1 operating-system track.
+
+Its job is to produce a minimal, bootable, recoverable Base1 image that launches Phase1 as the primary operator shell without pretending Phase1 is already a kernel or hardened standalone OS.
+
+## Goal
+
+Build a repeatable image pipeline for:
+
+- Raspberry Pi-class targets.
+- ThinkPad X200-class targets.
+- Generic x86_64 test targets.
+
+The first checkpoint is documentation-only. The next checkpoints should add scripts behind dry-run and preflight guards.
+
+## Stage 1 boot image contract
+
+A Base1 boot image must provide:
+
+- Minimal Linux-based host foundation.
+- Read-only base layer.
+- Writable user/data layer.
+- Phase1 auto-launch as the primary shell.
+- Emergency shell fallback.
+- Recovery boot path.
+- Hardware preflight report.
+- Clear version metadata.
+- No silent host trust escalation.
+
+## Proposed image layout
+
+```text
+/boot/                 bootloader and kernel assets
+/base1/                read-only Base1 system layer
+/phase1/               Phase1 application checkout or packaged build
+/state/phase1/         writable Phase1 state, history, logs, learning data
+/recovery/             fallback tools and recovery metadata
+```
+
+## First boot flow
+
+1. Boot Base1.
+2. Mount read-only base.
+3. Mount writable state layer.
+4. Run hardware preflight.
+5. Start Phase1 in safe mode.
+6. Show recovery instructions in the boot panel.
+7. Write non-sensitive boot metadata to the audit log.
+
+## Recovery requirements
+
+Every image must include:
+
+- Emergency shell access.
+- Rollback or restore path.
+- Logs that do not expose secrets.
+- Clear instructions for leaving Phase1 and recovering the host.
+- A way to disable Phase1 auto-launch.
+
+## Guardrails
+
+- Do not claim the image is a secure OS replacement until recovery, update, hardware, and audit validation exist.
+- Do not remove safe mode.
+- Do not enable host tools by default.
+- Do not perform destructive disk actions without explicit confirmation.
+- Do not ship an image target without a hardware checklist.
+
+## Initial implementation slices
+
+1. Add image-builder design docs.
+2. Add dry-run script outline.
+3. Add preflight integration.
+4. Add hardware checklist docs.
+5. Add recovery design docs.
+6. Add first experimental image build script.

--- a/docs/os/ROADMAP.md
+++ b/docs/os/ROADMAP.md
@@ -19,7 +19,7 @@ The Phase1 operating-system track means:
 - No claim that the current terminal console replaces a kernel.
 - No claim that host-backed execution is hardened against hostile code.
 - No removal of recovery access to the underlying host.
-- No silent privilege escalation.
+- No silent privilege change.
 - No unsupported hardware promises.
 
 ## Stage 0: Documentation pivot
@@ -28,7 +28,7 @@ Status: active.
 
 Goals:
 
-- Replace blanket “not planned” language with a staged long-term OS track.
+- Use a staged long-term OS track.
 - Keep current limitations clear.
 - Link the track from README and Base1 documentation.
 - Add tests that prevent overclaiming.
@@ -46,6 +46,8 @@ Required pieces:
 - First-boot setup flow.
 - Hardware preflight checks.
 - Reproducible image build notes.
+
+First design slice: [`Base1 image-builder design`](BASE1_IMAGE_BUILDER.md).
 
 ## Stage 2: Installer and recovery
 
@@ -118,7 +120,7 @@ Each target needs:
 ## First engineering slices
 
 1. Add this roadmap and README positioning.
-2. Add Base1 image-builder design documentation.
+2. Add the [`Base1 image-builder design`](BASE1_IMAGE_BUILDER.md).
 3. Add installer design documentation.
 4. Add recovery design documentation.
 5. Add system-surface command stubs behind safe defaults.

--- a/tests/base1_image_builder_docs.rs
+++ b/tests/base1_image_builder_docs.rs
@@ -1,0 +1,29 @@
+#[test]
+fn readme_links_base1_image_builder_design() {
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(readme.contains("docs/os/BASE1_IMAGE_BUILDER.md"), "{readme}");
+    assert!(readme.contains("Base1 image-builder design"), "{readme}");
+}
+
+#[test]
+fn image_builder_doc_defines_stage1_boot_surface() {
+    let doc =
+        std::fs::read_to_string("docs/os/BASE1_IMAGE_BUILDER.md").expect("image builder doc");
+
+    assert!(doc.contains("Base1 image-builder design"), "{doc}");
+    assert!(doc.contains("Read-only base layer"), "{doc}");
+    assert!(doc.contains("Writable user/data layer"), "{doc}");
+    assert!(doc.contains("Phase1 auto-launch"), "{doc}");
+    assert!(doc.contains("Emergency shell fallback"), "{doc}");
+    assert!(doc.contains("Recovery boot path"), "{doc}");
+    assert!(doc.contains("No silent host trust escalation"), "{doc}");
+}
+
+#[test]
+fn os_roadmap_links_image_builder_design() {
+    let roadmap = std::fs::read_to_string("docs/os/ROADMAP.md").expect("os roadmap");
+
+    assert!(roadmap.contains("Base1 image-builder design"), "{roadmap}");
+    assert!(roadmap.contains("BASE1_IMAGE_BUILDER.md"), "{roadmap}");
+}


### PR DESCRIPTION
Adds the first Stage 1 design document for the Phase1 OS track.

Implements:
- Base1 image-builder design doc
- OS roadmap link
- docs tests for the boot image contract

Validation:
- cargo test -p phase1 --test base1_image_builder_docs
- cargo test -p phase1 --test os_replacement_track_docs
- cargo test --workspace --all-targets

Refs #135