### PR TITLE
Document Base1 Libreboot checkpoint release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Start here:
 - [`base1/LIBREBOOT_GRUB_RECOVERY.md`](base1/LIBREBOOT_GRUB_RECOVERY.md) — Libreboot GRUB recovery notes
 - [`base1/LIBREBOOT_OPERATOR_CHECKLIST.md`](base1/LIBREBOOT_OPERATOR_CHECKLIST.md) — Libreboot operator checklist
 - [`base1/LIBREBOOT_MILESTONE.md`](base1/LIBREBOOT_MILESTONE.md) — Libreboot milestone checkpoint
+- [`RELEASE_BASE1_LIBREBOOT_READONLY_V1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1.md) — Libreboot read-only checkpoint release notes
 - [`base1/LIBREBOOT_DOCS_SUMMARY.md`](base1/LIBREBOOT_DOCS_SUMMARY.md) — Libreboot docs summary
 - [`base1/LIBREBOOT_QUICKSTART.md`](base1/LIBREBOOT_QUICKSTART.md) — Libreboot quickstart
 - [`base1/LIBREBOOT_COMMAND_INDEX.md`](base1/LIBREBOOT_COMMAND_INDEX.md) — Libreboot command index

--- a/RELEASE_BASE1_LIBREBOOT_READONLY_V1.md
+++ b/RELEASE_BASE1_LIBREBOOT_READONLY_V1.md
@@ -1,0 +1,80 @@
+# Base1 Libreboot read-only validation checkpoint v1
+
+This checkpoint captures the first Libreboot-backed, GRUB-first Base1 validation track.
+
+## Status
+
+- Checkpoint branch: checkpoint/base1-libreboot-readonly-v1
+- Checkpoint tag: base1-libreboot-readonly-v1
+- Firmware profile: Libreboot
+- Hardware profile: ThinkPad X200-class
+- Bootloader expectation: GRUB first
+- Secure Boot: not assumed
+- TPM: not assumed
+- Current maturity: documentation and read-only scripts
+
+## What is included
+
+Documents:
+
+- base1/LIBREBOOT_MILESTONE.md
+- base1/LIBREBOOT_DOCS_SUMMARY.md
+- base1/LIBREBOOT_QUICKSTART.md
+- base1/LIBREBOOT_COMMAND_INDEX.md
+- base1/LIBREBOOT_PROFILE.md
+- base1/LIBREBOOT_PREFLIGHT.md
+- base1/LIBREBOOT_GRUB_RECOVERY.md
+- base1/LIBREBOOT_OPERATOR_CHECKLIST.md
+- base1/LIBREBOOT_VALIDATION_REPORT.md
+
+Scripts:
+
+- scripts/base1-libreboot-milestone.sh
+- scripts/base1-libreboot-docs.sh
+- scripts/base1-libreboot-index.sh
+- scripts/base1-libreboot-checklist.sh
+- scripts/base1-libreboot-preflight.sh
+- scripts/base1-grub-recovery-dry-run.sh --dry-run
+- scripts/base1-libreboot-validate.sh
+- scripts/base1-libreboot-report.sh
+
+## Validation
+
+Run:
+
+    cargo test -p phase1 --test base1_libreboot_milestone_script
+    cargo test -p phase1 --test base1_libreboot_milestone_docs
+    cargo test -p phase1 --test base1_libreboot_docs_script
+    cargo test -p phase1 --test base1_libreboot_docs_summary_docs
+    cargo test -p phase1 --test base1_libreboot_quickstart_docs
+    cargo test -p phase1 --test base1_libreboot_command_index_docs
+    cargo test -p phase1 --test base1_libreboot_validation_report_docs
+    cargo test -p phase1 --test base1_foundation
+
+## Non-claims
+
+This checkpoint does not claim:
+
+- Bootable Base1 image readiness.
+- Daily-driver readiness.
+- Destructive installer readiness.
+- Automatic GRUB repair.
+- Firmware mutation support.
+- Hardware recovery validation.
+- Rollback validation on real hardware.
+
+## Guardrails
+
+- Do not flash firmware automatically.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not change boot order.
+- Do not remove emergency shell access.
+- Do not assume systemd-boot.
+- Do not assume EFI-only boot.
+- Do not store secrets.
+
+## Next milestone
+
+The next milestone should remain read-only unless recovery USB behavior, emergency shell access, rollback metadata, storage layout, and GRUB boot behavior have been validated on the target Libreboot system.

--- a/base1/LIBREBOOT_DOCS_SUMMARY.md
+++ b/base1/LIBREBOOT_DOCS_SUMMARY.md
@@ -60,3 +60,6 @@ The current Libreboot path does not:
 ## Promotion rule
 
 Libreboot-backed Base1 work should stay in read-only docs and dry-runs until recovery media, emergency shell access, rollback metadata, storage layout, and hardware-specific boot behavior are validated on the target machine.
+
+
+See also: [RELEASE_BASE1_LIBREBOOT_READONLY_V1.md](../RELEASE_BASE1_LIBREBOOT_READONLY_V1.md).

--- a/base1/LIBREBOOT_MILESTONE.md
+++ b/base1/LIBREBOOT_MILESTONE.md
@@ -74,3 +74,6 @@ This milestone does not claim:
 ## Promotion rule
 
 The next milestone should stay read-only unless recovery USB behavior, emergency shell access, rollback metadata, storage layout, and GRUB boot behavior have been validated on the target Libreboot system.
+
+
+See also: [RELEASE_BASE1_LIBREBOOT_READONLY_V1.md](../RELEASE_BASE1_LIBREBOOT_READONLY_V1.md).

--- a/tests/base1_libreboot_release_notes_docs.rs
+++ b/tests/base1_libreboot_release_notes_docs.rs
@@ -1,0 +1,59 @@
+#[test]
+fn libreboot_release_notes_record_checkpoint_status() {
+    let doc = std::fs::read_to_string("RELEASE_BASE1_LIBREBOOT_READONLY_V1.md")
+        .expect("libreboot release notes");
+
+    assert!(
+        doc.contains("Base1 Libreboot read-only validation checkpoint v1"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("checkpoint/base1-libreboot-readonly-v1"),
+        "{doc}"
+    );
+    assert!(doc.contains("base1-libreboot-readonly-v1"), "{doc}");
+    assert!(doc.contains("Firmware profile: Libreboot"), "{doc}");
+    assert!(doc.contains("Bootloader expectation: GRUB first"), "{doc}");
+    assert!(doc.contains("documentation and read-only scripts"), "{doc}");
+}
+
+#[test]
+fn libreboot_release_notes_list_surfaces_and_non_claims() {
+    let doc = std::fs::read_to_string("RELEASE_BASE1_LIBREBOOT_READONLY_V1.md")
+        .expect("libreboot release notes");
+
+    assert!(doc.contains("base1/LIBREBOOT_MILESTONE.md"), "{doc}");
+    assert!(
+        doc.contains("scripts/base1-libreboot-milestone.sh"),
+        "{doc}"
+    );
+    assert!(doc.contains("scripts/base1-libreboot-validate.sh"), "{doc}");
+    assert!(doc.contains("Bootable Base1 image readiness"), "{doc}");
+    assert!(doc.contains("Hardware recovery validation"), "{doc}");
+    assert!(
+        doc.contains("Rollback validation on real hardware"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn libreboot_indexes_link_release_notes() {
+    let milestone =
+        std::fs::read_to_string("base1/LIBREBOOT_MILESTONE.md").expect("libreboot milestone");
+    let summary =
+        std::fs::read_to_string("base1/LIBREBOOT_DOCS_SUMMARY.md").expect("libreboot docs summary");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        milestone.contains("RELEASE_BASE1_LIBREBOOT_READONLY_V1.md"),
+        "{milestone}"
+    );
+    assert!(
+        summary.contains("RELEASE_BASE1_LIBREBOOT_READONLY_V1.md"),
+        "{summary}"
+    );
+    assert!(
+        readme.contains("RELEASE_BASE1_LIBREBOOT_READONLY_V1.md"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds release notes for the Libreboot-backed GRUB-first Base1 read-only validation checkpoint.

Implements:
- RELEASE_BASE1_LIBREBOOT_READONLY_V1.md
- checkpoint branch and tag references
- completed docs and scripts inventory
- validation command set
- explicit non-claims and guardrails
- README, milestone, and docs summary links
- docs tests for release notes coverage

Validation:
- cargo test -p phase1 --test base1_libreboot_release_notes_docs
- cargo test -p phase1 --test base1_libreboot_milestone_script
- cargo test -p phase1 --test base1_libreboot_milestone_docs
- cargo test -p phase1 --test base1_libreboot_docs_summary_docs
- cargo test -p phase1 --test base1_foundation

Refs #135