### PR TITLE
Add Base1 Libreboot validation bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ First safe check:
 ```bash
 sh scripts/base1-preflight.sh
 sh scripts/base1-libreboot-preflight.sh
+sh scripts/base1-libreboot-validate.sh
 sh scripts/base1-libreboot-index.sh
 sh scripts/base1-libreboot-checklist.sh
 sh scripts/base1-grub-recovery-dry-run.sh --dry-run

--- a/base1/LIBREBOOT_COMMAND_INDEX.md
+++ b/base1/LIBREBOOT_COMMAND_INDEX.md
@@ -13,6 +13,7 @@ This document is advisory and read-only. It does not flash firmware, change boot
 
 ## Libreboot scripts
 
+- `scripts/base1-libreboot-validate.sh`
 - `scripts/base1-libreboot-index.sh`
 - `scripts/base1-libreboot-preflight.sh`
 - `scripts/base1-grub-recovery-dry-run.sh --dry-run`

--- a/scripts/base1-libreboot-validate.sh
+++ b/scripts/base1-libreboot-validate.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 Libreboot validation bundle
+
+usage:
+  sh scripts/base1-libreboot-validate.sh
+
+This command is read-only. It runs the Libreboot and Base1 preview commands
+that report firmware, GRUB-first recovery, storage, rollback, and installer
+readiness without changing firmware, boot order, /boot, disks, or host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+run_cmd() {
+  echo
+  echo "$ $*"
+  "$@"
+}
+
+cat <<'EOF'
+base1 libreboot validation bundle
+firmware : Libreboot expected
+hardware : X200-class expected
+boot     : GRUB first
+mode     : read-only
+writes   : no
+trust    : no host trust escalation
+EOF
+
+run_cmd sh scripts/base1-libreboot-index.sh
+run_cmd sh scripts/base1-libreboot-checklist.sh
+run_cmd sh scripts/base1-libreboot-preflight.sh
+run_cmd sh scripts/base1-grub-recovery-dry-run.sh --dry-run
+run_cmd sh scripts/base1-recovery-dry-run.sh --dry-run
+run_cmd sh scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example
+run_cmd sh scripts/base1-rollback-metadata-dry-run.sh --dry-run
+run_cmd sh scripts/base1-install-dry-run.sh --dry-run --target /dev/example
+
+echo
+echo "base1 libreboot validation bundle complete"

--- a/tests/base1_libreboot_validation_bundle.rs
+++ b/tests/base1_libreboot_validation_bundle.rs
@@ -1,0 +1,77 @@
+use std::process::Command;
+
+#[test]
+fn libreboot_validation_bundle_runs_all_read_only_previews() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-libreboot-validate.sh")
+        .output()
+        .expect("run libreboot validation bundle");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("base1 libreboot validation bundle"), "{text}");
+    assert!(text.contains("firmware : Libreboot expected"), "{text}");
+    assert!(text.contains("hardware : X200-class expected"), "{text}");
+    assert!(text.contains("boot     : GRUB first"), "{text}");
+    assert!(text.contains("writes   : no"), "{text}");
+    assert!(text.contains("base1 libreboot command index"), "{text}");
+    assert!(
+        text.contains("base1 libreboot operator checklist"),
+        "{text}"
+    );
+    assert!(text.contains("base1 grub recovery dry-run"), "{text}");
+    assert!(text.contains("base1 installer dry-run"), "{text}");
+}
+
+#[test]
+fn libreboot_validation_bundle_help_is_read_only() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-libreboot-validate.sh")
+        .arg("--help")
+        .output()
+        .expect("run libreboot validation help");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("read-only"), "{text}");
+    assert!(text.contains("without changing firmware"), "{text}");
+    assert!(text.contains("host trust"), "{text}");
+}
+
+#[test]
+fn libreboot_validation_bundle_avoids_mutating_tools_and_secret_terms() {
+    let script = std::fs::read_to_string("scripts/base1-libreboot-validate.sh")
+        .expect("libreboot validation bundle");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only Libreboot validation bundle for GRUB-first X200-class Base1 systems.

Implements:
- scripts/base1-libreboot-validate.sh
- grouped Libreboot/Base1 preview command runner
- GRUB-first validation summary
- README and Libreboot command index updates
- mutating-tool and secret-term guard test

Validation:
- cargo test -p phase1 --test base1_libreboot_validation_bundle
- cargo test -p phase1 --test base1_libreboot_index_script
- cargo test -p phase1 --test base1_libreboot_command_index_docs
- cargo test -p phase1 --test base1_libreboot_checklist_script
- cargo test -p phase1 --test base1_foundation

Refs #135