### PR TITLE
Document Base1 Libreboot GRUB recovery notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ Start here:
 - [`base1/HARDWARE_TARGETS.md`](base1/HARDWARE_TARGETS.md) — Raspberry Pi and X200 target matrix
 - [`base1/LIBREBOOT_PROFILE.md`](base1/LIBREBOOT_PROFILE.md) — Libreboot profile for X200-class operator laptops
 - [`base1/LIBREBOOT_PREFLIGHT.md`](base1/LIBREBOOT_PREFLIGHT.md) — Libreboot preflight notes for GRUB-first systems
+- [`base1/LIBREBOOT_GRUB_RECOVERY.md`](base1/LIBREBOOT_GRUB_RECOVERY.md) — Libreboot GRUB recovery notes
 - [`base1/PHASE1_COMPATIBILITY.md`](base1/PHASE1_COMPATIBILITY.md) — compatibility contract
 - [`base1/ROADMAP.md`](base1/ROADMAP.md) — staged roadmap
 

--- a/base1/LIBREBOOT_GRUB_RECOVERY.md
+++ b/base1/LIBREBOOT_GRUB_RECOVERY.md
@@ -1,0 +1,54 @@
+# Base1 Libreboot GRUB recovery notes
+
+These notes define the first recovery guidance for Libreboot-backed, GRUB-first Base1 systems.
+
+This document is advisory and read-only. It does not install GRUB, edit GRUB configuration, write to /boot, change boot order, flash firmware, or modify disks.
+
+## Goal
+
+Give operators a clear recovery path for Libreboot-backed X200-class systems where GRUB is the expected first bootloader.
+
+## Expected profile
+
+- Firmware profile: Libreboot.
+- Hardware profile: ThinkPad X200-class.
+- Bootloader path: GRUB first.
+- Recovery access: emergency shell required.
+- Recovery media: external USB recommended.
+- Secure Boot: not assumed.
+- TPM: not assumed.
+- Host trust escalation: not allowed from Phase1.
+
+## Operator recovery checklist
+
+Before treating a Libreboot system as recoverable, document:
+
+- How to reach the GRUB menu.
+- Which entry starts the normal Base1 path.
+- Which entry starts emergency recovery.
+- Where recovery USB media is stored.
+- Whether disk encryption is enabled.
+- Where Phase1 state lives.
+- Where rollback metadata lives.
+- How to reach a host shell without Phase1 auto-launch.
+- How to restore Phase1 state from backup.
+
+Do not store passwords, recovery phrases, private keys, tokens, or personal secrets in recovery notes.
+
+## Guardrails
+
+- Do not run grub-install automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not flash firmware.
+- Do not change boot order.
+- Do not assume systemd-boot.
+- Do not assume EFI-only boot.
+- Do not remove emergency shell access.
+- Do not hide boot uncertainty from the operator.
+
+## Related read-only checks
+
+    sh scripts/base1-libreboot-preflight.sh
+    sh scripts/base1-recovery-dry-run.sh --dry-run
+    sh scripts/base1-rollback-metadata-dry-run.sh --dry-run

--- a/base1/LIBREBOOT_PREFLIGHT.md
+++ b/base1/LIBREBOOT_PREFLIGHT.md
@@ -52,4 +52,6 @@ sh scripts/base1-preflight.sh
 sh scripts/base1-libreboot-preflight.sh
 ```
 
+See also: [Libreboot GRUB recovery notes](LIBREBOOT_GRUB_RECOVERY.md).
+
 Future script support should remain read-only and should print notes instead of mutating firmware or boot settings.

--- a/base1/LIBREBOOT_PROFILE.md
+++ b/base1/LIBREBOOT_PROFILE.md
@@ -73,6 +73,8 @@ The profile should document:
 
 See also: [Libreboot preflight notes](LIBREBOOT_PREFLIGHT.md).
 
+See also: [Libreboot GRUB recovery notes](LIBREBOOT_GRUB_RECOVERY.md).
+
 ## First validation command
 
 ```bash

--- a/tests/base1_libreboot_grub_recovery_docs.rs
+++ b/tests/base1_libreboot_grub_recovery_docs.rs
@@ -1,0 +1,43 @@
+#[test]
+fn libreboot_grub_recovery_notes_define_read_only_recovery_path() {
+    let doc = std::fs::read_to_string("base1/LIBREBOOT_GRUB_RECOVERY.md")
+        .expect("libreboot grub recovery notes");
+
+    assert!(doc.contains("Base1 Libreboot GRUB recovery notes"), "{doc}");
+    assert!(doc.contains("read-only"), "{doc}");
+    assert!(doc.contains("GRUB first"), "{doc}");
+    assert!(doc.contains("emergency shell required"), "{doc}");
+    assert!(doc.contains("external USB recommended"), "{doc}");
+    assert!(
+        doc.contains("Do not run grub-install automatically"),
+        "{doc}"
+    );
+    assert!(doc.contains("Do not edit grub.cfg automatically"), "{doc}");
+    assert!(doc.contains("Do not write to /boot"), "{doc}");
+    assert!(doc.contains("Do not assume systemd-boot"), "{doc}");
+    assert!(doc.contains("Do not assume EFI-only boot"), "{doc}");
+}
+
+#[test]
+fn libreboot_docs_link_grub_recovery_notes() {
+    let profile = std::fs::read_to_string("base1/LIBREBOOT_PROFILE.md").expect("libreboot profile");
+    let preflight =
+        std::fs::read_to_string("base1/LIBREBOOT_PREFLIGHT.md").expect("libreboot preflight");
+
+    assert!(profile.contains("LIBREBOOT_GRUB_RECOVERY.md"), "{profile}");
+    assert!(
+        preflight.contains("LIBREBOOT_GRUB_RECOVERY.md"),
+        "{preflight}"
+    );
+}
+
+#[test]
+fn readme_links_grub_recovery_notes() {
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        readme.contains("base1/LIBREBOOT_GRUB_RECOVERY.md"),
+        "{readme}"
+    );
+    assert!(readme.contains("Libreboot GRUB recovery notes"), "{readme}");
+}


### PR DESCRIPTION
Adds GRUB-first recovery notes for Libreboot-backed X200-class Base1 systems.

Implements:
- Libreboot GRUB recovery notes
- README link
- Libreboot profile link
- Libreboot preflight link
- Docs tests for read-only boot and recovery guardrails

Validation:
- cargo test -p phase1 --test base1_libreboot_grub_recovery_docs
- cargo test -p phase1 --test base1_libreboot_preflight_script
- cargo test -p phase1 --test base1_libreboot_preflight_docs
- cargo test -p phase1 --test base1_libreboot_profile_docs
- cargo test -p phase1 --test base1_foundation

Refs #135