### PR TITLE
Add Base1 GRUB recovery dry-run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ First safe check:
 ```bash
 sh scripts/base1-preflight.sh
 sh scripts/base1-libreboot-preflight.sh
+sh scripts/base1-grub-recovery-dry-run.sh --dry-run
 sh scripts/base1-install-dry-run.sh --dry-run --target /dev/example
 sh scripts/base1-recovery-dry-run.sh --dry-run
 sh scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example

--- a/base1/LIBREBOOT_GRUB_RECOVERY.md
+++ b/base1/LIBREBOOT_GRUB_RECOVERY.md
@@ -50,5 +50,6 @@ Do not store passwords, recovery phrases, private keys, tokens, or personal secr
 ## Related read-only checks
 
     sh scripts/base1-libreboot-preflight.sh
+    sh scripts/base1-grub-recovery-dry-run.sh --dry-run
     sh scripts/base1-recovery-dry-run.sh --dry-run
     sh scripts/base1-rollback-metadata-dry-run.sh --dry-run

--- a/scripts/base1-grub-recovery-dry-run.sh
+++ b/scripts/base1-grub-recovery-dry-run.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 GRUB recovery dry-run
+
+usage:
+  sh scripts/base1-grub-recovery-dry-run.sh --dry-run
+
+This command is read-only. It does not edit GRUB config, write to /boot,
+change boot order, install bootloader files, flash firmware, or modify disks.
+EOF
+}
+
+dry_run=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      show_help >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$dry_run" -ne 1 ]; then
+  echo "refusing: --dry-run is required" >&2
+  exit 2
+fi
+
+cat <<'EOF'
+base1 grub recovery dry-run
+firmware    : Libreboot expected
+hardware    : X200-class expected
+bootloader  : GRUB first
+writes      : no
+boot_order  : no change
+boot_config : grub.cfg preview only
+boot_path   : /boot preview only
+emergency   : shell access required
+recovery_usb: recommended
+phase1_auto : no change
+rollback    : metadata preview only
+trust       : no host trust escalation
+status      : GRUB recovery dry-run complete
+EOF
+
+cat <<'EOF'
+base1 grub recovery dry-run
+firmware    : Libreboot expected
+hardware    : X200-class expected
+bootloader  : GRUB first
+writes      : no
+boot_order  : no change
+boot_config : grub.cfg preview only
+boot_path   : /boot preview only
+emergency   : shell access required
+recovery_usb: recommended
+phase1_auto : no change
+rollback    : metadata preview only
+trust       : no host trust escalation
+status      : GRUB recovery dry-run complete
+EOF

--- a/tests/base1_grub_recovery_dry_run_script.rs
+++ b/tests/base1_grub_recovery_dry_run_script.rs
@@ -1,0 +1,92 @@
+use std::process::Command;
+
+fn run_script(args: &[&str]) -> (bool, String) {
+    let output = Command::new("sh")
+        .arg("scripts/base1-grub-recovery-dry-run.sh")
+        .args(args)
+        .output()
+        .expect("run grub recovery dry-run script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    (output.status.success(), text)
+}
+
+#[test]
+fn grub_recovery_dry_run_requires_dry_run_flag() {
+    let (ok, text) = run_script(&[]);
+
+    assert!(!ok, "{text}");
+    assert!(text.contains("refusing: --dry-run is required"), "{text}");
+}
+
+#[test]
+fn grub_recovery_dry_run_reports_read_only_recovery_plan() {
+    let (ok, text) = run_script(&["--dry-run"]);
+
+    assert!(ok, "{text}");
+    assert!(text.contains("base1 grub recovery dry-run"), "{text}");
+    assert!(text.contains("firmware    : Libreboot expected"), "{text}");
+    assert!(text.contains("hardware    : X200-class expected"), "{text}");
+    assert!(text.contains("bootloader  : GRUB first"), "{text}");
+    assert!(text.contains("writes      : no"), "{text}");
+    assert!(text.contains("boot_order  : no change"), "{text}");
+    assert!(
+        text.contains("boot_config : grub.cfg preview only"),
+        "{text}"
+    );
+    assert!(text.contains("boot_path   : /boot preview only"), "{text}");
+    assert!(
+        text.contains("emergency   : shell access required"),
+        "{text}"
+    );
+}
+
+#[test]
+fn grub_recovery_dry_run_script_avoids_mutating_tools() {
+    let script = std::fs::read_to_string("scripts/base1-grub-recovery-dry-run.sh")
+        .expect("grub recovery dry-run script");
+
+    let forbidden = [
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "flashrom",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}
+
+#[test]
+fn grub_recovery_dry_run_help_is_read_only() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-grub-recovery-dry-run.sh")
+        .arg("--help")
+        .output()
+        .expect("run grub recovery help");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("read-only"), "{text}");
+    assert!(text.contains("does not edit GRUB config"), "{text}");
+    assert!(text.contains("write to /boot"), "{text}");
+}


### PR DESCRIPTION
Adds a read-only GRUB recovery dry-run script for Libreboot-backed X200-class Base1 systems.

Implements:
- scripts/base1-grub-recovery-dry-run.sh
- --dry-run enforcement
- GRUB-first recovery preview
- no /boot or grub.cfg mutation
- destructive-tool guard test
- README and Libreboot GRUB recovery doc links

Validation:
- cargo test -p phase1 --test base1_grub_recovery_dry_run_script
- cargo test -p phase1 --test base1_libreboot_grub_recovery_docs
- cargo test -p phase1 --test base1_libreboot_preflight_script
- cargo test -p phase1 --test base1_libreboot_preflight_docs
- cargo test -p phase1 --test base1_foundation

Refs #135