### PR TITLE
Fix duplicate GRUB recovery dry-run output

### DIFF
--- a/scripts/base1-grub-recovery-dry-run.sh
+++ b/scripts/base1-grub-recovery-dry-run.sh
@@ -54,20 +54,3 @@ rollback    : metadata preview only
 trust       : no host trust escalation
 status      : GRUB recovery dry-run complete
 EOF
-
-cat <<'EOF'
-base1 grub recovery dry-run
-firmware    : Libreboot expected
-hardware    : X200-class expected
-bootloader  : GRUB first
-writes      : no
-boot_order  : no change
-boot_config : grub.cfg preview only
-boot_path   : /boot preview only
-emergency   : shell access required
-recovery_usb: recommended
-phase1_auto : no change
-rollback    : metadata preview only
-trust       : no host trust escalation
-status      : GRUB recovery dry-run complete
-EOF

--- a/tests/base1_grub_recovery_dry_run_script.rs
+++ b/tests/base1_grub_recovery_dry_run_script.rs
@@ -28,6 +28,11 @@ fn grub_recovery_dry_run_reports_read_only_recovery_plan() {
 
     assert!(ok, "{text}");
     assert!(text.contains("base1 grub recovery dry-run"), "{text}");
+    assert_eq!(
+        text.matches("base1 grub recovery dry-run").count(),
+        1,
+        "{text}"
+    );
     assert!(text.contains("firmware    : Libreboot expected"), "{text}");
     assert!(text.contains("hardware    : X200-class expected"), "{text}");
     assert!(text.contains("bootloader  : GRUB first"), "{text}");


### PR DESCRIPTION
Ensures the Base1 GRUB recovery dry-run script prints its recovery report once.

Implements:
- Rewrites scripts/base1-grub-recovery-dry-run.sh with one report block
- Adds test coverage that the report header appears exactly once

Validation:
- cargo test -p phase1 --test base1_grub_recovery_dry_run_script
- cargo test -p phase1 --test base1_libreboot_validation_bundle
- cargo test -p phase1 --test base1_libreboot_milestone_script
- cargo test -p phase1 --test base1_libreboot_release_notes_docs
- cargo test -p phase1 --test base1_foundation

Refs #135