### PR TITLE
Document Base1 recovery USB design

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Start here:
 - [`base1/LIBREBOOT_GRUB_RECOVERY.md`](base1/LIBREBOOT_GRUB_RECOVERY.md) — Libreboot GRUB recovery notes
 - [`base1/LIBREBOOT_OPERATOR_CHECKLIST.md`](base1/LIBREBOOT_OPERATOR_CHECKLIST.md) — Libreboot operator checklist
 - [`base1/LIBREBOOT_MILESTONE.md`](base1/LIBREBOOT_MILESTONE.md) — Libreboot milestone checkpoint
+- [`base1/RECOVERY_USB_DESIGN.md`](base1/RECOVERY_USB_DESIGN.md) — Recovery USB design
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1.md) — Libreboot read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md) — Libreboot read-only checkpoint v1.1 release notes
 - [`base1/LIBREBOOT_DOCS_SUMMARY.md`](base1/LIBREBOOT_DOCS_SUMMARY.md) — Libreboot docs summary

--- a/base1/RECOVERY_USB_DESIGN.md
+++ b/base1/RECOVERY_USB_DESIGN.md
@@ -1,0 +1,67 @@
+# Base1 recovery USB design
+
+The Base1 recovery USB design defines the first safe recovery-media path for Phase1 OS-track work.
+
+This checkpoint is documentation-only and read-only. It does not create USB media, write images, partition disks, install GRUB, edit grub.cfg, flash firmware, or change boot order.
+
+## Goal
+
+Provide an operator-visible recovery USB plan before any recovery media builder exists.
+
+The recovery USB path should help an operator reach a trusted emergency shell, inspect Phase1 state, inspect rollback metadata, and recover from a failed Base1 boot path without weakening the host boundary.
+
+## Target profiles
+
+Initial target profiles:
+
+- Libreboot-backed ThinkPad X200-class systems.
+- GRUB-first boot path.
+- No Secure Boot assumption.
+- No TPM assumption.
+- Keyboard-first recovery.
+- Offline-first notes.
+- External USB recovery media.
+
+## Recovery USB contract
+
+A Base1 recovery USB must document:
+
+- Firmware profile.
+- Hardware profile.
+- Bootloader expectation.
+- USB boot path.
+- Emergency shell path.
+- Phase1 state path.
+- Rollback metadata path.
+- Storage layout preview.
+- Network/offline status.
+- Known hardware limitations.
+
+## Required dry-runs before media creation
+
+Run read-only checks first:
+
+    sh scripts/base1-libreboot-docs.sh
+    sh scripts/base1-libreboot-milestone.sh
+    sh scripts/base1-libreboot-validate.sh
+    sh scripts/base1-grub-recovery-dry-run.sh --dry-run
+    sh scripts/base1-recovery-dry-run.sh --dry-run
+    sh scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example
+
+## Guardrails
+
+- Do not write USB media in this checkpoint.
+- Do not run dd automatically.
+- Do not partition disks.
+- Do not format disks.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not change boot order.
+- Do not flash firmware.
+- Do not store passwords, tokens, private keys, recovery phrases, or personal secrets.
+- Do not remove emergency shell access.
+
+## Promotion rule
+
+A future recovery USB builder can only exist after the dry-run path, target selection, image provenance, checksum verification, rollback metadata, and emergency shell path are documented and tested.

--- a/docs/os/ROADMAP.md
+++ b/docs/os/ROADMAP.md
@@ -165,3 +165,8 @@ Each target needs:
 ## Stage 2 dry-run command index
 
 - [`Base1 dry-run command index`](BASE1_DRY_RUN_COMMANDS.md) lists the current non-destructive Base1 preview commands and their shared guardrails.
+
+
+## Stage 2 recovery USB design
+
+- [`Base1 recovery USB design`](../../base1/RECOVERY_USB_DESIGN.md) defines the first read-only recovery-media plan for Libreboot/X200-class systems without writing USB media or changing boot settings.

--- a/tests/base1_recovery_usb_design_docs.rs
+++ b/tests/base1_recovery_usb_design_docs.rs
@@ -1,0 +1,47 @@
+#[test]
+fn recovery_usb_design_doc_exists_and_defines_read_only_contract() {
+    let doc =
+        std::fs::read_to_string("base1/RECOVERY_USB_DESIGN.md").expect("recovery usb design doc");
+
+    assert!(doc.contains("Base1 recovery USB design"), "{doc}");
+    assert!(doc.contains("documentation-only and read-only"), "{doc}");
+    assert!(
+        doc.contains("Libreboot-backed ThinkPad X200-class"),
+        "{doc}"
+    );
+    assert!(doc.contains("GRUB-first boot path"), "{doc}");
+    assert!(doc.contains("External USB recovery media"), "{doc}");
+    assert!(doc.contains("Emergency shell path"), "{doc}");
+    assert!(doc.contains("Rollback metadata path"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_design_preserves_safety_guardrails() {
+    let doc =
+        std::fs::read_to_string("base1/RECOVERY_USB_DESIGN.md").expect("recovery usb design doc");
+
+    assert!(doc.contains("Do not write USB media"), "{doc}");
+    assert!(doc.contains("Do not run dd automatically"), "{doc}");
+    assert!(doc.contains("Do not partition disks"), "{doc}");
+    assert!(doc.contains("Do not format disks"), "{doc}");
+    assert!(doc.contains("Do not install GRUB automatically"), "{doc}");
+    assert!(doc.contains("Do not write to /boot"), "{doc}");
+    assert!(doc.contains("Do not flash firmware"), "{doc}");
+    assert!(doc.contains("Do not store passwords"), "{doc}");
+}
+
+#[test]
+fn readme_links_recovery_usb_design() {
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(readme.contains("base1/RECOVERY_USB_DESIGN.md"), "{readme}");
+    assert!(readme.contains("Recovery USB design"), "{readme}");
+}
+
+#[test]
+fn os_roadmap_links_recovery_usb_design() {
+    let roadmap = std::fs::read_to_string("docs/os/ROADMAP.md").expect("os roadmap");
+
+    assert!(roadmap.contains("RECOVERY_USB_DESIGN.md"), "{roadmap}");
+    assert!(roadmap.contains("recovery USB design"), "{roadmap}");
+}


### PR DESCRIPTION
Adds a read-only recovery USB design for the Base1 OS-track recovery path.

Implements:
- Base1 recovery USB design doc
- Libreboot/X200-class and GRUB-first target notes
- Emergency shell and rollback metadata contract
- README and OS roadmap links
- Docs tests for recovery USB guardrails

Validation:
- cargo test -p phase1 --test base1_recovery_usb_design_docs
- cargo test -p phase1 --test base1_libreboot_milestone_script
- cargo test -p phase1 --test base1_libreboot_release_notes_docs
- cargo test -p phase1 --test base1_foundation
- cargo test -p phase1 --test os_replacement_track_docs

Refs #135