### PR TITLE
Document Base1 dry-run command index

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Start here:
 - [`docs/os/BASE1_RECOVERY_COMMAND.md`](docs/os/BASE1_RECOVERY_COMMAND.md) — Base1 recovery command design
 - [`docs/os/BASE1_STORAGE_LAYOUT_CHECKER.md`](docs/os/BASE1_STORAGE_LAYOUT_CHECKER.md) — Base1 storage layout checker design
 - [`docs/os/BASE1_ROLLBACK_METADATA.md`](docs/os/BASE1_ROLLBACK_METADATA.md) — Base1 rollback metadata design
+- [`docs/os/BASE1_DRY_RUN_COMMANDS.md`](docs/os/BASE1_DRY_RUN_COMMANDS.md) — Base1 dry-run command index
 - [`base1/README.md`](base1/README.md) — Base1 overview
 - [`base1/SECURITY_MODEL.md`](base1/SECURITY_MODEL.md) — security model and boundary
 - [`base1/HARDWARE_TARGETS.md`](base1/HARDWARE_TARGETS.md) — Raspberry Pi and X200 target matrix

--- a/docs/os/BASE1_DRY_RUN_COMMANDS.md
+++ b/docs/os/BASE1_DRY_RUN_COMMANDS.md
@@ -1,0 +1,39 @@
+# Base1 dry-run command index
+
+This index collects the current non-destructive Base1 OS-track preview commands.
+
+These commands are operator-facing safety surfaces. They are designed to preview installer, recovery, storage, and rollback behavior before any destructive Base1 action exists.
+
+## Current dry-run commands
+
+```text
+sh scripts/base1-install-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-recovery-dry-run.sh --dry-run
+sh scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-rollback-metadata-dry-run.sh --dry-run
+```
+
+## Shared contract
+
+Every Base1 dry-run command must:
+
+- Require `--dry-run`.
+- Report `writes: no`.
+- Avoid destructive disk tools.
+- Avoid host trust escalation.
+- Avoid secret or credential storage.
+- Keep recovery access visible.
+- Make target identity visible when a target is required.
+
+## Command purposes
+
+| Command | Purpose |
+| --- | --- |
+| `base1-install-dry-run.sh` | Previews installer layout, boot plan, recovery, rollback, and Phase1 state paths. |
+| `base1-recovery-dry-run.sh` | Previews emergency recovery status without changing boot settings. |
+| `base1-storage-layout-dry-run.sh` | Previews `/boot`, `/base1`, `/state/phase1`, `/recovery`, and rollback layout. |
+| `base1-rollback-metadata-dry-run.sh` | Previews rollback metadata without writing restore records or secrets. |
+
+## Promotion rule
+
+No dry-run command may become mutating until the matching design doc, script test, recovery path, rollback plan, hardware target checks, and final destructive-action confirmation are all present.

--- a/docs/os/ROADMAP.md
+++ b/docs/os/ROADMAP.md
@@ -160,3 +160,8 @@ Each target needs:
 ## Stage 2 rollback metadata dry-run script
 
 - `scripts/base1-rollback-metadata-dry-run.sh` is the first non-destructive rollback metadata preview command. It requires `--dry-run`, stores no secrets, writes nothing, and reports `operator_confirmed: no`.
+
+
+## Stage 2 dry-run command index
+
+- [`Base1 dry-run command index`](BASE1_DRY_RUN_COMMANDS.md) lists the current non-destructive Base1 preview commands and their shared guardrails.

--- a/tests/base1_dry_run_command_index_docs.rs
+++ b/tests/base1_dry_run_command_index_docs.rs
@@ -1,0 +1,40 @@
+#[test]
+fn dry_run_command_index_documents_all_current_scripts() {
+    let doc = std::fs::read_to_string("docs/os/BASE1_DRY_RUN_COMMANDS.md")
+        .expect("dry-run command index");
+
+    assert!(doc.contains("Base1 dry-run command index"), "{doc}");
+    assert!(doc.contains("scripts/base1-install-dry-run.sh"), "{doc}");
+    assert!(doc.contains("scripts/base1-recovery-dry-run.sh"), "{doc}");
+    assert!(
+        doc.contains("scripts/base1-storage-layout-dry-run.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-rollback-metadata-dry-run.sh"),
+        "{doc}"
+    );
+    assert!(doc.contains("Require `--dry-run`"), "{doc}");
+    assert!(doc.contains("Report `writes: no`"), "{doc}");
+    assert!(doc.contains("Avoid destructive disk tools"), "{doc}");
+    assert!(doc.contains("Avoid host trust escalation"), "{doc}");
+}
+
+#[test]
+fn readme_links_dry_run_command_index() {
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        readme.contains("docs/os/BASE1_DRY_RUN_COMMANDS.md"),
+        "{readme}"
+    );
+    assert!(readme.contains("Base1 dry-run command index"), "{readme}");
+}
+
+#[test]
+fn os_roadmap_links_dry_run_command_index() {
+    let roadmap = std::fs::read_to_string("docs/os/ROADMAP.md").expect("os roadmap");
+
+    assert!(roadmap.contains("BASE1_DRY_RUN_COMMANDS.md"), "{roadmap}");
+    assert!(roadmap.contains("dry-run command index"), "{roadmap}");
+}


### PR DESCRIPTION
Adds an operator-facing index for the current non-destructive Base1 dry-run command surface.

Implements:
- Base1 dry-run command index
- README link
- OS roadmap link
- docs tests for shared dry-run guardrails

Validation:
- cargo test -p phase1 --test base1_dry_run_command_index_docs
- cargo test -p phase1 --test base1_rollback_metadata_dry_run_script
- cargo test -p phase1 --test base1_storage_layout_dry_run_script
- cargo test -p phase1 --test base1_recovery_dry_run_script
- cargo test -p phase1 --test base1_installer_dry_run_script
- cargo test -p phase1 --test os_replacement_track_docs

Refs #135