### PR TITLE
Add Base1 rollback metadata dry-run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ sh scripts/base1-preflight.sh
 sh scripts/base1-install-dry-run.sh --dry-run --target /dev/example
 sh scripts/base1-recovery-dry-run.sh --dry-run
 sh scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-rollback-metadata-dry-run.sh --dry-run
 ```
 
 The preflight checker is read-only.

--- a/docs/os/ROADMAP.md
+++ b/docs/os/ROADMAP.md
@@ -155,3 +155,8 @@ Each target needs:
 ## Stage 2 storage layout dry-run script
 
 - `scripts/base1-storage-layout-dry-run.sh` is the first non-destructive storage layout preview command. It requires `--dry-run`, requires an explicit target, and reports `writes: no`.
+
+
+## Stage 2 rollback metadata dry-run script
+
+- `scripts/base1-rollback-metadata-dry-run.sh` is the first non-destructive rollback metadata preview command. It requires `--dry-run`, stores no secrets, writes nothing, and reports `operator_confirmed: no`.

--- a/scripts/base1-rollback-metadata-dry-run.sh
+++ b/scripts/base1-rollback-metadata-dry-run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 rollback metadata dry-run
+
+usage:
+  sh scripts/base1-rollback-metadata-dry-run.sh --dry-run
+  sh scripts/base1-rollback-metadata-dry-run.sh --dry-run --target <disk>
+
+This command is preview-only. It does not write rollback files, change boot
+settings, export data, attach writable filesystems, or modify host trust.
+EOF
+}
+
+dry_run=0
+target="host-default"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --target)
+      if [ "$#" -lt 2 ]; then
+        echo "error: --target requires a value" >&2
+        exit 2
+      fi
+      target="$2"
+      shift 2
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      show_help >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$dry_run" -ne 1 ]; then
+  echo "refusing: --dry-run is required" >&2
+  exit 2
+fi
+
+cat <<EOF
+base1 rollback metadata dry-run
+target             : $target
+writes             : no
+base1_version      : foundation preview
+phase1_version     : v5.0.0 preview
+stable_version     : v4.4.0 preview
+previous_stable    : v4.3.0 preview
+boot_before        : host default preview
+boot_after         : phase1 preview
+state_path         : /state/phase1 preview
+recovery_path      : /recovery preview
+operator_confirmed : no
+trust              : no host trust escalation
+status             : rollback metadata dry-run complete
+EOF

--- a/tests/base1_rollback_metadata_dry_run_script.rs
+++ b/tests/base1_rollback_metadata_dry_run_script.rs
@@ -1,0 +1,91 @@
+use std::process::Command;
+
+fn run_script(args: &[&str]) -> (bool, String) {
+    let output = Command::new("sh")
+        .arg("scripts/base1-rollback-metadata-dry-run.sh")
+        .args(args)
+        .output()
+        .expect("run base1 rollback metadata dry-run script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    (output.status.success(), text)
+}
+
+#[test]
+fn rollback_metadata_dry_run_refuses_without_dry_run_flag() {
+    let (ok, text) = run_script(&[]);
+
+    assert!(!ok, "{text}");
+    assert!(text.contains("refusing: --dry-run is required"), "{text}");
+}
+
+#[test]
+fn rollback_metadata_dry_run_reports_preview_without_writes() {
+    let (ok, text) = run_script(&["--dry-run"]);
+
+    assert!(ok, "{text}");
+    assert!(text.contains("base1 rollback metadata dry-run"), "{text}");
+    assert!(text.contains("writes             : no"), "{text}");
+    assert!(
+        text.contains("base1_version      : foundation preview"),
+        "{text}"
+    );
+    assert!(
+        text.contains("phase1_version     : v5.0.0 preview"),
+        "{text}"
+    );
+    assert!(
+        text.contains("stable_version     : v4.4.0 preview"),
+        "{text}"
+    );
+    assert!(
+        text.contains("previous_stable    : v4.3.0 preview"),
+        "{text}"
+    );
+}
+
+#[test]
+fn rollback_metadata_dry_run_accepts_target_preview() {
+    let (ok, text) = run_script(&["--dry-run", "--target", "/dev/example"]);
+
+    assert!(ok, "{text}");
+    assert!(text.contains("target             : /dev/example"), "{text}");
+    assert!(text.contains("operator_confirmed : no"), "{text}");
+    assert!(
+        text.contains("trust              : no host trust escalation"),
+        "{text}"
+    );
+}
+
+#[test]
+fn rollback_metadata_dry_run_script_avoids_destructive_tools_and_secrets() {
+    let script = std::fs::read_to_string("scripts/base1-rollback-metadata-dry-run.sh")
+        .expect("base1 rollback metadata dry-run script");
+
+    let forbidden = [
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "grub-install",
+        "bootctl install",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds the first non-destructive Base1 rollback metadata dry-run script for the Phase1 OS track.

Implements:
- scripts/base1-rollback-metadata-dry-run.sh
- --dry-run enforcement
- rollback metadata preview report
- no secret storage
- destructive-tool guard test
- README and OS roadmap links

Validation:
- cargo test -p phase1 --test base1_rollback_metadata_dry_run_script
- cargo test -p phase1 --test base1_storage_layout_dry_run_script
- cargo test -p phase1 --test base1_recovery_dry_run_script
- cargo test -p phase1 --test base1_installer_dry_run_script
- cargo test -p phase1 --test os_replacement_track_docs

Refs #135