### PR TITLE
Fix Libreboot validation report index wording

### DIFF
--- a/base1/LIBREBOOT_COMMAND_INDEX.md
+++ b/base1/LIBREBOOT_COMMAND_INDEX.md
@@ -10,6 +10,7 @@ This document is advisory and read-only. It does not flash firmware, change boot
 - `base1/LIBREBOOT_PREFLIGHT.md` — read-only Libreboot and GRUB-first preflight notes.
 - `base1/LIBREBOOT_GRUB_RECOVERY.md` — GRUB-first recovery notes.
 - `base1/LIBREBOOT_OPERATOR_CHECKLIST.md` — operator readiness checklist.
+- `base1/LIBREBOOT_VALIDATION_REPORT.md` — Libreboot validation report template.
 
 ## Libreboot scripts
 


### PR DESCRIPTION
Adds the expected Libreboot validation report wording to the Libreboot command index.

Validation:
- cargo test -p phase1 --test base1_libreboot_validation_report_docs
- cargo test -p phase1 --test base1_libreboot_validation_bundle
- cargo test -p phase1 --test base1_libreboot_command_index_docs
- cargo test -p phase1 --test base1_foundation

Refs #135