### PR TITLE
Add Base1 Libreboot milestone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ sh scripts/base1-preflight.sh
 sh scripts/base1-libreboot-preflight.sh
 sh scripts/base1-libreboot-report.sh
 sh scripts/base1-libreboot-validate.sh
+sh scripts/base1-libreboot-milestone.sh
 sh scripts/base1-libreboot-docs.sh
 sh scripts/base1-libreboot-index.sh
 sh scripts/base1-libreboot-checklist.sh

--- a/base1/LIBREBOOT_COMMAND_INDEX.md
+++ b/base1/LIBREBOOT_COMMAND_INDEX.md
@@ -17,6 +17,7 @@ This document is advisory and read-only. It does not flash firmware, change boot
 
 ## Libreboot scripts
 
+- `scripts/base1-libreboot-milestone.sh`
 - `scripts/base1-libreboot-docs.sh`
 - `scripts/base1-libreboot-report.sh`
 - `scripts/base1-libreboot-validate.sh`

--- a/base1/LIBREBOOT_MILESTONE.md
+++ b/base1/LIBREBOOT_MILESTONE.md
@@ -31,6 +31,7 @@ Documents:
 
 Scripts:
 
+- scripts/base1-libreboot-milestone.sh
 - scripts/base1-libreboot-docs.sh
 - scripts/base1-libreboot-index.sh
 - scripts/base1-libreboot-checklist.sh

--- a/scripts/base1-libreboot-milestone.sh
+++ b/scripts/base1-libreboot-milestone.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 Libreboot milestone
+
+usage:
+  sh scripts/base1-libreboot-milestone.sh
+
+This command is read-only. It prints the Libreboot GRUB-first milestone
+checkpoint and does not change firmware, boot order, /boot, disks, or host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+cat <<'EOF'
+base1 libreboot milestone checkpoint
+firmware profile : Libreboot documented
+hardware profile : X200-class documented
+bootloader       : GRUB first documented
+secureboot       : not assumed
+tpm              : not assumed
+recovery media   : external USB recommended
+emergency shell  : required
+phase1 posture   : safe mode default
+maturity         : documentation and read-only scripts
+writes           : no
+trust            : no host trust escalation
+
+completed surfaces:
+- base1/LIBREBOOT_DOCS_SUMMARY.md
+- base1/LIBREBOOT_QUICKSTART.md
+- base1/LIBREBOOT_COMMAND_INDEX.md
+- base1/LIBREBOOT_MILESTONE.md
+- sh scripts/base1-libreboot-docs.sh
+- sh scripts/base1-libreboot-index.sh
+- sh scripts/base1-libreboot-checklist.sh
+- sh scripts/base1-libreboot-preflight.sh
+- sh scripts/base1-grub-recovery-dry-run.sh --dry-run
+- sh scripts/base1-libreboot-validate.sh
+- sh scripts/base1-libreboot-report.sh
+
+not claimed:
+- bootable Base1 image readiness
+- daily-driver readiness
+- destructive installer readiness
+- automatic GRUB repair
+- hardware recovery validation
+- rollback validation on real hardware
+EOF

--- a/tests/base1_libreboot_milestone_script.rs
+++ b/tests/base1_libreboot_milestone_script.rs
@@ -1,0 +1,104 @@
+use std::process::Command;
+
+#[test]
+fn libreboot_milestone_script_prints_checkpoint_summary() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-libreboot-milestone.sh")
+        .output()
+        .expect("run libreboot milestone script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("base1 libreboot milestone checkpoint"),
+        "{text}"
+    );
+    assert!(
+        text.contains("firmware profile : Libreboot documented"),
+        "{text}"
+    );
+    assert!(
+        text.contains("hardware profile : X200-class documented"),
+        "{text}"
+    );
+    assert!(
+        text.contains("bootloader       : GRUB first documented"),
+        "{text}"
+    );
+    assert!(
+        text.contains("maturity         : documentation and read-only scripts"),
+        "{text}"
+    );
+    assert!(text.contains("writes           : no"), "{text}");
+    assert!(
+        text.contains("trust            : no host trust escalation"),
+        "{text}"
+    );
+}
+
+#[test]
+fn libreboot_milestone_script_lists_surfaces_and_non_claims() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-libreboot-milestone.sh")
+        .output()
+        .expect("run libreboot milestone script");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(text.contains("base1/LIBREBOOT_MILESTONE.md"), "{text}");
+    assert!(
+        text.contains("sh scripts/base1-libreboot-docs.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-libreboot-validate.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-libreboot-report.sh"),
+        "{text}"
+    );
+    assert!(text.contains("bootable Base1 image readiness"), "{text}");
+    assert!(text.contains("daily-driver readiness"), "{text}");
+    assert!(
+        text.contains("rollback validation on real hardware"),
+        "{text}"
+    );
+}
+
+#[test]
+fn libreboot_milestone_script_avoids_mutating_tools_and_sensitive_terms() {
+    let script = std::fs::read_to_string("scripts/base1-libreboot-milestone.sh")
+        .expect("libreboot milestone script");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only Libreboot milestone command for GRUB-first X200-class Base1 systems.

Implements:
- scripts/base1-libreboot-milestone.sh
- milestone checkpoint summary output
- completed docs and scripts inventory
- explicit non-claims for image, installer, and hardware readiness
- README, milestone, and command index updates
- mutating-tool and sensitive-term guard test

Validation:
- cargo test -p phase1 --test base1_libreboot_milestone_script
- cargo test -p phase1 --test base1_libreboot_milestone_docs
- cargo test -p phase1 --test base1_libreboot_docs_script
- cargo test -p phase1 --test base1_libreboot_command_index_docs
- cargo test -p phase1 --test base1_foundation

Refs #135