### PR TITLE
Document Base1 Libreboot validation report

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Start here:
 - [`base1/LIBREBOOT_GRUB_RECOVERY.md`](base1/LIBREBOOT_GRUB_RECOVERY.md) — Libreboot GRUB recovery notes
 - [`base1/LIBREBOOT_OPERATOR_CHECKLIST.md`](base1/LIBREBOOT_OPERATOR_CHECKLIST.md) — Libreboot operator checklist
 - [`base1/LIBREBOOT_COMMAND_INDEX.md`](base1/LIBREBOOT_COMMAND_INDEX.md) — Libreboot command index
+- [`base1/LIBREBOOT_VALIDATION_REPORT.md`](base1/LIBREBOOT_VALIDATION_REPORT.md) — Libreboot validation report template
 - [`base1/PHASE1_COMPATIBILITY.md`](base1/PHASE1_COMPATIBILITY.md) — compatibility contract
 - [`base1/ROADMAP.md`](base1/ROADMAP.md) — staged roadmap
 

--- a/base1/LIBREBOOT_VALIDATION_REPORT.md
+++ b/base1/LIBREBOOT_VALIDATION_REPORT.md
@@ -1,0 +1,61 @@
+# Base1 Libreboot validation report
+
+This report template records operator-visible validation for a Libreboot-backed, GRUB-first Base1 target.
+
+This document is advisory and read-only. Do not store passwords, tokens, private keys, recovery phrases, or personal secrets here.
+
+## Target summary
+
+- Firmware profile: Libreboot.
+- Hardware profile: X200-class.
+- Bootloader expectation: GRUB first.
+- Secure Boot: not assumed.
+- TPM: not assumed.
+- Recovery media: external USB recommended.
+- Emergency shell: required.
+- Phase1 posture: safe mode default.
+
+## Validation commands
+
+Run and record whether each command completed:
+
+    sh scripts/base1-libreboot-validate.sh
+    sh scripts/base1-libreboot-index.sh
+    sh scripts/base1-libreboot-checklist.sh
+    sh scripts/base1-libreboot-preflight.sh
+    sh scripts/base1-grub-recovery-dry-run.sh --dry-run
+
+## Operator confirmations
+
+Record yes/no/status:
+
+- I can reach the GRUB menu.
+- I know the normal boot path.
+- I know the recovery boot path.
+- I can reach an emergency shell.
+- I know where Phase1 state should live.
+- I know where rollback metadata should live.
+- I have or plan recovery USB media.
+- I understand wireless firmware limitations.
+- I understand clock drift risk.
+- I understand no firmware or boot mutation should be automatic.
+
+## Guardrails
+
+- Do not flash firmware.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not change boot order.
+- Do not remove emergency shell access.
+- Do not assume systemd-boot.
+- Do not assume EFI-only boot.
+- Do not store secrets.
+
+## Result
+
+Status: not validated yet.
+
+Notes:
+
+- Add hardware-specific notes here after running read-only checks.

--- a/tests/base1_libreboot_validation_report_docs.rs
+++ b/tests/base1_libreboot_validation_report_docs.rs
@@ -1,0 +1,37 @@
+#[test]
+fn libreboot_validation_report_template_defines_safe_target_summary() {
+    let doc = std::fs::read_to_string("base1/LIBREBOOT_VALIDATION_REPORT.md")
+        .expect("libreboot validation report");
+
+    assert!(doc.contains("Base1 Libreboot validation report"), "{doc}");
+    assert!(doc.contains("Firmware profile: Libreboot"), "{doc}");
+    assert!(doc.contains("Hardware profile: X200-class"), "{doc}");
+    assert!(doc.contains("Bootloader expectation: GRUB first"), "{doc}");
+    assert!(doc.contains("Secure Boot: not assumed"), "{doc}");
+    assert!(doc.contains("TPM: not assumed"), "{doc}");
+    assert!(
+        doc.contains("sh scripts/base1-libreboot-validate.sh"),
+        "{doc}"
+    );
+    assert!(doc.contains("Do not store secrets"), "{doc}");
+}
+
+#[test]
+fn libreboot_command_index_links_validation_report() {
+    let index = std::fs::read_to_string("base1/LIBREBOOT_COMMAND_INDEX.md")
+        .expect("libreboot command index");
+
+    assert!(index.contains("LIBREBOOT_VALIDATION_REPORT.md"), "{index}");
+    assert!(index.contains("Libreboot validation report"), "{index}");
+}
+
+#[test]
+fn readme_links_validation_report() {
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        readme.contains("base1/LIBREBOOT_VALIDATION_REPORT.md"),
+        "{readme}"
+    );
+    assert!(readme.contains("Libreboot validation report"), "{readme}");
+}


### PR DESCRIPTION
Adds a validation report template for Libreboot-backed GRUB-first X200-class Base1 systems.

Implements:
- Libreboot validation report template
- Operator confirmation checklist
- Guardrails against firmware, GRUB, /boot, disk, and secret mutation
- README and Libreboot command index links
- Docs tests for the validation report

Validation:
- cargo test -p phase1 --test base1_libreboot_validation_report_docs
- cargo test -p phase1 --test base1_libreboot_validation_bundle
- cargo test -p phase1 --test base1_libreboot_command_index_docs
- cargo test -p phase1 --test base1_foundation

Refs #135