### PR TITLE
Add Base1 Libreboot docs command

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ sh scripts/base1-preflight.sh
 sh scripts/base1-libreboot-preflight.sh
 sh scripts/base1-libreboot-report.sh
 sh scripts/base1-libreboot-validate.sh
+sh scripts/base1-libreboot-docs.sh
 sh scripts/base1-libreboot-index.sh
 sh scripts/base1-libreboot-checklist.sh
 sh scripts/base1-grub-recovery-dry-run.sh --dry-run

--- a/base1/LIBREBOOT_COMMAND_INDEX.md
+++ b/base1/LIBREBOOT_COMMAND_INDEX.md
@@ -16,6 +16,7 @@ This document is advisory and read-only. It does not flash firmware, change boot
 
 ## Libreboot scripts
 
+- `scripts/base1-libreboot-docs.sh`
 - `scripts/base1-libreboot-report.sh`
 - `scripts/base1-libreboot-validate.sh`
 - `scripts/base1-libreboot-index.sh`

--- a/base1/LIBREBOOT_DOCS_SUMMARY.md
+++ b/base1/LIBREBOOT_DOCS_SUMMARY.md
@@ -18,6 +18,7 @@ This document is advisory and read-only. It does not flash firmware, change boot
 
 Run the read-only commands first:
 
+    sh scripts/base1-libreboot-docs.sh
     sh scripts/base1-libreboot-index.sh
     sh scripts/base1-libreboot-checklist.sh
     sh scripts/base1-libreboot-preflight.sh

--- a/scripts/base1-libreboot-docs.sh
+++ b/scripts/base1-libreboot-docs.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 Libreboot docs
+
+usage:
+  sh scripts/base1-libreboot-docs.sh
+
+This command is read-only. It prints the Libreboot GRUB-first documentation
+path and does not change firmware, boot order, /boot, disks, or host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+cat <<'EOF'
+base1 libreboot docs
+firmware : Libreboot
+hardware : X200-class
+boot     : GRUB first
+mode     : read-only
+writes   : no
+trust    : no host trust escalation
+
+read first:
+1. base1/LIBREBOOT_DOCS_SUMMARY.md
+2. base1/LIBREBOOT_QUICKSTART.md
+3. base1/LIBREBOOT_COMMAND_INDEX.md
+4. base1/LIBREBOOT_PROFILE.md
+5. base1/LIBREBOOT_PREFLIGHT.md
+6. base1/LIBREBOOT_GRUB_RECOVERY.md
+7. base1/LIBREBOOT_OPERATOR_CHECKLIST.md
+8. base1/LIBREBOOT_VALIDATION_REPORT.md
+
+first commands:
+- sh scripts/base1-libreboot-index.sh
+- sh scripts/base1-libreboot-checklist.sh
+- sh scripts/base1-libreboot-preflight.sh
+- sh scripts/base1-grub-recovery-dry-run.sh --dry-run
+- sh scripts/base1-libreboot-validate.sh
+- sh scripts/base1-libreboot-report.sh
+EOF

--- a/tests/base1_libreboot_docs_script.rs
+++ b/tests/base1_libreboot_docs_script.rs
@@ -1,0 +1,92 @@
+use std::process::Command;
+
+#[test]
+fn libreboot_docs_script_prints_docs_path() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-libreboot-docs.sh")
+        .output()
+        .expect("run libreboot docs script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("base1 libreboot docs"), "{text}");
+    assert!(text.contains("firmware : Libreboot"), "{text}");
+    assert!(text.contains("hardware : X200-class"), "{text}");
+    assert!(text.contains("boot     : GRUB first"), "{text}");
+    assert!(text.contains("writes   : no"), "{text}");
+    assert!(text.contains("LIBREBOOT_DOCS_SUMMARY.md"), "{text}");
+    assert!(text.contains("LIBREBOOT_QUICKSTART.md"), "{text}");
+    assert!(text.contains("LIBREBOOT_VALIDATION_REPORT.md"), "{text}");
+}
+
+#[test]
+fn libreboot_docs_script_lists_first_commands() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-libreboot-docs.sh")
+        .output()
+        .expect("run libreboot docs script");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        text.contains("sh scripts/base1-libreboot-index.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-libreboot-checklist.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-libreboot-preflight.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-grub-recovery-dry-run.sh --dry-run"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-libreboot-validate.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-libreboot-report.sh"),
+        "{text}"
+    );
+}
+
+#[test]
+fn libreboot_docs_script_avoids_mutating_tools_and_secret_terms() {
+    let script =
+        std::fs::read_to_string("scripts/base1-libreboot-docs.sh").expect("libreboot docs script");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only Libreboot docs command for GRUB-first X200-class Base1 systems.

Implements:
- scripts/base1-libreboot-docs.sh
- Libreboot documentation path output
- first safe command list
- README, docs summary, and command index updates
- mutating-tool and secret-term guard test

Validation:
- cargo test -p phase1 --test base1_libreboot_docs_script
- cargo test -p phase1 --test base1_libreboot_docs_summary_docs
- cargo test -p phase1 --test base1_libreboot_command_index_docs
- cargo test -p phase1 --test base1_libreboot_quickstart_docs
- cargo test -p phase1 --test base1_foundation

Refs #135