### PR TITLE
Document Base1 Libreboot command index

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ Start here:
 - [`base1/LIBREBOOT_PREFLIGHT.md`](base1/LIBREBOOT_PREFLIGHT.md) — Libreboot preflight notes for GRUB-first systems
 - [`base1/LIBREBOOT_GRUB_RECOVERY.md`](base1/LIBREBOOT_GRUB_RECOVERY.md) — Libreboot GRUB recovery notes
 - [`base1/LIBREBOOT_OPERATOR_CHECKLIST.md`](base1/LIBREBOOT_OPERATOR_CHECKLIST.md) — Libreboot operator checklist
+- [`base1/LIBREBOOT_COMMAND_INDEX.md`](base1/LIBREBOOT_COMMAND_INDEX.md) — Libreboot command index
 - [`base1/PHASE1_COMPATIBILITY.md`](base1/PHASE1_COMPATIBILITY.md) — compatibility contract
 - [`base1/ROADMAP.md`](base1/ROADMAP.md) — staged roadmap
 

--- a/base1/LIBREBOOT_COMMAND_INDEX.md
+++ b/base1/LIBREBOOT_COMMAND_INDEX.md
@@ -1,0 +1,56 @@
+# Base1 Libreboot command index
+
+This index collects the Libreboot and GRUB-first Base1 operator documents and read-only scripts.
+
+This document is advisory and read-only. It does not flash firmware, change boot order, install GRUB, edit grub.cfg, write to /boot, modify disks, or change host trust.
+
+## Libreboot documents
+
+- `base1/LIBREBOOT_PROFILE.md` — firmware-aware Base1 profile for Libreboot-backed X200-class systems.
+- `base1/LIBREBOOT_PREFLIGHT.md` — read-only Libreboot and GRUB-first preflight notes.
+- `base1/LIBREBOOT_GRUB_RECOVERY.md` — GRUB-first recovery notes.
+- `base1/LIBREBOOT_OPERATOR_CHECKLIST.md` — operator readiness checklist.
+
+## Libreboot scripts
+
+- `scripts/base1-libreboot-preflight.sh`
+- `scripts/base1-grub-recovery-dry-run.sh --dry-run`
+- `scripts/base1-libreboot-checklist.sh`
+
+## Related Base1 dry-runs
+
+- `scripts/base1-recovery-dry-run.sh --dry-run`
+- `scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example`
+- `scripts/base1-rollback-metadata-dry-run.sh --dry-run`
+- `scripts/base1-install-dry-run.sh --dry-run --target /dev/example`
+
+## Shared guardrails
+
+Every Libreboot-facing Base1 command or document must preserve these rules:
+
+- Do not flash firmware.
+- Do not change boot order.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not write to disk.
+- Do not assume systemd-boot.
+- Do not assume EFI-only boot.
+- Do not assume Secure Boot.
+- Do not assume TPM.
+- Do not hide recovery uncertainty.
+- Do not remove emergency shell access.
+- Do not store passwords, tokens, private keys, recovery phrases, or personal secrets.
+
+## Operator path
+
+The expected path is:
+
+1. Read the Libreboot profile.
+2. Read the Libreboot preflight notes.
+3. Read the GRUB recovery notes.
+4. Run the Libreboot checklist command.
+5. Run the read-only Libreboot preflight command.
+6. Run the GRUB recovery dry-run command.
+7. Run the broader Base1 dry-run commands.
+8. Confirm normal boot, recovery boot, Phase1 launch, rollback, and emergency shell paths.

--- a/base1/LIBREBOOT_GRUB_RECOVERY.md
+++ b/base1/LIBREBOOT_GRUB_RECOVERY.md
@@ -56,3 +56,6 @@ Do not store passwords, recovery phrases, private keys, tokens, or personal secr
 
 
 See also: [Libreboot operator checklist](LIBREBOOT_OPERATOR_CHECKLIST.md).
+
+
+See also: [Libreboot command index](LIBREBOOT_COMMAND_INDEX.md).

--- a/base1/LIBREBOOT_OPERATOR_CHECKLIST.md
+++ b/base1/LIBREBOOT_OPERATOR_CHECKLIST.md
@@ -59,3 +59,6 @@ Run these before any future destructive installer work:
 ## Ready marker
 
 A Libreboot-backed Base1 target is only ready for later install work when the operator can explain the normal boot path, recovery boot path, Phase1 launch path, rollback path, and emergency shell path without relying on hidden host mutation.
+
+
+See also: [Libreboot command index](LIBREBOOT_COMMAND_INDEX.md).

--- a/base1/LIBREBOOT_PREFLIGHT.md
+++ b/base1/LIBREBOOT_PREFLIGHT.md
@@ -58,3 +58,6 @@ Future script support should remain read-only and should print notes instead of 
 
 
 See also: [Libreboot operator checklist](LIBREBOOT_OPERATOR_CHECKLIST.md).
+
+
+See also: [Libreboot command index](LIBREBOOT_COMMAND_INDEX.md).

--- a/base1/LIBREBOOT_PROFILE.md
+++ b/base1/LIBREBOOT_PROFILE.md
@@ -86,3 +86,6 @@ Future Libreboot-aware validation may add read-only firmware notes, but firmware
 
 
 See also: [Libreboot operator checklist](LIBREBOOT_OPERATOR_CHECKLIST.md).
+
+
+See also: [Libreboot command index](LIBREBOOT_COMMAND_INDEX.md).

--- a/tests/base1_libreboot_command_index_docs.rs
+++ b/tests/base1_libreboot_command_index_docs.rs
@@ -1,0 +1,72 @@
+#[test]
+fn libreboot_command_index_lists_docs_and_scripts() {
+    let doc = std::fs::read_to_string("base1/LIBREBOOT_COMMAND_INDEX.md")
+        .expect("libreboot command index");
+
+    assert!(doc.contains("Base1 Libreboot command index"), "{doc}");
+    assert!(doc.contains("LIBREBOOT_PROFILE.md"), "{doc}");
+    assert!(doc.contains("LIBREBOOT_PREFLIGHT.md"), "{doc}");
+    assert!(doc.contains("LIBREBOOT_GRUB_RECOVERY.md"), "{doc}");
+    assert!(doc.contains("LIBREBOOT_OPERATOR_CHECKLIST.md"), "{doc}");
+    assert!(
+        doc.contains("scripts/base1-libreboot-preflight.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-grub-recovery-dry-run.sh --dry-run"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-libreboot-checklist.sh"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn libreboot_command_index_preserves_guardrails() {
+    let doc = std::fs::read_to_string("base1/LIBREBOOT_COMMAND_INDEX.md")
+        .expect("libreboot command index");
+
+    assert!(doc.contains("Do not flash firmware"), "{doc}");
+    assert!(doc.contains("Do not install GRUB automatically"), "{doc}");
+    assert!(doc.contains("Do not edit grub.cfg automatically"), "{doc}");
+    assert!(doc.contains("Do not write to /boot"), "{doc}");
+    assert!(doc.contains("Do not assume systemd-boot"), "{doc}");
+    assert!(doc.contains("Do not store passwords"), "{doc}");
+}
+
+#[test]
+fn libreboot_docs_link_command_index() {
+    let profile = std::fs::read_to_string("base1/LIBREBOOT_PROFILE.md").expect("libreboot profile");
+    let preflight =
+        std::fs::read_to_string("base1/LIBREBOOT_PREFLIGHT.md").expect("libreboot preflight");
+    let recovery =
+        std::fs::read_to_string("base1/LIBREBOOT_GRUB_RECOVERY.md").expect("libreboot recovery");
+    let checklist = std::fs::read_to_string("base1/LIBREBOOT_OPERATOR_CHECKLIST.md")
+        .expect("libreboot checklist");
+
+    assert!(profile.contains("LIBREBOOT_COMMAND_INDEX.md"), "{profile}");
+    assert!(
+        preflight.contains("LIBREBOOT_COMMAND_INDEX.md"),
+        "{preflight}"
+    );
+    assert!(
+        recovery.contains("LIBREBOOT_COMMAND_INDEX.md"),
+        "{recovery}"
+    );
+    assert!(
+        checklist.contains("LIBREBOOT_COMMAND_INDEX.md"),
+        "{checklist}"
+    );
+}
+
+#[test]
+fn readme_links_libreboot_command_index() {
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        readme.contains("base1/LIBREBOOT_COMMAND_INDEX.md"),
+        "{readme}"
+    );
+    assert!(readme.contains("Libreboot command index"), "{readme}");
+}


### PR DESCRIPTION
Adds an operator-facing index for Libreboot and GRUB-first Base1 docs and read-only commands.

Implements:
- Libreboot command index
- Links to Libreboot profile, preflight, GRUB recovery, and operator checklist
- Links to read-only Libreboot and Base1 dry-run scripts
- README and Libreboot doc links
- Docs tests for command index guardrails

Validation:
- cargo test -p phase1 --test base1_libreboot_command_index_docs
- cargo test -p phase1 --test base1_libreboot_checklist_script
- cargo test -p phase1 --test base1_libreboot_operator_checklist_docs
- cargo test -p phase1 --test base1_grub_recovery_dry_run_script
- cargo test -p phase1 --test base1_foundation

Refs #135