### PR TITLE
Document Base1 recovery command design

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Start here:
 - [`docs/os/BASE1_IMAGE_BUILDER.md`](docs/os/BASE1_IMAGE_BUILDER.md) — Base1 image-builder design
 - [`docs/os/INSTALLER_RECOVERY.md`](docs/os/INSTALLER_RECOVERY.md) — Base1 installer and recovery design
 - [`docs/os/BASE1_INSTALLER_DRY_RUN.md`](docs/os/BASE1_INSTALLER_DRY_RUN.md) — Base1 installer dry-run design
+- [`docs/os/BASE1_RECOVERY_COMMAND.md`](docs/os/BASE1_RECOVERY_COMMAND.md) — Base1 recovery command design
 - [`base1/README.md`](base1/README.md) — Base1 overview
 - [`base1/SECURITY_MODEL.md`](base1/SECURITY_MODEL.md) — security model and boundary
 - [`base1/HARDWARE_TARGETS.md`](base1/HARDWARE_TARGETS.md) — Raspberry Pi and X200 target matrix

--- a/docs/os/BASE1_RECOVERY_COMMAND.md
+++ b/docs/os/BASE1_RECOVERY_COMMAND.md
@@ -1,0 +1,80 @@
+# Base1 recovery command design
+
+The Base1 recovery command is the first safe recovery-control surface for the Phase1 OS track.
+
+This checkpoint is documentation-only. It defines the future command contract before any recovery script changes boot settings, mounts disks, or modifies system state.
+
+## Goal
+
+Provide a visible, non-destructive recovery preview that lets an operator understand how to disable Phase1 auto-launch, access emergency tools, inspect logs, and recover user data without weakening the host boundary.
+
+## Command shape
+
+```text
+base1 recovery --dry-run
+base1 recovery status
+base1 recovery plan
+```
+
+Early implementations must be read-only and must not require host trust.
+
+## Required recovery status output
+
+A recovery status report must include:
+
+- Current boot target.
+- Whether Phase1 auto-launch is enabled.
+- Emergency shell availability.
+- Recovery partition or recovery directory status.
+- Rollback metadata status.
+- Writable state layer status.
+- Safe-mode and host-trust status.
+- Explicit statement that no recovery changes were made.
+
+## Required recovery plan output
+
+A recovery plan must preview:
+
+- How to disable Phase1 auto-launch.
+- How to enter emergency shell mode.
+- How to read recovery logs.
+- How to export `/state/phase1`.
+- How to restore the previous boot target.
+- How to verify rollback metadata.
+- What manual confirmation would be required before any change.
+
+## Forbidden early behavior
+
+The recovery command must not:
+
+- Modify bootloader entries.
+- Disable Phase1 auto-launch.
+- Delete state.
+- Mount writable system targets.
+- Enable host trust.
+- Hide recovery failures.
+- Claim recovery is validated before hardware tests exist.
+
+## Example output
+
+```text
+base1 recovery status
+boot target : phase1
+auto-launch : enabled
+shell       : emergency fallback available
+state       : /state/phase1 preview only
+rollback    : metadata preview only
+writes      : no
+status      : recovery check complete
+```
+
+## Promotion gate
+
+The recovery command can only gain mutating behavior after:
+
+1. Dry-run status exists.
+2. Dry-run plan exists.
+3. Recovery shell path is tested.
+4. Rollback metadata is tested.
+5. State export is tested.
+6. Final confirmation exists for every destructive or boot-changing action.

--- a/docs/os/ROADMAP.md
+++ b/docs/os/ROADMAP.md
@@ -125,3 +125,8 @@ Each target needs:
 4. Add the [`Base1 installer dry-run design`](BASE1_INSTALLER_DRY_RUN.md).
 5. Add system-surface command stubs behind safe defaults.
 6. Add hardware-target checklists.
+
+
+## Stage 1 recovery command design
+
+- [`Base1 recovery command design`](BASE1_RECOVERY_COMMAND.md) defines the first read-only recovery command surface for status and planning.

--- a/tests/base1_recovery_command_docs.rs
+++ b/tests/base1_recovery_command_docs.rs
@@ -1,0 +1,35 @@
+#[test]
+fn recovery_command_doc_exists_and_defines_safe_surface() {
+    let doc =
+        std::fs::read_to_string("docs/os/BASE1_RECOVERY_COMMAND.md").expect("recovery command doc");
+
+    assert!(doc.contains("Base1 recovery command design"), "{doc}");
+    assert!(doc.contains("base1 recovery --dry-run"), "{doc}");
+    assert!(doc.contains("base1 recovery status"), "{doc}");
+    assert!(doc.contains("base1 recovery plan"), "{doc}");
+    assert!(doc.contains("must be read-only"), "{doc}");
+    assert!(doc.contains("no recovery changes were made"), "{doc}");
+    assert!(
+        doc.contains("Modify bootloader entries") || doc.contains("modify bootloader entries"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn readme_links_recovery_command_design() {
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        readme.contains("docs/os/BASE1_RECOVERY_COMMAND.md"),
+        "{readme}"
+    );
+    assert!(readme.contains("Base1 recovery command design"), "{readme}");
+}
+
+#[test]
+fn os_roadmap_links_recovery_command_design() {
+    let roadmap = std::fs::read_to_string("docs/os/ROADMAP.md").expect("os roadmap");
+
+    assert!(roadmap.contains("BASE1_RECOVERY_COMMAND.md"), "{roadmap}");
+    assert!(roadmap.contains("recovery command design"), "{roadmap}");
+}


### PR DESCRIPTION
Adds the recovery command design slice for the Phase1 OS track.

Implements:
- Base1 recovery command design doc
- README link
- OS roadmap link
- docs tests for read-only recovery guardrails

Validation:
- cargo test -p phase1 --test base1_recovery_command_docs
- cargo test -p phase1 --test base1_installer_dry_run_docs
- cargo test -p phase1 --test base1_installer_recovery_docs
- cargo test -p phase1 --test base1_image_builder_docs
- cargo test -p phase1 --test os_replacement_track_docs

Refs #135