### PR TITLE
Add Base1 storage layout dry-run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ First safe check:
 sh scripts/base1-preflight.sh
 sh scripts/base1-install-dry-run.sh --dry-run --target /dev/example
 sh scripts/base1-recovery-dry-run.sh --dry-run
+sh scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example
 ```
 
 The preflight checker is read-only.

--- a/docs/os/ROADMAP.md
+++ b/docs/os/ROADMAP.md
@@ -150,3 +150,8 @@ Each target needs:
 ## Stage 2 recovery dry-run script
 
 - `scripts/base1-recovery-dry-run.sh` is the first non-destructive recovery preview command. It requires `--dry-run`, keeps boot settings unchanged, and reports `writes: no`.
+
+
+## Stage 2 storage layout dry-run script
+
+- `scripts/base1-storage-layout-dry-run.sh` is the first non-destructive storage layout preview command. It requires `--dry-run`, requires an explicit target, and reports `writes: no`.

--- a/scripts/base1-storage-layout-dry-run.sh
+++ b/scripts/base1-storage-layout-dry-run.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 storage layout dry-run
+
+usage:
+  sh scripts/base1-storage-layout-dry-run.sh --dry-run --target <disk>
+
+This command is preview-only. It does not partition, format, attach writable
+filesystems, erase data, install bootloaders, or change host trust.
+EOF
+}
+
+dry_run=0
+target=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --target)
+      if [ "$#" -lt 2 ]; then
+        echo "error: --target requires a value" >&2
+        exit 2
+      fi
+      target="$2"
+      shift 2
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      show_help >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$dry_run" -ne 1 ]; then
+  echo "refusing: --dry-run is required" >&2
+  exit 2
+fi
+
+if [ -z "$target" ]; then
+  echo "error: --target <disk> is required" >&2
+  exit 2
+fi
+
+case "$target" in
+  /dev/*|/dev/disk/*)
+    ;;
+  *)
+    echo "error: target must look like a device path under /dev" >&2
+    exit 2
+    ;;
+esac
+
+cat <<EOF
+base1 storage layout dry-run
+target   : $target
+writes   : no
+disk     : identity preview only
+boot     : /boot preview only
+base1    : read-only layer preview
+state    : /state/phase1 writable layer preview
+recovery : /recovery area preview
+rollback : metadata location preview only
+trust    : no host trust escalation
+status   : storage layout dry-run complete
+EOF

--- a/tests/base1_storage_layout_dry_run_script.rs
+++ b/tests/base1_storage_layout_dry_run_script.rs
@@ -1,0 +1,86 @@
+use std::process::Command;
+
+fn run_script(args: &[&str]) -> (bool, String) {
+    let output = Command::new("sh")
+        .arg("scripts/base1-storage-layout-dry-run.sh")
+        .args(args)
+        .output()
+        .expect("run base1 storage layout dry-run script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    (output.status.success(), text)
+}
+
+#[test]
+fn storage_layout_dry_run_refuses_without_dry_run_flag() {
+    let (ok, text) = run_script(&["--target", "/dev/example"]);
+
+    assert!(!ok, "{text}");
+    assert!(text.contains("refusing: --dry-run is required"), "{text}");
+}
+
+#[test]
+fn storage_layout_dry_run_requires_target() {
+    let (ok, text) = run_script(&["--dry-run"]);
+
+    assert!(!ok, "{text}");
+    assert!(text.contains("--target <disk> is required"), "{text}");
+}
+
+#[test]
+fn storage_layout_dry_run_reports_preview_without_writes() {
+    let (ok, text) = run_script(&["--dry-run", "--target", "/dev/example"]);
+
+    assert!(ok, "{text}");
+    assert!(text.contains("base1 storage layout dry-run"), "{text}");
+    assert!(text.contains("target   : /dev/example"), "{text}");
+    assert!(text.contains("writes   : no"), "{text}");
+    assert!(text.contains("boot     : /boot preview only"), "{text}");
+    assert!(
+        text.contains("base1    : read-only layer preview"),
+        "{text}"
+    );
+    assert!(
+        text.contains("state    : /state/phase1 writable layer preview"),
+        "{text}"
+    );
+    assert!(text.contains("recovery : /recovery area preview"), "{text}");
+    assert!(
+        text.contains("rollback : metadata location preview only"),
+        "{text}"
+    );
+    assert!(
+        text.contains("trust    : no host trust escalation"),
+        "{text}"
+    );
+}
+
+#[test]
+fn storage_layout_dry_run_script_avoids_destructive_tools() {
+    let script = std::fs::read_to_string("scripts/base1-storage-layout-dry-run.sh")
+        .expect("base1 storage layout dry-run script");
+
+    let forbidden = [
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "grub-install",
+        "bootctl install",
+        "rm -rf",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds the first non-destructive Base1 storage layout dry-run script for the Phase1 OS track.

Implements:
- scripts/base1-storage-layout-dry-run.sh
- --dry-run enforcement
- explicit --target requirement
- storage layout preview report
- destructive-tool guard test
- README and OS roadmap links

Validation:
- cargo test -p phase1 --test base1_storage_layout_dry_run_script
- cargo test -p phase1 --test base1_storage_layout_checker_docs
- cargo test -p phase1 --test base1_recovery_dry_run_script
- cargo test -p phase1 --test base1_installer_dry_run_script
- cargo test -p phase1 --test os_replacement_track_docs

Refs #135