### PR TITLE
Document Base1 rollback metadata design

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Start here:
 - [`docs/os/BASE1_INSTALLER_DRY_RUN.md`](docs/os/BASE1_INSTALLER_DRY_RUN.md) — Base1 installer dry-run design
 - [`docs/os/BASE1_RECOVERY_COMMAND.md`](docs/os/BASE1_RECOVERY_COMMAND.md) — Base1 recovery command design
 - [`docs/os/BASE1_STORAGE_LAYOUT_CHECKER.md`](docs/os/BASE1_STORAGE_LAYOUT_CHECKER.md) — Base1 storage layout checker design
+- [`docs/os/BASE1_ROLLBACK_METADATA.md`](docs/os/BASE1_ROLLBACK_METADATA.md) — Base1 rollback metadata design
 - [`base1/README.md`](base1/README.md) — Base1 overview
 - [`base1/SECURITY_MODEL.md`](base1/SECURITY_MODEL.md) — security model and boundary
 - [`base1/HARDWARE_TARGETS.md`](base1/HARDWARE_TARGETS.md) — Raspberry Pi and X200 target matrix

--- a/docs/os/BASE1_ROLLBACK_METADATA.md
+++ b/docs/os/BASE1_ROLLBACK_METADATA.md
@@ -1,0 +1,64 @@
+# Base1 rollback metadata design
+
+The Base1 rollback metadata design defines the safe record format for restoring a Phase1-first Base1 system after an update, install preview, or recovery event.
+
+This checkpoint is documentation-only. It does not add mutating installer behavior.
+
+## Goal
+
+Provide a conservative metadata contract that lets Base1 describe what changed, what can be restored, and what recovery path exists without hiding risks or weakening the host boundary.
+
+## Metadata scope
+
+Rollback metadata should describe:
+
+- Base1 version.
+- Phase1 version.
+- Boot target before the change.
+- Boot target after the change.
+- State directory path.
+- Recovery directory path.
+- Timestamp.
+- Hardware target summary.
+- Validation status.
+- Operator confirmation status.
+- Whether destructive writes occurred.
+
+## Example metadata
+
+```text
+base1 rollback metadata
+base1_version      : foundation
+phase1_version     : v5.0.0
+stable_version     : v4.4.0
+previous_stable    : v4.3.0
+boot_before        : host default
+boot_after         : phase1
+state_path         : /state/phase1
+recovery_path      : /recovery
+writes             : no
+operator_confirmed : no
+status             : preview only
+```
+
+## Guardrails
+
+- Do not store secrets.
+- Do not store credentials.
+- Do not store private keys.
+- Do not imply rollback was tested unless it was actually tested.
+- Do not overwrite rollback metadata silently.
+- Do not allow rollback metadata to replace a recovery shell.
+- Do not mark destructive writes as safe by default.
+
+## Promotion gate
+
+Rollback metadata can only become part of an installer or updater after:
+
+1. Preview metadata exists.
+2. Secret redaction is tested.
+3. Metadata write location is explicit.
+4. Recovery shell path is tested.
+5. State export path is tested.
+6. Restore instructions are documented.
+7. Final confirmation exists for destructive actions.

--- a/docs/os/ROADMAP.md
+++ b/docs/os/ROADMAP.md
@@ -135,3 +135,8 @@ Each target needs:
 ## Stage 2 storage layout checker design
 
 - [`Base1 storage layout checker design`](BASE1_STORAGE_LAYOUT_CHECKER.md) defines the first read-only disk-layout validation surface for Base1 installer planning.
+
+
+## Stage 2 rollback metadata design
+
+- [`Base1 rollback metadata design`](BASE1_ROLLBACK_METADATA.md) defines the first safe restore-record contract for Base1 installer, update, and recovery planning.

--- a/tests/base1_rollback_metadata_docs.rs
+++ b/tests/base1_rollback_metadata_docs.rs
@@ -1,0 +1,39 @@
+#[test]
+fn rollback_metadata_doc_exists_and_defines_safe_contract() {
+    let doc = std::fs::read_to_string("docs/os/BASE1_ROLLBACK_METADATA.md")
+        .expect("rollback metadata doc");
+
+    assert!(doc.contains("Base1 rollback metadata design"), "{doc}");
+    assert!(doc.contains("documentation-only"), "{doc}");
+    assert!(doc.contains("base1 rollback metadata"), "{doc}");
+    assert!(doc.contains("phase1_version"), "{doc}");
+    assert!(doc.contains("stable_version"), "{doc}");
+    assert!(doc.contains("Do not store secrets"), "{doc}");
+    assert!(doc.contains("Do not store credentials"), "{doc}");
+    assert!(
+        doc.contains("Do not imply rollback was tested unless it was actually tested"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn readme_links_rollback_metadata_design() {
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        readme.contains("docs/os/BASE1_ROLLBACK_METADATA.md"),
+        "{readme}"
+    );
+    assert!(
+        readme.contains("Base1 rollback metadata design"),
+        "{readme}"
+    );
+}
+
+#[test]
+fn os_roadmap_links_rollback_metadata_design() {
+    let roadmap = std::fs::read_to_string("docs/os/ROADMAP.md").expect("os roadmap");
+
+    assert!(roadmap.contains("BASE1_ROLLBACK_METADATA.md"), "{roadmap}");
+    assert!(roadmap.contains("rollback metadata design"), "{roadmap}");
+}


### PR DESCRIPTION
Adds the rollback metadata design slice for the Phase1 OS track.

Implements:
- Base1 rollback metadata design doc
- README link
- OS roadmap link
- docs tests for rollback metadata guardrails

Validation:
- cargo test -p phase1 --test base1_rollback_metadata_docs
- cargo test -p phase1 --test base1_storage_layout_checker_docs
- cargo test -p phase1 --test base1_recovery_command_docs
- cargo test -p phase1 --test base1_installer_dry_run_docs
- cargo test -p phase1 --test os_replacement_track_docs

Refs #135