### PR TITLE
Document Base1 Libreboot operator checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Start here:
 - [`base1/LIBREBOOT_PROFILE.md`](base1/LIBREBOOT_PROFILE.md) — Libreboot profile for X200-class operator laptops
 - [`base1/LIBREBOOT_PREFLIGHT.md`](base1/LIBREBOOT_PREFLIGHT.md) — Libreboot preflight notes for GRUB-first systems
 - [`base1/LIBREBOOT_GRUB_RECOVERY.md`](base1/LIBREBOOT_GRUB_RECOVERY.md) — Libreboot GRUB recovery notes
+- [`base1/LIBREBOOT_OPERATOR_CHECKLIST.md`](base1/LIBREBOOT_OPERATOR_CHECKLIST.md) — Libreboot operator checklist
 - [`base1/PHASE1_COMPATIBILITY.md`](base1/PHASE1_COMPATIBILITY.md) — compatibility contract
 - [`base1/ROADMAP.md`](base1/ROADMAP.md) — staged roadmap
 

--- a/base1/LIBREBOOT_GRUB_RECOVERY.md
+++ b/base1/LIBREBOOT_GRUB_RECOVERY.md
@@ -53,3 +53,6 @@ Do not store passwords, recovery phrases, private keys, tokens, or personal secr
     sh scripts/base1-grub-recovery-dry-run.sh --dry-run
     sh scripts/base1-recovery-dry-run.sh --dry-run
     sh scripts/base1-rollback-metadata-dry-run.sh --dry-run
+
+
+See also: [Libreboot operator checklist](LIBREBOOT_OPERATOR_CHECKLIST.md).

--- a/base1/LIBREBOOT_OPERATOR_CHECKLIST.md
+++ b/base1/LIBREBOOT_OPERATOR_CHECKLIST.md
@@ -1,0 +1,60 @@
+# Base1 Libreboot operator checklist
+
+This checklist ties together the Libreboot, GRUB, recovery USB, dry-run, and Phase1 launch readiness path for X200-class Base1 systems.
+
+This document is advisory and read-only. It does not flash firmware, change boot order, install GRUB, write to /boot, modify disks, or change host trust.
+
+## Target profile
+
+- Firmware: Libreboot.
+- Hardware: ThinkPad X200-class.
+- Bootloader: GRUB first.
+- Secure Boot: not assumed.
+- TPM: not assumed.
+- Recovery media: external USB recommended.
+- Recovery path: emergency shell required.
+- Phase1 posture: safe mode on by default.
+
+## Before install or boot-image work
+
+Confirm:
+
+- Current firmware is Libreboot.
+- GRUB menu access is understood.
+- Emergency shell access is documented.
+- Recovery USB exists or is planned.
+- Disk encryption status is known.
+- Wireless firmware limitations are known.
+- Clock drift risk is known.
+- Phase1 state path is known.
+- Rollback metadata path is known.
+
+## Required dry-runs
+
+Run these before any future destructive installer work:
+
+    sh scripts/base1-preflight.sh
+    sh scripts/base1-libreboot-preflight.sh
+    sh scripts/base1-grub-recovery-dry-run.sh --dry-run
+    sh scripts/base1-recovery-dry-run.sh --dry-run
+    sh scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example
+    sh scripts/base1-rollback-metadata-dry-run.sh --dry-run
+    sh scripts/base1-install-dry-run.sh --dry-run --target /dev/example
+
+## Guardrails
+
+- Do not flash firmware automatically.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not change boot order.
+- Do not remove emergency shell access.
+- Do not assume systemd-boot.
+- Do not assume EFI-only boot.
+- Do not assume Secure Boot.
+- Do not assume TPM.
+- Do not store passwords, tokens, private keys, recovery phrases, or personal secrets.
+
+## Ready marker
+
+A Libreboot-backed Base1 target is only ready for later install work when the operator can explain the normal boot path, recovery boot path, Phase1 launch path, rollback path, and emergency shell path without relying on hidden host mutation.

--- a/base1/LIBREBOOT_PREFLIGHT.md
+++ b/base1/LIBREBOOT_PREFLIGHT.md
@@ -55,3 +55,6 @@ sh scripts/base1-libreboot-preflight.sh
 See also: [Libreboot GRUB recovery notes](LIBREBOOT_GRUB_RECOVERY.md).
 
 Future script support should remain read-only and should print notes instead of mutating firmware or boot settings.
+
+
+See also: [Libreboot operator checklist](LIBREBOOT_OPERATOR_CHECKLIST.md).

--- a/base1/LIBREBOOT_PROFILE.md
+++ b/base1/LIBREBOOT_PROFILE.md
@@ -83,3 +83,6 @@ sh scripts/base1-libreboot-preflight.sh
 ```
 
 Future Libreboot-aware validation may add read-only firmware notes, but firmware mutation remains explicit operator work.
+
+
+See also: [Libreboot operator checklist](LIBREBOOT_OPERATOR_CHECKLIST.md).

--- a/tests/base1_libreboot_operator_checklist_docs.rs
+++ b/tests/base1_libreboot_operator_checklist_docs.rs
@@ -1,0 +1,55 @@
+#[test]
+fn libreboot_operator_checklist_defines_grub_first_readiness_path() {
+    let doc = std::fs::read_to_string("base1/LIBREBOOT_OPERATOR_CHECKLIST.md")
+        .expect("libreboot operator checklist");
+
+    assert!(doc.contains("Base1 Libreboot operator checklist"), "{doc}");
+    assert!(doc.contains("Libreboot"), "{doc}");
+    assert!(doc.contains("GRUB first"), "{doc}");
+    assert!(doc.contains("external USB recommended"), "{doc}");
+    assert!(doc.contains("emergency shell required"), "{doc}");
+    assert!(
+        doc.contains("sh scripts/base1-libreboot-preflight.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("sh scripts/base1-grub-recovery-dry-run.sh --dry-run"),
+        "{doc}"
+    );
+    assert!(doc.contains("Do not install GRUB automatically"), "{doc}");
+    assert!(doc.contains("Do not write to /boot"), "{doc}");
+    assert!(doc.contains("Do not store passwords"), "{doc}");
+}
+
+#[test]
+fn libreboot_docs_link_operator_checklist() {
+    let profile = std::fs::read_to_string("base1/LIBREBOOT_PROFILE.md").expect("libreboot profile");
+    let preflight =
+        std::fs::read_to_string("base1/LIBREBOOT_PREFLIGHT.md").expect("libreboot preflight");
+    let recovery = std::fs::read_to_string("base1/LIBREBOOT_GRUB_RECOVERY.md")
+        .expect("libreboot grub recovery");
+
+    assert!(
+        profile.contains("LIBREBOOT_OPERATOR_CHECKLIST.md"),
+        "{profile}"
+    );
+    assert!(
+        preflight.contains("LIBREBOOT_OPERATOR_CHECKLIST.md"),
+        "{preflight}"
+    );
+    assert!(
+        recovery.contains("LIBREBOOT_OPERATOR_CHECKLIST.md"),
+        "{recovery}"
+    );
+}
+
+#[test]
+fn readme_links_operator_checklist() {
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        readme.contains("base1/LIBREBOOT_OPERATOR_CHECKLIST.md"),
+        "{readme}"
+    );
+    assert!(readme.contains("Libreboot operator checklist"), "{readme}");
+}


### PR DESCRIPTION
Adds an operator checklist for Libreboot-backed GRUB-first X200-class Base1 systems.

Implements:
- Libreboot operator checklist
- GRUB-first readiness path
- Recovery USB and emergency shell checklist
- Dry-run command checklist
- README and Libreboot doc links
- Docs tests for boot and recovery guardrails

Validation:
- cargo test -p phase1 --test base1_libreboot_operator_checklist_docs
- cargo test -p phase1 --test base1_grub_recovery_dry_run_script
- cargo test -p phase1 --test base1_libreboot_grub_recovery_docs
- cargo test -p phase1 --test base1_libreboot_preflight_script
- cargo test -p phase1 --test base1_foundation

Refs #135