### PR TITLE
Document Base1 Libreboot preflight notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Start here:
 - [`base1/SECURITY_MODEL.md`](base1/SECURITY_MODEL.md) — security model and boundary
 - [`base1/HARDWARE_TARGETS.md`](base1/HARDWARE_TARGETS.md) — Raspberry Pi and X200 target matrix
 - [`base1/LIBREBOOT_PROFILE.md`](base1/LIBREBOOT_PROFILE.md) — Libreboot profile for X200-class operator laptops
+- [`base1/LIBREBOOT_PREFLIGHT.md`](base1/LIBREBOOT_PREFLIGHT.md) — Libreboot preflight notes for GRUB-first systems
 - [`base1/PHASE1_COMPATIBILITY.md`](base1/PHASE1_COMPATIBILITY.md) — compatibility contract
 - [`base1/ROADMAP.md`](base1/ROADMAP.md) — staged roadmap
 

--- a/base1/LIBREBOOT_PREFLIGHT.md
+++ b/base1/LIBREBOOT_PREFLIGHT.md
@@ -1,0 +1,54 @@
+# Base1 Libreboot preflight notes
+
+The Base1 Libreboot preflight notes define read-only checks for Libreboot-backed Phase1 operator systems.
+
+This document is advisory. It does not flash firmware, change boot order, install bootloaders, or modify disks.
+
+## Goal
+
+Give operators a clear checklist for confirming that a Libreboot-backed X200-class system can safely run the Base1 path.
+
+## Read-only checks
+
+A Libreboot preflight should report:
+
+- Firmware profile: Libreboot expected.
+- Hardware target: X200-class expected.
+- Bootloader expectation: GRUB first.
+- Secure Boot assumption: not required.
+- TPM assumption: not required.
+- Emergency shell path: required.
+- Recovery USB path: recommended.
+- Offline install path: recommended.
+- Disk encryption status: operator-confirmed.
+- Wireless firmware status: operator-confirmed.
+
+## GRUB expectation
+
+For Libreboot-backed X200-class systems, Base1 should treat GRUB as the first bootloader path until another boot path has been verified on that exact machine.
+
+The preflight should not assume:
+
+- systemd-boot.
+- EFI-only boot.
+- Secure Boot.
+- TPM-backed unlock.
+- Automatic bootloader repair.
+
+## Guardrails
+
+- Do not flash firmware.
+- Do not change boot order.
+- Do not install GRUB automatically.
+- Do not write to /boot.
+- Do not write to disk.
+- Do not weaken recovery access.
+- Do not hide firmware or boot uncertainty.
+
+## First command
+
+```bash
+sh scripts/base1-preflight.sh
+```
+
+Future script support should remain read-only and should print notes instead of mutating firmware or boot settings.

--- a/base1/LIBREBOOT_PROFILE.md
+++ b/base1/LIBREBOOT_PROFILE.md
@@ -71,6 +71,8 @@ The profile should document:
 - Do not remove emergency shell access.
 - Do not hide host and Phase1 authority boundaries.
 
+See also: [Libreboot preflight notes](LIBREBOOT_PREFLIGHT.md).
+
 ## First validation command
 
 ```bash

--- a/tests/base1_libreboot_preflight_docs.rs
+++ b/tests/base1_libreboot_preflight_docs.rs
@@ -1,0 +1,34 @@
+#[test]
+fn libreboot_preflight_doc_exists_and_defines_read_only_checks() {
+    let doc =
+        std::fs::read_to_string("base1/LIBREBOOT_PREFLIGHT.md").expect("libreboot preflight doc");
+
+    assert!(doc.contains("Base1 Libreboot preflight notes"), "{doc}");
+    assert!(doc.contains("read-only checks"), "{doc}");
+    assert!(
+        doc.contains("Firmware profile: Libreboot expected"),
+        "{doc}"
+    );
+    assert!(doc.contains("Bootloader expectation: GRUB first"), "{doc}");
+    assert!(doc.contains("Do not flash firmware"), "{doc}");
+    assert!(doc.contains("Do not install GRUB automatically"), "{doc}");
+    assert!(doc.contains("Do not write to /boot"), "{doc}");
+    assert!(doc.contains("sh scripts/base1-preflight.sh"), "{doc}");
+}
+
+#[test]
+fn libreboot_profile_links_preflight_notes() {
+    let profile =
+        std::fs::read_to_string("base1/LIBREBOOT_PROFILE.md").expect("libreboot profile doc");
+
+    assert!(profile.contains("LIBREBOOT_PREFLIGHT.md"), "{profile}");
+    assert!(profile.contains("Libreboot preflight notes"), "{profile}");
+}
+
+#[test]
+fn readme_links_libreboot_preflight_notes() {
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(readme.contains("base1/LIBREBOOT_PREFLIGHT.md"), "{readme}");
+    assert!(readme.contains("Libreboot preflight notes"), "{readme}");
+}


### PR DESCRIPTION
Adds Libreboot preflight notes for GRUB-first X200-class Base1 systems.

Implements:
- Libreboot preflight notes
- GRUB-first bootloader expectation
- README link
- Libreboot profile link
- Docs tests for read-only firmware and boot guardrails

Validation:
- cargo test -p phase1 --test base1_libreboot_preflight_docs
- cargo test -p phase1 --test base1_libreboot_profile_docs
- cargo test -p phase1 --test base1_foundation
- cargo test -p phase1 --test os_replacement_track_docs

Refs #135