### PR TITLE
Document Base1 storage layout checker design

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Start here:
 - [`docs/os/INSTALLER_RECOVERY.md`](docs/os/INSTALLER_RECOVERY.md) — Base1 installer and recovery design
 - [`docs/os/BASE1_INSTALLER_DRY_RUN.md`](docs/os/BASE1_INSTALLER_DRY_RUN.md) — Base1 installer dry-run design
 - [`docs/os/BASE1_RECOVERY_COMMAND.md`](docs/os/BASE1_RECOVERY_COMMAND.md) — Base1 recovery command design
+- [`docs/os/BASE1_STORAGE_LAYOUT_CHECKER.md`](docs/os/BASE1_STORAGE_LAYOUT_CHECKER.md) — Base1 storage layout checker design
 - [`base1/README.md`](base1/README.md) — Base1 overview
 - [`base1/SECURITY_MODEL.md`](base1/SECURITY_MODEL.md) — security model and boundary
 - [`base1/HARDWARE_TARGETS.md`](base1/HARDWARE_TARGETS.md) — Raspberry Pi and X200 target matrix

--- a/docs/os/BASE1_STORAGE_LAYOUT_CHECKER.md
+++ b/docs/os/BASE1_STORAGE_LAYOUT_CHECKER.md
@@ -1,0 +1,71 @@
+# Base1 storage layout checker design
+
+The Base1 storage layout checker is the first safe storage-validation surface for the Phase1 OS track.
+
+This checkpoint is documentation-only. It defines a future read-only checker before any command is allowed to partition, format, mount, or modify disks.
+
+## Goal
+
+Provide a non-destructive storage report that shows whether a target system can support a Phase1-first Base1 layout.
+
+The checker must explain the proposed storage model, recovery path, writable state layer, and rollback expectations without changing the host.
+
+## Command shape
+
+```text
+base1 storage check --dry-run --target <disk>
+base1 storage check --target <disk>
+base1 storage plan --target <disk>
+```
+
+All initial command shapes are read-only previews.
+
+## Required report fields
+
+A storage layout check must report:
+
+- Target disk identity.
+- Disk size.
+- Existing partition summary.
+- Proposed `/boot` layout.
+- Proposed read-only `/base1` layer.
+- Proposed writable `/state/phase1` layer.
+- Proposed `/recovery` area.
+- Whether rollback metadata can be stored.
+- Whether destructive writes are disabled.
+- Whether final confirmation would be required.
+
+## Example output
+
+```text
+base1 storage layout check
+target   : /dev/example
+writes   : no
+boot     : preview only
+base1    : read-only layer preview
+state    : writable phase1 state preview
+recovery : recovery area preview
+rollback : metadata preview only
+status   : storage check complete
+```
+
+## Guardrails
+
+- Do not partition disks.
+- Do not format disks.
+- Do not mount writable filesystems.
+- Do not hide existing partitions.
+- Do not erase or overwrite data.
+- Do not imply install readiness from a dry-run report.
+- Do not proceed without explicit target disk selection.
+
+## Promotion gate
+
+The checker can only become part of an installer path after:
+
+1. Read-only reporting exists.
+2. Target disk detection is tested.
+3. Existing partitions are displayed clearly.
+4. Recovery layout is documented.
+5. Rollback metadata is documented.
+6. Final destructive-action confirmation exists.

--- a/docs/os/ROADMAP.md
+++ b/docs/os/ROADMAP.md
@@ -130,3 +130,8 @@ Each target needs:
 ## Stage 1 recovery command design
 
 - [`Base1 recovery command design`](BASE1_RECOVERY_COMMAND.md) defines the first read-only recovery command surface for status and planning.
+
+
+## Stage 2 storage layout checker design
+
+- [`Base1 storage layout checker design`](BASE1_STORAGE_LAYOUT_CHECKER.md) defines the first read-only disk-layout validation surface for Base1 installer planning.

--- a/tests/base1_storage_layout_checker_docs.rs
+++ b/tests/base1_storage_layout_checker_docs.rs
@@ -1,0 +1,44 @@
+#[test]
+fn storage_layout_checker_doc_exists_and_defines_read_only_surface() {
+    let doc = std::fs::read_to_string("docs/os/BASE1_STORAGE_LAYOUT_CHECKER.md")
+        .expect("storage layout checker doc");
+
+    assert!(doc.contains("Base1 storage layout checker design"), "{doc}");
+    assert!(doc.contains("documentation-only"), "{doc}");
+    assert!(
+        doc.contains("base1 storage check --dry-run --target <disk>"),
+        "{doc}"
+    );
+    assert!(doc.contains("read-only previews"), "{doc}");
+    assert!(doc.contains("Do not partition disks"), "{doc}");
+    assert!(doc.contains("Do not format disks"), "{doc}");
+    assert!(doc.contains("rollback metadata"), "{doc}");
+}
+
+#[test]
+fn readme_links_storage_layout_checker_design() {
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        readme.contains("docs/os/BASE1_STORAGE_LAYOUT_CHECKER.md"),
+        "{readme}"
+    );
+    assert!(
+        readme.contains("Base1 storage layout checker design"),
+        "{readme}"
+    );
+}
+
+#[test]
+fn os_roadmap_links_storage_layout_checker_design() {
+    let roadmap = std::fs::read_to_string("docs/os/ROADMAP.md").expect("os roadmap");
+
+    assert!(
+        roadmap.contains("BASE1_STORAGE_LAYOUT_CHECKER.md"),
+        "{roadmap}"
+    );
+    assert!(
+        roadmap.contains("storage layout checker design"),
+        "{roadmap}"
+    );
+}


### PR DESCRIPTION
Adds the storage layout checker design slice for the Phase1 OS track.

Implements:
- Base1 storage layout checker design doc
- README link
- OS roadmap link
- docs tests for read-only storage guardrails

Validation:
- cargo test -p phase1 --test base1_storage_layout_checker_docs
- cargo test -p phase1 --test base1_recovery_command_docs
- cargo test -p phase1 --test base1_installer_dry_run_docs
- cargo test -p phase1 --test base1_installer_recovery_docs
- cargo test -p phase1 --test os_replacement_track_docs

Refs #135