### PR TITLE
Document Base1 Libreboot profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Start here:
 - [`base1/README.md`](base1/README.md) — Base1 overview
 - [`base1/SECURITY_MODEL.md`](base1/SECURITY_MODEL.md) — security model and boundary
 - [`base1/HARDWARE_TARGETS.md`](base1/HARDWARE_TARGETS.md) — Raspberry Pi and X200 target matrix
+- [`base1/LIBREBOOT_PROFILE.md`](base1/LIBREBOOT_PROFILE.md) — Libreboot profile for X200-class operator laptops
 - [`base1/PHASE1_COMPATIBILITY.md`](base1/PHASE1_COMPATIBILITY.md) — compatibility contract
 - [`base1/ROADMAP.md`](base1/ROADMAP.md) — staged roadmap
 

--- a/base1/HARDWARE_TARGETS.md
+++ b/base1/HARDWARE_TARGETS.md
@@ -69,6 +69,7 @@ optional recovery image
 ### Security goals
 
 - Support firmware-aware documentation for libreboot or coreboot-friendly use cases.
+- Use the dedicated [Libreboot profile](LIBREBOOT_PROFILE.md) for Libreboot-backed X200-class systems.
 - Keep Phase1 isolated from host package, boot, and recovery controls.
 - Prefer minimal desktop or terminal-only install.
 - Prefer storage encryption where practical.

--- a/base1/LIBREBOOT_PROFILE.md
+++ b/base1/LIBREBOOT_PROFILE.md
@@ -1,0 +1,73 @@
+# Base1 Libreboot profile
+
+The Base1 Libreboot profile documents the firmware-aware path for running Phase1 on Libreboot-backed hardware.
+
+This profile is documentation-only. It does not change firmware, boot settings, partitions, recovery media, or host trust.
+
+## Goal
+
+Support Libreboot-backed operator laptops as a first-class Base1 target profile without assuming proprietary firmware tools or hidden host authority.
+
+## Intended target
+
+The first Libreboot-friendly target is the ThinkPad X200-class operator laptop profile.
+
+The profile should prioritize:
+
+- Terminal-first operation.
+- Keyboard-only recovery.
+- Offline-first installation notes.
+- Conservative display and color output.
+- Explicit recovery media.
+- No hidden boot changes.
+- No host trust escalation from Phase1.
+
+## Firmware boundary
+
+Phase1 and Base1 must not silently modify firmware state.
+
+Libreboot-specific guidance should be treated as operator documentation, not automatic mutation.
+
+## Compatibility assumptions
+
+A Libreboot Base1 profile should avoid assuming:
+
+- Vendor firmware management tools.
+- Proprietary firmware update paths.
+- Secure Boot availability.
+- TPM availability.
+- Modern graphical firmware setup screens.
+- Network boot availability.
+- Automatic bootloader repair.
+
+## Required operator notes
+
+The profile should document:
+
+- Current firmware profile: Libreboot.
+- Boot media path.
+- Emergency shell path.
+- Recovery USB path.
+- Disk encryption status.
+- Wireless firmware limitations.
+- Clock drift risk.
+- Display/color fallback.
+- Keyboard-only recovery steps.
+
+## Guardrails
+
+- Do not flash firmware.
+- Do not change boot order automatically.
+- Do not install bootloaders automatically.
+- Do not assume Secure Boot.
+- Do not assume TPM.
+- Do not remove emergency shell access.
+- Do not hide host and Phase1 authority boundaries.
+
+## First validation command
+
+```bash
+sh scripts/base1-preflight.sh
+```
+
+Future Libreboot-aware validation may add read-only firmware notes, but firmware mutation remains explicit operator work.

--- a/base1/LIBREBOOT_PROFILE.md
+++ b/base1/LIBREBOOT_PROFILE.md
@@ -39,6 +39,13 @@ A Libreboot Base1 profile should avoid assuming:
 - Modern graphical firmware setup screens.
 - Network boot availability.
 - Automatic bootloader repair.
+- Non-GRUB boot compatibility.
+
+## Bootloader expectation
+
+For this profile, treat GRUB as the first expected bootloader path unless a specific Libreboot-backed machine has been verified with another boot path.
+
+Base1 should not assume systemd-boot, EFI-only boot, or automatic bootloader repair for Libreboot-backed X200-class systems.
 
 ## Required operator notes
 

--- a/tests/base1_libreboot_profile_docs.rs
+++ b/tests/base1_libreboot_profile_docs.rs
@@ -1,0 +1,33 @@
+#[test]
+fn libreboot_profile_doc_exists_and_defines_boundary() {
+    let doc = std::fs::read_to_string("base1/LIBREBOOT_PROFILE.md").expect("libreboot profile doc");
+
+    assert!(doc.contains("Base1 Libreboot profile"), "{doc}");
+    assert!(doc.contains("documentation-only"), "{doc}");
+    assert!(doc.contains("ThinkPad X200-class"), "{doc}");
+    assert!(doc.contains("Do not flash firmware"), "{doc}");
+    assert!(
+        doc.contains("Do not change boot order automatically"),
+        "{doc}"
+    );
+    assert!(doc.contains("Do not assume Secure Boot"), "{doc}");
+    assert!(doc.contains("Do not assume TPM"), "{doc}");
+    assert!(doc.contains("sh scripts/base1-preflight.sh"), "{doc}");
+}
+
+#[test]
+fn hardware_targets_link_libreboot_profile() {
+    let targets =
+        std::fs::read_to_string("base1/HARDWARE_TARGETS.md").expect("hardware targets doc");
+
+    assert!(targets.contains("LIBREBOOT_PROFILE.md"), "{targets}");
+    assert!(targets.contains("Libreboot profile"), "{targets}");
+}
+
+#[test]
+fn readme_links_libreboot_profile() {
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(readme.contains("base1/LIBREBOOT_PROFILE.md"), "{readme}");
+    assert!(readme.contains("Libreboot profile"), "{readme}");
+}

--- a/tests/base1_libreboot_profile_docs.rs
+++ b/tests/base1_libreboot_profile_docs.rs
@@ -12,6 +12,12 @@ fn libreboot_profile_doc_exists_and_defines_boundary() {
     );
     assert!(doc.contains("Do not assume Secure Boot"), "{doc}");
     assert!(doc.contains("Do not assume TPM"), "{doc}");
+    assert!(
+        doc.contains("GRUB as the first expected bootloader path"),
+        "{doc}"
+    );
+    assert!(doc.contains("systemd-boot"), "{doc}");
+    assert!(doc.contains("EFI-only boot"), "{doc}");
     assert!(doc.contains("sh scripts/base1-preflight.sh"), "{doc}");
 }
 


### PR DESCRIPTION
Adds a Libreboot-aware Base1 hardware profile for X200-class operator systems.

Implements:
- Base1 Libreboot profile doc
- Hardware target link
- README link
- Docs tests for firmware-boundary guardrails

Validation:
- cargo test -p phase1 --test base1_libreboot_profile_docs
- cargo test -p phase1 --test base1_foundation
- cargo test -p phase1 --test os_replacement_track_docs

Refs #135