### PR TITLE
Document Base1 installer and recovery design

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The current surface is intentionally conservative: it tracks child contexts, act
 
 Phase1 now has an explicit long-term operating-system track. The immediate goal is not to claim a finished OS. The goal is to move toward a bootable, recoverable, Phase1-first environment through Base1.
 
-Start with [`docs/os/ROADMAP.md`](docs/os/ROADMAP.md). The first Stage 1 design slice is [`docs/os/BASE1_IMAGE_BUILDER.md`](docs/os/BASE1_IMAGE_BUILDER.md).
+Start with [`docs/os/ROADMAP.md`](docs/os/ROADMAP.md). The first Stage 1 design slice is [`docs/os/BASE1_IMAGE_BUILDER.md`](docs/os/BASE1_IMAGE_BUILDER.md). The installer/recovery slice is [`docs/os/INSTALLER_RECOVERY.md`](docs/os/INSTALLER_RECOVERY.md).
 
 The staged path is:
 
@@ -328,6 +328,7 @@ Start here:
 
 - [`docs/os/ROADMAP.md`](docs/os/ROADMAP.md) — Phase1 operating-system track
 - [`docs/os/BASE1_IMAGE_BUILDER.md`](docs/os/BASE1_IMAGE_BUILDER.md) — Base1 image-builder design
+- [`docs/os/INSTALLER_RECOVERY.md`](docs/os/INSTALLER_RECOVERY.md) — Base1 installer and recovery design
 - [`base1/README.md`](base1/README.md) — Base1 overview
 - [`base1/SECURITY_MODEL.md`](base1/SECURITY_MODEL.md) — security model and boundary
 - [`base1/HARDWARE_TARGETS.md`](base1/HARDWARE_TARGETS.md) — Raspberry Pi and X200 target matrix

--- a/docs/os/INSTALLER_RECOVERY.md
+++ b/docs/os/INSTALLER_RECOVERY.md
@@ -1,0 +1,71 @@
+# Base1 installer and recovery design
+
+The Base1 installer and recovery design defines how Phase1 can move toward a bootable, daily-driver-capable OS track without risking user data or pretending the current console is already a full operating system.
+
+## Goal
+
+Create a boring, visible, recoverable installation path for a Phase1-first Base1 system.
+
+The first checkpoint is documentation-only. Later checkpoints should add dry-run scripts before any disk-changing behavior exists.
+
+## Installer contract
+
+A Base1 installer must provide:
+
+- Non-destructive dry-run mode by default.
+- Explicit target-disk selection.
+- Hardware preflight check.
+- Storage layout preview.
+- Recovery path preview.
+- Rollback explanation.
+- Clear final confirmation before destructive actions.
+- No host trust escalation by default.
+
+## Proposed storage layout
+
+```text
+/boot/                 bootloader and kernel assets
+/base1/                read-only Base1 system layer
+/state/phase1/         writable Phase1 state and user data
+/recovery/             recovery tools, rollback metadata, and restore notes
+```
+
+## Recovery contract
+
+A Base1 recovery path must provide:
+
+- Emergency shell access.
+- Disable Phase1 auto-launch.
+- Restore previous boot target.
+- Read logs without exposing secrets.
+- Roll back system updates.
+- Export user data from the writable layer.
+- Verify image and update metadata.
+
+## First-boot recovery message
+
+Every Base1 boot image should show the operator:
+
+```text
+Recovery:
+  hold recovery key during boot, or run base1 recovery from Phase1
+  safe mode remains default-on
+  host tools remain off unless explicitly enabled
+```
+
+## Guardrails
+
+- Do not run destructive disk commands in early checkpoints.
+- Do not hide the target disk.
+- Do not overwrite a user system without explicit confirmation.
+- Do not remove recovery shell access.
+- Do not claim daily-driver readiness until install, rollback, update, and hardware checks pass.
+
+## Initial implementation slices
+
+1. Add installer and recovery design docs.
+2. Add dry-run installer command design.
+3. Add recovery command design.
+4. Add storage layout checker.
+5. Add rollback metadata design.
+6. Add first non-destructive installer dry-run script.

--- a/docs/os/ROADMAP.md
+++ b/docs/os/ROADMAP.md
@@ -121,7 +121,7 @@ Each target needs:
 
 1. Add this roadmap and README positioning.
 2. Add the [`Base1 image-builder design`](BASE1_IMAGE_BUILDER.md).
-3. Add installer design documentation.
+3. Add the [`Base1 installer and recovery design`](INSTALLER_RECOVERY.md).
 4. Add recovery design documentation.
 5. Add system-surface command stubs behind safe defaults.
 6. Add hardware-target checklists.

--- a/tests/base1_installer_recovery_docs.rs
+++ b/tests/base1_installer_recovery_docs.rs
@@ -1,0 +1,37 @@
+#[test]
+fn installer_recovery_doc_exists_and_defines_contracts() {
+    let doc =
+        std::fs::read_to_string("docs/os/INSTALLER_RECOVERY.md").expect("installer recovery doc");
+
+    assert!(doc.contains("Base1 installer and recovery design"), "{doc}");
+    assert!(doc.contains("Non-destructive dry-run mode"), "{doc}");
+    assert!(doc.contains("Explicit target-disk selection"), "{doc}");
+    assert!(doc.contains("Emergency shell access"), "{doc}");
+    assert!(doc.contains("Disable Phase1 auto-launch"), "{doc}");
+    assert!(
+        doc.contains("Do not run destructive disk commands"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn readme_links_installer_recovery_design() {
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(readme.contains("docs/os/INSTALLER_RECOVERY.md"), "{readme}");
+    assert!(
+        readme.contains("Base1 installer and recovery design"),
+        "{readme}"
+    );
+}
+
+#[test]
+fn os_roadmap_mentions_installer_recovery_design() {
+    let roadmap = std::fs::read_to_string("docs/os/ROADMAP.md").expect("os roadmap");
+
+    assert!(roadmap.contains("INSTALLER_RECOVERY.md"), "{roadmap}");
+    assert!(
+        roadmap.contains("installer and recovery design"),
+        "{roadmap}"
+    );
+}


### PR DESCRIPTION
Adds the installer and recovery design slice for the Phase1 OS track.

Implements:
- Base1 installer and recovery design doc
- README link
- OS roadmap link
- docs tests for installer/recovery guardrails

Validation:
- cargo test -p phase1 --test base1_installer_recovery_docs
- cargo test -p phase1 --test base1_image_builder_docs
- cargo test -p phase1 --test os_replacement_track_docs

Refs #135