### PR TITLE
Add Base1 Libreboot preflight script

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ First safe check:
 
 ```bash
 sh scripts/base1-preflight.sh
+sh scripts/base1-libreboot-preflight.sh
 sh scripts/base1-install-dry-run.sh --dry-run --target /dev/example
 sh scripts/base1-recovery-dry-run.sh --dry-run
 sh scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example

--- a/base1/LIBREBOOT_PREFLIGHT.md
+++ b/base1/LIBREBOOT_PREFLIGHT.md
@@ -49,6 +49,7 @@ The preflight should not assume:
 
 ```bash
 sh scripts/base1-preflight.sh
+sh scripts/base1-libreboot-preflight.sh
 ```
 
 Future script support should remain read-only and should print notes instead of mutating firmware or boot settings.

--- a/base1/LIBREBOOT_PROFILE.md
+++ b/base1/LIBREBOOT_PROFILE.md
@@ -77,6 +77,7 @@ See also: [Libreboot preflight notes](LIBREBOOT_PREFLIGHT.md).
 
 ```bash
 sh scripts/base1-preflight.sh
+sh scripts/base1-libreboot-preflight.sh
 ```
 
 Future Libreboot-aware validation may add read-only firmware notes, but firmware mutation remains explicit operator work.

--- a/scripts/base1-libreboot-preflight.sh
+++ b/scripts/base1-libreboot-preflight.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 Libreboot preflight
+
+usage:
+  sh scripts/base1-libreboot-preflight.sh
+
+This command is read-only. It does not flash firmware, change boot order,
+install GRUB, write to /boot, write to disk, or modify host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+cat <<'EOF'
+base1 libreboot preflight
+firmware  : Libreboot expected
+hardware  : X200-class expected
+bootloader: GRUB first
+secureboot: not required
+tpm       : not required
+recovery  : emergency shell required
+usb       : recovery USB recommended
+offline   : offline install path recommended
+writes    : no
+trust     : no host trust escalation
+status    : preflight notes complete
+EOF

--- a/tests/base1_libreboot_preflight_script.rs
+++ b/tests/base1_libreboot_preflight_script.rs
@@ -1,0 +1,71 @@
+use std::process::Command;
+
+#[test]
+fn libreboot_preflight_script_reports_read_only_grub_first_notes() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-libreboot-preflight.sh")
+        .output()
+        .expect("run libreboot preflight script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("base1 libreboot preflight"), "{text}");
+    assert!(text.contains("firmware  : Libreboot expected"), "{text}");
+    assert!(text.contains("hardware  : X200-class expected"), "{text}");
+    assert!(text.contains("bootloader: GRUB first"), "{text}");
+    assert!(text.contains("secureboot: not required"), "{text}");
+    assert!(text.contains("tpm       : not required"), "{text}");
+    assert!(text.contains("writes    : no"), "{text}");
+    assert!(
+        text.contains("trust     : no host trust escalation"),
+        "{text}"
+    );
+}
+
+#[test]
+fn libreboot_preflight_script_avoids_mutating_tools() {
+    let script = std::fs::read_to_string("scripts/base1-libreboot-preflight.sh")
+        .expect("libreboot preflight script");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}
+
+#[test]
+fn libreboot_preflight_script_help_is_read_only() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-libreboot-preflight.sh")
+        .arg("--help")
+        .output()
+        .expect("run libreboot preflight help");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("read-only"), "{text}");
+    assert!(text.contains("does not flash firmware"), "{text}");
+    assert!(text.contains("install GRUB"), "{text}");
+}


### PR DESCRIPTION
Adds a read-only Libreboot preflight script for GRUB-first X200-class Base1 systems.

Implements:
- scripts/base1-libreboot-preflight.sh
- Libreboot + X200-class preflight notes
- GRUB-first bootloader reporting
- no Secure Boot or TPM assumption
- destructive-tool guard test
- README and Libreboot doc links

Validation:
- cargo test -p phase1 --test base1_libreboot_preflight_script
- cargo test -p phase1 --test base1_libreboot_preflight_docs
- cargo test -p phase1 --test base1_libreboot_profile_docs
- cargo test -p phase1 --test base1_foundation
- cargo test -p phase1 --test os_replacement_track_docs

Refs #135