### PR TITLE
Document Base1 Libreboot quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ Start here:
 - [`base1/LIBREBOOT_PREFLIGHT.md`](base1/LIBREBOOT_PREFLIGHT.md) — Libreboot preflight notes for GRUB-first systems
 - [`base1/LIBREBOOT_GRUB_RECOVERY.md`](base1/LIBREBOOT_GRUB_RECOVERY.md) — Libreboot GRUB recovery notes
 - [`base1/LIBREBOOT_OPERATOR_CHECKLIST.md`](base1/LIBREBOOT_OPERATOR_CHECKLIST.md) — Libreboot operator checklist
+- [`base1/LIBREBOOT_QUICKSTART.md`](base1/LIBREBOOT_QUICKSTART.md) — Libreboot quickstart
 - [`base1/LIBREBOOT_COMMAND_INDEX.md`](base1/LIBREBOOT_COMMAND_INDEX.md) — Libreboot command index
 - [`base1/LIBREBOOT_VALIDATION_REPORT.md`](base1/LIBREBOOT_VALIDATION_REPORT.md) — Libreboot validation report template
 - [`base1/PHASE1_COMPATIBILITY.md`](base1/PHASE1_COMPATIBILITY.md) — compatibility contract

--- a/base1/LIBREBOOT_COMMAND_INDEX.md
+++ b/base1/LIBREBOOT_COMMAND_INDEX.md
@@ -6,6 +6,7 @@ This document is advisory and read-only. It does not flash firmware, change boot
 
 ## Libreboot documents
 
+- `base1/LIBREBOOT_QUICKSTART.md` — Libreboot quickstart.
 - `base1/LIBREBOOT_PROFILE.md` — firmware-aware Base1 profile for Libreboot-backed X200-class systems.
 - `base1/LIBREBOOT_PREFLIGHT.md` — read-only Libreboot and GRUB-first preflight notes.
 - `base1/LIBREBOOT_GRUB_RECOVERY.md` — GRUB-first recovery notes.

--- a/base1/LIBREBOOT_QUICKSTART.md
+++ b/base1/LIBREBOOT_QUICKSTART.md
@@ -1,0 +1,58 @@
+# Base1 Libreboot quickstart
+
+This quickstart is the safe first path for a Libreboot-backed, GRUB-first X200-class Base1 target.
+
+This document is advisory and read-only. It does not flash firmware, change boot order, install GRUB, edit grub.cfg, write to /boot, modify disks, or change host trust.
+
+## Target assumptions
+
+- Firmware: Libreboot.
+- Hardware: ThinkPad X200-class.
+- Bootloader: GRUB first.
+- Secure Boot: not assumed.
+- TPM: not assumed.
+- Recovery media: external USB recommended.
+- Emergency shell: required.
+- Phase1 posture: safe mode on by default.
+
+## First safe commands
+
+Run the read-only checks first:
+
+    sh scripts/base1-libreboot-index.sh
+    sh scripts/base1-libreboot-checklist.sh
+    sh scripts/base1-libreboot-preflight.sh
+    sh scripts/base1-grub-recovery-dry-run.sh --dry-run
+    sh scripts/base1-libreboot-validate.sh
+    sh scripts/base1-libreboot-report.sh
+
+## What to confirm before anything destructive exists
+
+Before future install work, confirm:
+
+- You can reach the GRUB menu.
+- You know the normal boot path.
+- You know the recovery boot path.
+- You can reach an emergency shell.
+- You know where Phase1 state should live.
+- You know where rollback metadata should live.
+- You have or plan recovery USB media.
+- You understand wireless firmware limitations.
+- You understand clock drift risk.
+- You understand Base1 must not mutate firmware or boot settings silently.
+
+## Guardrails
+
+- Do not flash firmware automatically.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not change boot order.
+- Do not remove emergency shell access.
+- Do not assume systemd-boot.
+- Do not assume EFI-only boot.
+- Do not store passwords, tokens, private keys, recovery phrases, or personal secrets.
+
+## Next safe step
+
+After this quickstart passes, keep development in read-only dry-runs until hardware validation, rollback validation, and recovery validation are complete.

--- a/tests/base1_libreboot_quickstart_docs.rs
+++ b/tests/base1_libreboot_quickstart_docs.rs
@@ -1,0 +1,40 @@
+#[test]
+fn libreboot_quickstart_defines_safe_grub_first_path() {
+    let doc =
+        std::fs::read_to_string("base1/LIBREBOOT_QUICKSTART.md").expect("libreboot quickstart");
+
+    assert!(doc.contains("Base1 Libreboot quickstart"), "{doc}");
+    assert!(doc.contains("Libreboot"), "{doc}");
+    assert!(doc.contains("GRUB first"), "{doc}");
+    assert!(doc.contains("Secure Boot: not assumed"), "{doc}");
+    assert!(doc.contains("TPM: not assumed"), "{doc}");
+    assert!(doc.contains("sh scripts/base1-libreboot-index.sh"), "{doc}");
+    assert!(
+        doc.contains("sh scripts/base1-libreboot-validate.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("sh scripts/base1-libreboot-report.sh"),
+        "{doc}"
+    );
+    assert!(doc.contains("Do not install GRUB automatically"), "{doc}");
+    assert!(doc.contains("Do not write to /boot"), "{doc}");
+    assert!(doc.contains("Do not store passwords"), "{doc}");
+}
+
+#[test]
+fn libreboot_index_links_quickstart() {
+    let index = std::fs::read_to_string("base1/LIBREBOOT_COMMAND_INDEX.md")
+        .expect("libreboot command index");
+
+    assert!(index.contains("LIBREBOOT_QUICKSTART.md"), "{index}");
+    assert!(index.contains("Libreboot quickstart"), "{index}");
+}
+
+#[test]
+fn readme_links_libreboot_quickstart() {
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(readme.contains("base1/LIBREBOOT_QUICKSTART.md"), "{readme}");
+    assert!(readme.contains("Libreboot quickstart"), "{readme}");
+}


### PR DESCRIPTION
Adds a safe quickstart for Libreboot-backed GRUB-first X200-class Base1 systems.

Implements:
- Libreboot quickstart doc
- First safe read-only command sequence
- GRUB-first and recovery guardrails
- README and Libreboot command index links
- Docs tests for the quickstart

Validation:
- cargo test -p phase1 --test base1_libreboot_quickstart_docs
- cargo test -p phase1 --test base1_libreboot_report_script
- cargo test -p phase1 --test base1_libreboot_validation_report_docs
- cargo test -p phase1 --test base1_libreboot_command_index_docs
- cargo test -p phase1 --test base1_foundation

Refs #135