### PR TITLE
Add Base1 Libreboot checklist command

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ First safe check:
 ```bash
 sh scripts/base1-preflight.sh
 sh scripts/base1-libreboot-preflight.sh
+sh scripts/base1-libreboot-checklist.sh
 sh scripts/base1-grub-recovery-dry-run.sh --dry-run
 sh scripts/base1-install-dry-run.sh --dry-run --target /dev/example
 sh scripts/base1-recovery-dry-run.sh --dry-run

--- a/base1/LIBREBOOT_OPERATOR_CHECKLIST.md
+++ b/base1/LIBREBOOT_OPERATOR_CHECKLIST.md
@@ -33,6 +33,7 @@ Confirm:
 
 Run these before any future destructive installer work:
 
+    sh scripts/base1-libreboot-checklist.sh
     sh scripts/base1-preflight.sh
     sh scripts/base1-libreboot-preflight.sh
     sh scripts/base1-grub-recovery-dry-run.sh --dry-run

--- a/scripts/base1-libreboot-checklist.sh
+++ b/scripts/base1-libreboot-checklist.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 Libreboot checklist
+
+usage:
+  sh scripts/base1-libreboot-checklist.sh
+
+This command is read-only. It prints the Libreboot GRUB-first operator
+checklist and does not change firmware, boot order, /boot, disks, or host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+cat <<'EOF'
+base1 libreboot operator checklist
+firmware       : Libreboot
+hardware       : X200-class
+bootloader     : GRUB first
+secureboot     : not assumed
+tpm            : not assumed
+recovery_media : external USB recommended
+emergency      : shell access required
+phase1_posture : safe mode default
+writes         : no
+trust          : no host trust escalation
+
+required dry-runs:
+- sh scripts/base1-preflight.sh
+- sh scripts/base1-libreboot-preflight.sh
+- sh scripts/base1-grub-recovery-dry-run.sh --dry-run
+- sh scripts/base1-recovery-dry-run.sh --dry-run
+- sh scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example
+- sh scripts/base1-rollback-metadata-dry-run.sh --dry-run
+- sh scripts/base1-install-dry-run.sh --dry-run --target /dev/example
+
+ready marker:
+operator can explain normal boot, recovery boot, Phase1 launch, rollback, and emergency shell paths
+EOF

--- a/tests/base1_libreboot_checklist_script.rs
+++ b/tests/base1_libreboot_checklist_script.rs
@@ -1,0 +1,102 @@
+use std::process::Command;
+
+#[test]
+fn libreboot_checklist_script_reports_operator_summary() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-libreboot-checklist.sh")
+        .output()
+        .expect("run libreboot checklist script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("base1 libreboot operator checklist"),
+        "{text}"
+    );
+    assert!(text.contains("firmware       : Libreboot"), "{text}");
+    assert!(text.contains("hardware       : X200-class"), "{text}");
+    assert!(text.contains("bootloader     : GRUB first"), "{text}");
+    assert!(text.contains("secureboot     : not assumed"), "{text}");
+    assert!(text.contains("tpm            : not assumed"), "{text}");
+    assert!(
+        text.contains("recovery_media : external USB recommended"),
+        "{text}"
+    );
+    assert!(
+        text.contains("emergency      : shell access required"),
+        "{text}"
+    );
+    assert!(text.contains("writes         : no"), "{text}");
+}
+
+#[test]
+fn libreboot_checklist_script_lists_required_dry_runs() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-libreboot-checklist.sh")
+        .output()
+        .expect("run libreboot checklist script");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        text.contains("sh scripts/base1-libreboot-preflight.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-grub-recovery-dry-run.sh --dry-run"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-recovery-dry-run.sh --dry-run"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-rollback-metadata-dry-run.sh --dry-run"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-install-dry-run.sh --dry-run --target /dev/example"),
+        "{text}"
+    );
+}
+
+#[test]
+fn libreboot_checklist_script_avoids_mutating_tools_and_secret_terms() {
+    let script = std::fs::read_to_string("scripts/base1-libreboot-checklist.sh")
+        .expect("libreboot checklist script");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only Libreboot operator checklist command for GRUB-first X200-class Base1 systems.

Implements:
- scripts/base1-libreboot-checklist.sh
- Libreboot + X200-class checklist output
- GRUB-first readiness summary
- Required dry-run command list
- mutating-tool and secret-term guard test
- README and operator checklist doc links

Validation:
- cargo test -p phase1 --test base1_libreboot_checklist_script
- cargo test -p phase1 --test base1_libreboot_operator_checklist_docs
- cargo test -p phase1 --test base1_grub_recovery_dry_run_script
- cargo test -p phase1 --test base1_libreboot_preflight_script
- cargo test -p phase1 --test base1_foundation

Refs #135