### PR TITLE
Document Base1 Libreboot docs summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ Start here:
 - [`base1/LIBREBOOT_PREFLIGHT.md`](base1/LIBREBOOT_PREFLIGHT.md) — Libreboot preflight notes for GRUB-first systems
 - [`base1/LIBREBOOT_GRUB_RECOVERY.md`](base1/LIBREBOOT_GRUB_RECOVERY.md) — Libreboot GRUB recovery notes
 - [`base1/LIBREBOOT_OPERATOR_CHECKLIST.md`](base1/LIBREBOOT_OPERATOR_CHECKLIST.md) — Libreboot operator checklist
+- [`base1/LIBREBOOT_DOCS_SUMMARY.md`](base1/LIBREBOOT_DOCS_SUMMARY.md) — Libreboot docs summary
 - [`base1/LIBREBOOT_QUICKSTART.md`](base1/LIBREBOOT_QUICKSTART.md) — Libreboot quickstart
 - [`base1/LIBREBOOT_COMMAND_INDEX.md`](base1/LIBREBOOT_COMMAND_INDEX.md) — Libreboot command index
 - [`base1/LIBREBOOT_VALIDATION_REPORT.md`](base1/LIBREBOOT_VALIDATION_REPORT.md) — Libreboot validation report template

--- a/base1/LIBREBOOT_COMMAND_INDEX.md
+++ b/base1/LIBREBOOT_COMMAND_INDEX.md
@@ -6,6 +6,7 @@ This document is advisory and read-only. It does not flash firmware, change boot
 
 ## Libreboot documents
 
+- `base1/LIBREBOOT_DOCS_SUMMARY.md` — Libreboot docs summary.
 - `base1/LIBREBOOT_QUICKSTART.md` — Libreboot quickstart.
 - `base1/LIBREBOOT_PROFILE.md` — firmware-aware Base1 profile for Libreboot-backed X200-class systems.
 - `base1/LIBREBOOT_PREFLIGHT.md` — read-only Libreboot and GRUB-first preflight notes.

--- a/base1/LIBREBOOT_DOCS_SUMMARY.md
+++ b/base1/LIBREBOOT_DOCS_SUMMARY.md
@@ -1,0 +1,60 @@
+# Base1 Libreboot docs summary
+
+This summary ties together the Libreboot-backed, GRUB-first Base1 documentation path for X200-class operator systems.
+
+This document is advisory and read-only. It does not flash firmware, change boot order, install GRUB, edit grub.cfg, write to /boot, modify disks, or change host trust.
+
+## Start here
+
+1. `base1/LIBREBOOT_QUICKSTART.md`
+2. `base1/LIBREBOOT_COMMAND_INDEX.md`
+3. `base1/LIBREBOOT_PROFILE.md`
+4. `base1/LIBREBOOT_PREFLIGHT.md`
+5. `base1/LIBREBOOT_GRUB_RECOVERY.md`
+6. `base1/LIBREBOOT_OPERATOR_CHECKLIST.md`
+7. `base1/LIBREBOOT_VALIDATION_REPORT.md`
+
+## First commands
+
+Run the read-only commands first:
+
+    sh scripts/base1-libreboot-index.sh
+    sh scripts/base1-libreboot-checklist.sh
+    sh scripts/base1-libreboot-preflight.sh
+    sh scripts/base1-grub-recovery-dry-run.sh --dry-run
+    sh scripts/base1-libreboot-validate.sh
+    sh scripts/base1-libreboot-report.sh
+
+## What this covers
+
+The current Libreboot path covers:
+
+- Libreboot-backed X200-class hardware assumptions.
+- GRUB-first bootloader expectation.
+- No Secure Boot assumption.
+- No TPM assumption.
+- Recovery USB recommendation.
+- Emergency shell requirement.
+- Read-only preflight checks.
+- Read-only recovery dry-runs.
+- Read-only validation report output.
+- Phase1 safe-mode default posture.
+
+## What this does not do
+
+The current Libreboot path does not:
+
+- Flash firmware.
+- Install GRUB.
+- Edit grub.cfg.
+- Write to /boot.
+- Modify disks.
+- Change boot order.
+- Store secrets.
+- Claim daily-driver readiness.
+- Replace hardware recovery testing.
+- Replace rollback validation.
+
+## Promotion rule
+
+Libreboot-backed Base1 work should stay in read-only docs and dry-runs until recovery media, emergency shell access, rollback metadata, storage layout, and hardware-specific boot behavior are validated on the target machine.

--- a/tests/base1_libreboot_docs_summary_docs.rs
+++ b/tests/base1_libreboot_docs_summary_docs.rs
@@ -1,0 +1,55 @@
+#[test]
+fn libreboot_docs_summary_lists_core_docs_and_commands() {
+    let doc =
+        std::fs::read_to_string("base1/LIBREBOOT_DOCS_SUMMARY.md").expect("libreboot docs summary");
+
+    assert!(doc.contains("Base1 Libreboot docs summary"), "{doc}");
+    assert!(doc.contains("LIBREBOOT_QUICKSTART.md"), "{doc}");
+    assert!(doc.contains("LIBREBOOT_COMMAND_INDEX.md"), "{doc}");
+    assert!(doc.contains("LIBREBOOT_PROFILE.md"), "{doc}");
+    assert!(doc.contains("LIBREBOOT_PREFLIGHT.md"), "{doc}");
+    assert!(doc.contains("LIBREBOOT_GRUB_RECOVERY.md"), "{doc}");
+    assert!(doc.contains("LIBREBOOT_OPERATOR_CHECKLIST.md"), "{doc}");
+    assert!(doc.contains("LIBREBOOT_VALIDATION_REPORT.md"), "{doc}");
+    assert!(
+        doc.contains("sh scripts/base1-libreboot-validate.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("sh scripts/base1-libreboot-report.sh"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn libreboot_docs_summary_preserves_read_only_guardrails() {
+    let doc =
+        std::fs::read_to_string("base1/LIBREBOOT_DOCS_SUMMARY.md").expect("libreboot docs summary");
+
+    assert!(doc.contains("does not flash firmware"), "{doc}");
+    assert!(
+        doc.contains("does not flash firmware") || doc.contains("Flash firmware"),
+        "{doc}"
+    );
+    assert!(doc.contains("Install GRUB"), "{doc}");
+    assert!(doc.contains("Write to /boot"), "{doc}");
+    assert!(doc.contains("Modify disks"), "{doc}");
+    assert!(doc.contains("Change boot order"), "{doc}");
+    assert!(doc.contains("Store secrets"), "{doc}");
+    assert!(doc.contains("read-only docs and dry-runs"), "{doc}");
+}
+
+#[test]
+fn libreboot_index_and_readme_link_docs_summary() {
+    let index = std::fs::read_to_string("base1/LIBREBOOT_COMMAND_INDEX.md")
+        .expect("libreboot command index");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(index.contains("LIBREBOOT_DOCS_SUMMARY.md"), "{index}");
+    assert!(index.contains("Libreboot docs summary"), "{index}");
+    assert!(
+        readme.contains("base1/LIBREBOOT_DOCS_SUMMARY.md"),
+        "{readme}"
+    );
+    assert!(readme.contains("Libreboot docs summary"), "{readme}");
+}


### PR DESCRIPTION
Adds a summary page tying together the Libreboot-backed GRUB-first Base1 documentation path.

Implements:
- Libreboot docs summary
- Links to quickstart, command index, profile, preflight, recovery, checklist, and report docs
- First read-only command sequence
- README and Libreboot command index links
- Docs tests for summary coverage and guardrails

Validation:
- cargo test -p phase1 --test base1_libreboot_docs_summary_docs
- cargo test -p phase1 --test base1_libreboot_quickstart_docs
- cargo test -p phase1 --test base1_libreboot_report_script
- cargo test -p phase1 --test base1_libreboot_command_index_docs
- cargo test -p phase1 --test base1_foundation

Refs #135