### PR TITLE
Add Base1 Libreboot index command

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ First safe check:
 ```bash
 sh scripts/base1-preflight.sh
 sh scripts/base1-libreboot-preflight.sh
+sh scripts/base1-libreboot-index.sh
 sh scripts/base1-libreboot-checklist.sh
 sh scripts/base1-grub-recovery-dry-run.sh --dry-run
 sh scripts/base1-install-dry-run.sh --dry-run --target /dev/example

--- a/base1/LIBREBOOT_COMMAND_INDEX.md
+++ b/base1/LIBREBOOT_COMMAND_INDEX.md
@@ -13,6 +13,7 @@ This document is advisory and read-only. It does not flash firmware, change boot
 
 ## Libreboot scripts
 
+- `scripts/base1-libreboot-index.sh`
 - `scripts/base1-libreboot-preflight.sh`
 - `scripts/base1-grub-recovery-dry-run.sh --dry-run`
 - `scripts/base1-libreboot-checklist.sh`

--- a/scripts/base1-libreboot-index.sh
+++ b/scripts/base1-libreboot-index.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 Libreboot index
+
+usage:
+  sh scripts/base1-libreboot-index.sh
+
+This command is read-only. It prints the Libreboot and GRUB-first Base1
+document/script index and does not change firmware, boot order, /boot, disks,
+or host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+cat <<'EOF'
+base1 libreboot command index
+firmware : Libreboot
+hardware : X200-class
+boot     : GRUB first
+writes   : no
+trust    : no host trust escalation
+
+documents:
+- base1/LIBREBOOT_PROFILE.md
+- base1/LIBREBOOT_PREFLIGHT.md
+- base1/LIBREBOOT_GRUB_RECOVERY.md
+- base1/LIBREBOOT_OPERATOR_CHECKLIST.md
+- base1/LIBREBOOT_COMMAND_INDEX.md
+
+read-only scripts:
+- sh scripts/base1-libreboot-index.sh
+- sh scripts/base1-libreboot-checklist.sh
+- sh scripts/base1-libreboot-preflight.sh
+- sh scripts/base1-grub-recovery-dry-run.sh --dry-run
+- sh scripts/base1-recovery-dry-run.sh --dry-run
+- sh scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example
+- sh scripts/base1-rollback-metadata-dry-run.sh --dry-run
+- sh scripts/base1-install-dry-run.sh --dry-run --target /dev/example
+EOF

--- a/tests/base1_libreboot_index_script.rs
+++ b/tests/base1_libreboot_index_script.rs
@@ -1,0 +1,80 @@
+use std::process::Command;
+
+#[test]
+fn libreboot_index_script_prints_docs_and_scripts() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-libreboot-index.sh")
+        .output()
+        .expect("run libreboot index script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("base1 libreboot command index"), "{text}");
+    assert!(text.contains("firmware : Libreboot"), "{text}");
+    assert!(text.contains("hardware : X200-class"), "{text}");
+    assert!(text.contains("boot     : GRUB first"), "{text}");
+    assert!(text.contains("writes   : no"), "{text}");
+    assert!(text.contains("base1/LIBREBOOT_PROFILE.md"), "{text}");
+    assert!(text.contains("base1/LIBREBOOT_COMMAND_INDEX.md"), "{text}");
+    assert!(
+        text.contains("sh scripts/base1-libreboot-checklist.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-grub-recovery-dry-run.sh --dry-run"),
+        "{text}"
+    );
+}
+
+#[test]
+fn libreboot_index_script_help_is_read_only() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-libreboot-index.sh")
+        .arg("--help")
+        .output()
+        .expect("run libreboot index help");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("read-only"), "{text}");
+    assert!(text.contains("does not change firmware"), "{text}");
+    assert!(text.contains("host trust"), "{text}");
+}
+
+#[test]
+fn libreboot_index_script_avoids_mutating_tools_and_secret_terms() {
+    let script = std::fs::read_to_string("scripts/base1-libreboot-index.sh")
+        .expect("libreboot index script");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only Libreboot command index script for GRUB-first X200-class Base1 systems.

Implements:
- scripts/base1-libreboot-index.sh
- Libreboot document index output
- read-only script index output
- README and Libreboot command index updates
- mutating-tool and secret-term guard test

Validation:
- cargo test -p phase1 --test base1_libreboot_index_script
- cargo test -p phase1 --test base1_libreboot_command_index_docs
- cargo test -p phase1 --test base1_libreboot_checklist_script
- cargo test -p phase1 --test base1_grub_recovery_dry_run_script
- cargo test -p phase1 --test base1_foundation

Refs #135