### PR TITLE
Add Base1 installer dry-run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ First safe check:
 
 ```bash
 sh scripts/base1-preflight.sh
+sh scripts/base1-install-dry-run.sh --dry-run --target /dev/example
 ```
 
 The preflight checker is read-only.

--- a/docs/os/ROADMAP.md
+++ b/docs/os/ROADMAP.md
@@ -140,3 +140,8 @@ Each target needs:
 ## Stage 2 rollback metadata design
 
 - [`Base1 rollback metadata design`](BASE1_ROLLBACK_METADATA.md) defines the first safe restore-record contract for Base1 installer, update, and recovery planning.
+
+
+## Stage 2 installer dry-run script
+
+- `scripts/base1-install-dry-run.sh` is the first non-destructive installer preview command. It requires `--dry-run`, requires an explicit target, and reports `writes: no`.

--- a/scripts/base1-install-dry-run.sh
+++ b/scripts/base1-install-dry-run.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 installer dry-run
+
+usage:
+  sh scripts/base1-install-dry-run.sh --dry-run --target <disk>
+
+This command is preview-only. It does not partition, format, mount, install
+bootloaders, or change host trust.
+EOF
+}
+
+dry_run=0
+target=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --target)
+      if [ "$#" -lt 2 ]; then
+        echo "error: --target requires a value" >&2
+        exit 2
+      fi
+      target="$2"
+      shift 2
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      show_help >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$dry_run" -ne 1 ]; then
+  echo "refusing: --dry-run is required" >&2
+  exit 2
+fi
+
+if [ -z "$target" ]; then
+  echo "error: --target <disk> is required" >&2
+  exit 2
+fi
+
+case "$target" in
+  /dev/*|/dev/disk/*)
+    ;;
+  *)
+    echo "error: target must look like a device path under /dev" >&2
+    exit 2
+    ;;
+esac
+
+cat <<EOF
+base1 installer dry-run
+target   : $target
+writes   : no
+hardware : preflight preview only
+boot     : preview only
+base1    : read-only layer preview
+state    : writable phase1 state preview
+recovery : emergency shell preview
+rollback : metadata preview only
+trust    : no host trust escalation
+status   : dry-run complete
+EOF

--- a/tests/base1_installer_dry_run_script.rs
+++ b/tests/base1_installer_dry_run_script.rs
@@ -1,0 +1,85 @@
+use std::process::Command;
+
+fn run_script(args: &[&str]) -> (bool, String) {
+    let output = Command::new("sh")
+        .arg("scripts/base1-install-dry-run.sh")
+        .args(args)
+        .output()
+        .expect("run base1 installer dry-run script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    (output.status.success(), text)
+}
+
+#[test]
+fn installer_dry_run_refuses_without_dry_run_flag() {
+    let (ok, text) = run_script(&["--target", "/dev/example"]);
+
+    assert!(!ok, "{text}");
+    assert!(text.contains("refusing: --dry-run is required"), "{text}");
+}
+
+#[test]
+fn installer_dry_run_requires_target() {
+    let (ok, text) = run_script(&["--dry-run"]);
+
+    assert!(!ok, "{text}");
+    assert!(text.contains("--target <disk> is required"), "{text}");
+}
+
+#[test]
+fn installer_dry_run_reports_preview_without_writes() {
+    let (ok, text) = run_script(&["--dry-run", "--target", "/dev/example"]);
+
+    assert!(ok, "{text}");
+    assert!(text.contains("base1 installer dry-run"), "{text}");
+    assert!(text.contains("target   : /dev/example"), "{text}");
+    assert!(text.contains("writes   : no"), "{text}");
+    assert!(text.contains("boot     : preview only"), "{text}");
+    assert!(
+        text.contains("base1    : read-only layer preview"),
+        "{text}"
+    );
+    assert!(
+        text.contains("state    : writable phase1 state preview"),
+        "{text}"
+    );
+    assert!(
+        text.contains("recovery : emergency shell preview"),
+        "{text}"
+    );
+    assert!(text.contains("rollback : metadata preview only"), "{text}");
+    assert!(
+        text.contains("trust    : no host trust escalation"),
+        "{text}"
+    );
+}
+
+#[test]
+fn installer_dry_run_script_avoids_destructive_tools() {
+    let script =
+        std::fs::read_to_string("scripts/base1-install-dry-run.sh").expect("base1 dry-run script");
+
+    let forbidden = [
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "grub-install",
+        "bootctl install",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds the first non-destructive Base1 installer dry-run script for the Phase1 OS track.

Implements:
- scripts/base1-install-dry-run.sh
- --dry-run enforcement
- explicit --target requirement
- preview-only installer report
- destructive-tool guard test
- README and OS roadmap links

Validation:
- cargo test -p phase1 --test base1_installer_dry_run_script
- cargo test -p phase1 --test base1_installer_dry_run_docs
- cargo test -p phase1 --test base1_rollback_metadata_docs
- cargo test -p phase1 --test base1_storage_layout_checker_docs
- cargo test -p phase1 --test os_replacement_track_docs

Refs #135