### PR TITLE
Document Base1 installer dry-run design

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Start here:
 - [`docs/os/ROADMAP.md`](docs/os/ROADMAP.md) — Phase1 operating-system track
 - [`docs/os/BASE1_IMAGE_BUILDER.md`](docs/os/BASE1_IMAGE_BUILDER.md) — Base1 image-builder design
 - [`docs/os/INSTALLER_RECOVERY.md`](docs/os/INSTALLER_RECOVERY.md) — Base1 installer and recovery design
+- [`docs/os/BASE1_INSTALLER_DRY_RUN.md`](docs/os/BASE1_INSTALLER_DRY_RUN.md) — Base1 installer dry-run design
 - [`base1/README.md`](base1/README.md) — Base1 overview
 - [`base1/SECURITY_MODEL.md`](base1/SECURITY_MODEL.md) — security model and boundary
 - [`base1/HARDWARE_TARGETS.md`](base1/HARDWARE_TARGETS.md) — Raspberry Pi and X200 target matrix

--- a/docs/os/BASE1_INSTALLER_DRY_RUN.md
+++ b/docs/os/BASE1_INSTALLER_DRY_RUN.md
@@ -1,0 +1,67 @@
+# Base1 installer dry-run design
+
+The Base1 installer dry-run is the first safe command surface for moving Phase1 toward a bootable OS track.
+
+This checkpoint is still documentation-only. It defines what the future dry-run command must show before any installer script is allowed to touch disks.
+
+## Goal
+
+Provide a non-destructive installer preview that helps an operator understand the target system, proposed layout, recovery path, and risks before any destructive action exists.
+
+## Command shape
+
+```text
+base1 install --dry-run --target <disk>
+```
+
+The first implementation must refuse to run without `--dry-run`.
+
+## Required dry-run output
+
+A dry-run report must include:
+
+- Selected target disk.
+- Hardware preflight summary.
+- Proposed boot partition.
+- Proposed read-only Base1 layer.
+- Proposed writable Phase1 state layer.
+- Proposed recovery layer.
+- Phase1 auto-launch plan.
+- Emergency shell fallback.
+- Rollback metadata plan.
+- Explicit statement that no disk writes occurred.
+
+## Forbidden early behavior
+
+The dry-run command must not:
+
+- Partition disks.
+- Format filesystems.
+- Mount writable system targets.
+- Install bootloaders.
+- Enable host trust.
+- Disable recovery access.
+- Hide the target disk identity.
+
+## Example output
+
+```text
+base1 installer dry-run
+target  : /dev/example
+writes  : no
+boot    : preview only
+base1   : read-only layer preview
+state   : writable phase1 state preview
+recover : emergency shell + rollback metadata preview
+status  : dry-run complete
+```
+
+## Promotion gate
+
+The dry-run command can only become a real installer after:
+
+1. Target-disk confirmation exists.
+2. Recovery boot path is tested.
+3. Rollback metadata is tested.
+4. Hardware target checks pass.
+5. The user receives a final destructive-action confirmation.

--- a/docs/os/ROADMAP.md
+++ b/docs/os/ROADMAP.md
@@ -122,6 +122,6 @@ Each target needs:
 1. Add this roadmap and README positioning.
 2. Add the [`Base1 image-builder design`](BASE1_IMAGE_BUILDER.md).
 3. Add the [`Base1 installer and recovery design`](INSTALLER_RECOVERY.md).
-4. Add recovery design documentation.
+4. Add the [`Base1 installer dry-run design`](BASE1_INSTALLER_DRY_RUN.md).
 5. Add system-surface command stubs behind safe defaults.
 6. Add hardware-target checklists.

--- a/tests/base1_installer_dry_run_docs.rs
+++ b/tests/base1_installer_dry_run_docs.rs
@@ -1,0 +1,42 @@
+#[test]
+fn installer_dry_run_doc_exists_and_defines_safe_command() {
+    let doc = std::fs::read_to_string("docs/os/BASE1_INSTALLER_DRY_RUN.md")
+        .expect("installer dry-run doc");
+
+    assert!(doc.contains("Base1 installer dry-run design"), "{doc}");
+    assert!(
+        doc.contains("base1 install --dry-run --target <disk>"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("must refuse to run without `--dry-run`"),
+        "{doc}"
+    );
+    assert!(doc.contains("no disk writes occurred"), "{doc}");
+    assert!(
+        doc.contains("Partition disks") || doc.contains("partition disks"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn readme_links_installer_dry_run_design() {
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        readme.contains("docs/os/BASE1_INSTALLER_DRY_RUN.md"),
+        "{readme}"
+    );
+    assert!(
+        readme.contains("Base1 installer dry-run design"),
+        "{readme}"
+    );
+}
+
+#[test]
+fn os_roadmap_links_installer_dry_run_design() {
+    let roadmap = std::fs::read_to_string("docs/os/ROADMAP.md").expect("os roadmap");
+
+    assert!(roadmap.contains("BASE1_INSTALLER_DRY_RUN.md"), "{roadmap}");
+    assert!(roadmap.contains("installer dry-run design"), "{roadmap}");
+}


### PR DESCRIPTION
Adds the dry-run installer design slice for the Phase1 OS track.

Implements:
- Base1 installer dry-run design doc
- README link
- OS roadmap link
- docs tests for dry-run guardrails

Validation:
- cargo test -p phase1 --test base1_installer_dry_run_docs
- cargo test -p phase1 --test base1_installer_recovery_docs
- cargo test -p phase1 --test base1_image_builder_docs
- cargo test -p phase1 --test os_replacement_track_docs

Refs #135