### PR TITLE
Document Base1 Libreboot v1.1 patch release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Start here:
 - [`base1/LIBREBOOT_OPERATOR_CHECKLIST.md`](base1/LIBREBOOT_OPERATOR_CHECKLIST.md) — Libreboot operator checklist
 - [`base1/LIBREBOOT_MILESTONE.md`](base1/LIBREBOOT_MILESTONE.md) — Libreboot milestone checkpoint
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1.md) — Libreboot read-only checkpoint release notes
+- [`RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md) — Libreboot read-only checkpoint v1.1 release notes
 - [`base1/LIBREBOOT_DOCS_SUMMARY.md`](base1/LIBREBOOT_DOCS_SUMMARY.md) — Libreboot docs summary
 - [`base1/LIBREBOOT_QUICKSTART.md`](base1/LIBREBOOT_QUICKSTART.md) — Libreboot quickstart
 - [`base1/LIBREBOOT_COMMAND_INDEX.md`](base1/LIBREBOOT_COMMAND_INDEX.md) — Libreboot command index

--- a/RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md
+++ b/RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md
@@ -1,0 +1,34 @@
+# Base1 Libreboot read-only validation checkpoint v1.1
+
+This patch checkpoint updates the first Libreboot-backed, GRUB-first Base1 validation track after the GRUB recovery dry-run output cleanup.
+
+## Status
+
+- Checkpoint branch: checkpoint/base1-libreboot-readonly-v1.1
+- Checkpoint tag: base1-libreboot-readonly-v1.1
+- Previous checkpoint tag: base1-libreboot-readonly-v1
+- Firmware profile: Libreboot
+- Hardware profile: ThinkPad X200-class
+- Bootloader expectation: GRUB first
+- Current maturity: documentation and read-only scripts
+
+## Patch fix
+
+- `scripts/base1-grub-recovery-dry-run.sh` now prints the GRUB recovery report once.
+- `tests/base1_grub_recovery_dry_run_script.rs` verifies the report header appears exactly once.
+
+## Validation
+
+Run:
+
+    cargo test -p phase1 --test base1_grub_recovery_dry_run_script
+    cargo test -p phase1 --test base1_libreboot_validation_bundle
+    cargo test -p phase1 --test base1_libreboot_milestone_script
+    cargo test -p phase1 --test base1_libreboot_release_notes_docs
+    cargo test -p phase1 --test base1_foundation
+
+Expected manual check:
+
+    sh scripts/base1-grub-recovery-dry-run.sh --dry-run | grep -c "base1 grub recovery dry-run"
+
+Expected count: 1

--- a/tests/base1_libreboot_patch_release_notes_docs.rs
+++ b/tests/base1_libreboot_patch_release_notes_docs.rs
@@ -1,0 +1,38 @@
+#[test]
+fn libreboot_patch_release_notes_record_v1_1_checkpoint() {
+    let doc = std::fs::read_to_string("RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md")
+        .expect("libreboot v1.1 release notes");
+
+    assert!(
+        doc.contains("Base1 Libreboot read-only validation checkpoint v1.1"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("checkpoint/base1-libreboot-readonly-v1.1"),
+        "{doc}"
+    );
+    assert!(doc.contains("base1-libreboot-readonly-v1.1"), "{doc}");
+    assert!(
+        doc.contains("Previous checkpoint tag: base1-libreboot-readonly-v1"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("prints the GRUB recovery report once"),
+        "{doc}"
+    );
+    assert!(doc.contains("Expected count: 1"), "{doc}");
+}
+
+#[test]
+fn readme_links_v1_1_patch_release_notes() {
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        readme.contains("RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md"),
+        "{readme}"
+    );
+    assert!(
+        readme.contains("Libreboot read-only checkpoint v1.1 release notes"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds v1.1 patch release notes for the Libreboot-backed GRUB-first Base1 read-only checkpoint.

Implements:
- RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md
- notes for the duplicate GRUB recovery dry-run output fix
- README link
- docs tests for v1.1 release note coverage

Validation:
- cargo test -p phase1 --test base1_libreboot_patch_release_notes_docs
- cargo test -p phase1 --test base1_grub_recovery_dry_run_script
- cargo test -p phase1 --test base1_libreboot_validation_bundle
- cargo test -p phase1 --test base1_foundation

Refs #135