### PR TITLE
Add Base1 Libreboot validation report command

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ First safe check:
 ```bash
 sh scripts/base1-preflight.sh
 sh scripts/base1-libreboot-preflight.sh
+sh scripts/base1-libreboot-report.sh
 sh scripts/base1-libreboot-validate.sh
 sh scripts/base1-libreboot-index.sh
 sh scripts/base1-libreboot-checklist.sh

--- a/base1/LIBREBOOT_COMMAND_INDEX.md
+++ b/base1/LIBREBOOT_COMMAND_INDEX.md
@@ -14,6 +14,7 @@ This document is advisory and read-only. It does not flash firmware, change boot
 
 ## Libreboot scripts
 
+- `scripts/base1-libreboot-report.sh`
 - `scripts/base1-libreboot-validate.sh`
 - `scripts/base1-libreboot-index.sh`
 - `scripts/base1-libreboot-preflight.sh`

--- a/base1/LIBREBOOT_VALIDATION_REPORT.md
+++ b/base1/LIBREBOOT_VALIDATION_REPORT.md
@@ -19,6 +19,7 @@ This document is advisory and read-only. Do not store passwords, tokens, private
 
 Run and record whether each command completed:
 
+    sh scripts/base1-libreboot-report.sh
     sh scripts/base1-libreboot-validate.sh
     sh scripts/base1-libreboot-index.sh
     sh scripts/base1-libreboot-checklist.sh

--- a/scripts/base1-libreboot-report.sh
+++ b/scripts/base1-libreboot-report.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 Libreboot validation report
+
+usage:
+  sh scripts/base1-libreboot-report.sh
+
+This command is read-only. It prints a validation report template for
+Libreboot-backed, GRUB-first Base1 systems and does not change firmware,
+boot order, /boot, disks, or host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+cat <<'EOF'
+base1 libreboot validation report
+firmware profile     : Libreboot
+hardware profile     : X200-class
+bootloader expected  : GRUB first
+secure boot          : not assumed
+tpm                  : not assumed
+recovery media       : external USB recommended
+emergency shell      : required
+phase1 posture       : safe mode default
+writes               : no
+trust                : no host trust escalation
+
+validation commands:
+- sh scripts/base1-libreboot-validate.sh
+- sh scripts/base1-libreboot-index.sh
+- sh scripts/base1-libreboot-checklist.sh
+- sh scripts/base1-libreboot-preflight.sh
+- sh scripts/base1-grub-recovery-dry-run.sh --dry-run
+
+operator confirmations:
+- GRUB menu reachable: unknown
+- normal boot path known: unknown
+- recovery boot path known: unknown
+- emergency shell reachable: unknown
+- Phase1 state path known: unknown
+- rollback metadata path known: unknown
+
+status: not validated yet
+EOF

--- a/tests/base1_libreboot_report_script.rs
+++ b/tests/base1_libreboot_report_script.rs
@@ -1,0 +1,94 @@
+use std::process::Command;
+
+#[test]
+fn libreboot_report_script_prints_validation_template() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-libreboot-report.sh")
+        .output()
+        .expect("run libreboot report script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("base1 libreboot validation report"), "{text}");
+    assert!(text.contains("firmware profile     : Libreboot"), "{text}");
+    assert!(text.contains("hardware profile     : X200-class"), "{text}");
+    assert!(text.contains("bootloader expected  : GRUB first"), "{text}");
+    assert!(
+        text.contains("secure boot          : not assumed"),
+        "{text}"
+    );
+    assert!(
+        text.contains("tpm                  : not assumed"),
+        "{text}"
+    );
+    assert!(text.contains("writes               : no"), "{text}");
+    assert!(text.contains("status: not validated yet"), "{text}");
+}
+
+#[test]
+fn libreboot_report_script_lists_validation_commands() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-libreboot-report.sh")
+        .output()
+        .expect("run libreboot report script");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        text.contains("sh scripts/base1-libreboot-validate.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-libreboot-index.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-libreboot-checklist.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-libreboot-preflight.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-grub-recovery-dry-run.sh --dry-run"),
+        "{text}"
+    );
+}
+
+#[test]
+fn libreboot_report_script_avoids_mutating_tools_and_secret_terms() {
+    let script = std::fs::read_to_string("scripts/base1-libreboot-report.sh")
+        .expect("libreboot report script");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only Libreboot validation report command for GRUB-first X200-class Base1 systems.

Implements:
- scripts/base1-libreboot-report.sh
- validation report template output
- operator confirmation placeholders
- README, command index, and validation report updates
- mutating-tool and secret-term guard test

Validation:
- cargo test -p phase1 --test base1_libreboot_report_script
- cargo test -p phase1 --test base1_libreboot_validation_report_docs
- cargo test -p phase1 --test base1_libreboot_validation_bundle
- cargo test -p phase1 --test base1_libreboot_command_index_docs
- cargo test -p phase1 --test base1_foundation

Refs #135