### PR TITLE
Document Base1 Libreboot milestone checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ Start here:
 - [`base1/LIBREBOOT_PREFLIGHT.md`](base1/LIBREBOOT_PREFLIGHT.md) — Libreboot preflight notes for GRUB-first systems
 - [`base1/LIBREBOOT_GRUB_RECOVERY.md`](base1/LIBREBOOT_GRUB_RECOVERY.md) — Libreboot GRUB recovery notes
 - [`base1/LIBREBOOT_OPERATOR_CHECKLIST.md`](base1/LIBREBOOT_OPERATOR_CHECKLIST.md) — Libreboot operator checklist
+- [`base1/LIBREBOOT_MILESTONE.md`](base1/LIBREBOOT_MILESTONE.md) — Libreboot milestone checkpoint
 - [`base1/LIBREBOOT_DOCS_SUMMARY.md`](base1/LIBREBOOT_DOCS_SUMMARY.md) — Libreboot docs summary
 - [`base1/LIBREBOOT_QUICKSTART.md`](base1/LIBREBOOT_QUICKSTART.md) — Libreboot quickstart
 - [`base1/LIBREBOOT_COMMAND_INDEX.md`](base1/LIBREBOOT_COMMAND_INDEX.md) — Libreboot command index

--- a/base1/LIBREBOOT_COMMAND_INDEX.md
+++ b/base1/LIBREBOOT_COMMAND_INDEX.md
@@ -6,6 +6,7 @@ This document is advisory and read-only. It does not flash firmware, change boot
 
 ## Libreboot documents
 
+- `base1/LIBREBOOT_MILESTONE.md` — Libreboot milestone checkpoint.
 - `base1/LIBREBOOT_DOCS_SUMMARY.md` — Libreboot docs summary.
 - `base1/LIBREBOOT_QUICKSTART.md` — Libreboot quickstart.
 - `base1/LIBREBOOT_PROFILE.md` — firmware-aware Base1 profile for Libreboot-backed X200-class systems.

--- a/base1/LIBREBOOT_DOCS_SUMMARY.md
+++ b/base1/LIBREBOOT_DOCS_SUMMARY.md
@@ -6,7 +6,7 @@ This document is advisory and read-only. It does not flash firmware, change boot
 
 ## Start here
 
-1. `base1/LIBREBOOT_MILESTONE.md`
+1. `base1/LIBREBOOT_MILESTONE.md` — Libreboot milestone checkpoint
 1. `base1/LIBREBOOT_QUICKSTART.md`
 2. `base1/LIBREBOOT_COMMAND_INDEX.md`
 3. `base1/LIBREBOOT_PROFILE.md`

--- a/base1/LIBREBOOT_DOCS_SUMMARY.md
+++ b/base1/LIBREBOOT_DOCS_SUMMARY.md
@@ -6,6 +6,7 @@ This document is advisory and read-only. It does not flash firmware, change boot
 
 ## Start here
 
+1. `base1/LIBREBOOT_MILESTONE.md`
 1. `base1/LIBREBOOT_QUICKSTART.md`
 2. `base1/LIBREBOOT_COMMAND_INDEX.md`
 3. `base1/LIBREBOOT_PROFILE.md`

--- a/base1/LIBREBOOT_MILESTONE.md
+++ b/base1/LIBREBOOT_MILESTONE.md
@@ -1,0 +1,75 @@
+# Base1 Libreboot milestone checkpoint
+
+This checkpoint records the current Libreboot-backed, GRUB-first Base1 validation track.
+
+The milestone is read-only. It does not flash firmware, change boot order, install GRUB, edit grub.cfg, write to /boot, modify disks, or change host trust.
+
+## Status
+
+- Firmware profile: Libreboot documented.
+- Hardware profile: X200-class documented.
+- Bootloader expectation: GRUB first documented.
+- Secure Boot: not assumed.
+- TPM: not assumed.
+- Recovery media: external USB recommended.
+- Emergency shell: required.
+- Phase1 posture: safe mode default.
+- Current maturity: documentation and read-only scripts.
+
+## Completed read-only surfaces
+
+Documents:
+
+- base1/LIBREBOOT_DOCS_SUMMARY.md
+- base1/LIBREBOOT_QUICKSTART.md
+- base1/LIBREBOOT_COMMAND_INDEX.md
+- base1/LIBREBOOT_PROFILE.md
+- base1/LIBREBOOT_PREFLIGHT.md
+- base1/LIBREBOOT_GRUB_RECOVERY.md
+- base1/LIBREBOOT_OPERATOR_CHECKLIST.md
+- base1/LIBREBOOT_VALIDATION_REPORT.md
+
+Scripts:
+
+- scripts/base1-libreboot-docs.sh
+- scripts/base1-libreboot-index.sh
+- scripts/base1-libreboot-checklist.sh
+- scripts/base1-libreboot-preflight.sh
+- scripts/base1-grub-recovery-dry-run.sh --dry-run
+- scripts/base1-libreboot-validate.sh
+- scripts/base1-libreboot-report.sh
+
+## Validation command set
+
+Run:
+
+    cargo test -p phase1 --test base1_libreboot_docs_script
+    cargo test -p phase1 --test base1_libreboot_docs_summary_docs
+    cargo test -p phase1 --test base1_libreboot_quickstart_docs
+    cargo test -p phase1 --test base1_libreboot_command_index_docs
+    cargo test -p phase1 --test base1_libreboot_profile_docs
+    cargo test -p phase1 --test base1_libreboot_preflight_docs
+    cargo test -p phase1 --test base1_libreboot_preflight_script
+    cargo test -p phase1 --test base1_libreboot_grub_recovery_docs
+    cargo test -p phase1 --test base1_grub_recovery_dry_run_script
+    cargo test -p phase1 --test base1_libreboot_operator_checklist_docs
+    cargo test -p phase1 --test base1_libreboot_checklist_script
+    cargo test -p phase1 --test base1_libreboot_validation_bundle
+    cargo test -p phase1 --test base1_libreboot_validation_report_docs
+    cargo test -p phase1 --test base1_libreboot_report_script
+
+## Not yet claimed
+
+This milestone does not claim:
+
+- Bootable Base1 image readiness.
+- Daily-driver readiness.
+- Destructive installer readiness.
+- Automatic GRUB repair.
+- Hardware recovery validation.
+- Rollback validation on real hardware.
+- Firmware mutation support.
+
+## Promotion rule
+
+The next milestone should stay read-only unless recovery USB behavior, emergency shell access, rollback metadata, storage layout, and GRUB boot behavior have been validated on the target Libreboot system.

--- a/tests/base1_libreboot_milestone_docs.rs
+++ b/tests/base1_libreboot_milestone_docs.rs
@@ -1,0 +1,59 @@
+#[test]
+fn libreboot_milestone_records_read_only_checkpoint() {
+    let doc = std::fs::read_to_string("base1/LIBREBOOT_MILESTONE.md").expect("libreboot milestone");
+
+    assert!(
+        doc.contains("Base1 Libreboot milestone checkpoint"),
+        "{doc}"
+    );
+    assert!(doc.contains("read-only"), "{doc}");
+    assert!(doc.contains("Libreboot documented"), "{doc}");
+    assert!(doc.contains("GRUB first documented"), "{doc}");
+    assert!(doc.contains("documentation and read-only scripts"), "{doc}");
+    assert!(doc.contains("does not flash firmware"), "{doc}");
+    assert!(
+        doc.contains("does not flash firmware") || doc.contains("flash firmware"),
+        "{doc}"
+    );
+    assert!(doc.contains("does not claim"), "{doc}");
+    assert!(doc.contains("Bootable Base1 image readiness"), "{doc}");
+    assert!(
+        doc.contains("Rollback validation on real hardware"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn libreboot_milestone_lists_current_docs_and_scripts() {
+    let doc = std::fs::read_to_string("base1/LIBREBOOT_MILESTONE.md").expect("libreboot milestone");
+
+    assert!(doc.contains("LIBREBOOT_DOCS_SUMMARY.md"), "{doc}");
+    assert!(doc.contains("LIBREBOOT_QUICKSTART.md"), "{doc}");
+    assert!(doc.contains("LIBREBOOT_COMMAND_INDEX.md"), "{doc}");
+    assert!(doc.contains("LIBREBOOT_VALIDATION_REPORT.md"), "{doc}");
+    assert!(doc.contains("scripts/base1-libreboot-docs.sh"), "{doc}");
+    assert!(doc.contains("scripts/base1-libreboot-validate.sh"), "{doc}");
+    assert!(doc.contains("scripts/base1-libreboot-report.sh"), "{doc}");
+}
+
+#[test]
+fn libreboot_indexes_link_milestone_checkpoint() {
+    let summary =
+        std::fs::read_to_string("base1/LIBREBOOT_DOCS_SUMMARY.md").expect("libreboot docs summary");
+    let index = std::fs::read_to_string("base1/LIBREBOOT_COMMAND_INDEX.md")
+        .expect("libreboot command index");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(summary.contains("LIBREBOOT_MILESTONE.md"), "{summary}");
+    assert!(
+        summary.contains("Libreboot milestone checkpoint"),
+        "{summary}"
+    );
+    assert!(index.contains("LIBREBOOT_MILESTONE.md"), "{index}");
+    assert!(index.contains("Libreboot milestone checkpoint"), "{index}");
+    assert!(readme.contains("base1/LIBREBOOT_MILESTONE.md"), "{readme}");
+    assert!(
+        readme.contains("Libreboot milestone checkpoint"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds a milestone checkpoint for the Libreboot-backed GRUB-first Base1 read-only validation track.

Implements:
- Libreboot milestone checkpoint doc
- Completed docs and scripts inventory
- Validation command set
- Explicit non-claims for bootable image, installer, and hardware readiness
- README, docs summary, and command index links
- Docs tests for milestone coverage

Validation:
- cargo test -p phase1 --test base1_libreboot_milestone_docs
- cargo test -p phase1 --test base1_libreboot_docs_script
- cargo test -p phase1 --test base1_libreboot_docs_summary_docs
- cargo test -p phase1 --test base1_libreboot_command_index_docs
- cargo test -p phase1 --test base1_foundation

Refs #135