### PR TITLE
Add Base1 recovery USB dry-run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ sh scripts/base1-preflight.sh
 sh scripts/base1-libreboot-preflight.sh
 sh scripts/base1-libreboot-report.sh
 sh scripts/base1-libreboot-validate.sh
+sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
 sh scripts/base1-libreboot-milestone.sh
 sh scripts/base1-libreboot-docs.sh
 sh scripts/base1-libreboot-index.sh

--- a/base1/RECOVERY_USB_DESIGN.md
+++ b/base1/RECOVERY_USB_DESIGN.md
@@ -44,6 +44,7 @@ Run read-only checks first:
     sh scripts/base1-libreboot-docs.sh
     sh scripts/base1-libreboot-milestone.sh
     sh scripts/base1-libreboot-validate.sh
+    sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
     sh scripts/base1-grub-recovery-dry-run.sh --dry-run
     sh scripts/base1-recovery-dry-run.sh --dry-run
     sh scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example

--- a/scripts/base1-recovery-usb-dry-run.sh
+++ b/scripts/base1-recovery-usb-dry-run.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 recovery USB dry-run
+
+usage:
+  sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target <usb-device>
+
+This command is read-only. It previews recovery USB planning and does not
+write USB media, partition disks, format disks, install GRUB, edit grub.cfg,
+write to /boot, change boot order, flash firmware, or modify host trust.
+EOF
+}
+
+dry_run=0
+target=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --target)
+      if [ "$#" -lt 2 ]; then
+        echo "error: --target requires a value" >&2
+        exit 2
+      fi
+      target="$2"
+      shift 2
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      show_help >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$dry_run" -ne 1 ]; then
+  echo "refusing: --dry-run is required" >&2
+  exit 2
+fi
+
+if [ -z "$target" ]; then
+  echo "error: --target <usb-device> is required" >&2
+  exit 2
+fi
+
+case "$target" in
+  /dev/*|/dev/disk/*)
+    ;;
+  *)
+    echo "error: target must look like a device path under /dev" >&2
+    exit 2
+    ;;
+esac
+
+cat <<EOF
+base1 recovery USB dry-run
+target       : $target
+writes       : no
+firmware     : Libreboot expected
+hardware     : X200-class expected
+bootloader   : GRUB first
+usb_media    : preview only
+image        : not created
+boot_order   : no change
+emergency    : shell path preview
+phase1_state : /state/phase1 preview
+rollback     : metadata preview only
+trust        : no host trust escalation
+status       : recovery USB dry-run complete
+EOF

--- a/tests/base1_recovery_usb_dry_run_script.rs
+++ b/tests/base1_recovery_usb_dry_run_script.rs
@@ -1,0 +1,99 @@
+use std::process::Command;
+
+fn run_script(args: &[&str]) -> (bool, String) {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-dry-run.sh")
+        .args(args)
+        .output()
+        .expect("run recovery USB dry-run script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    (output.status.success(), text)
+}
+
+#[test]
+fn recovery_usb_dry_run_requires_dry_run_flag() {
+    let (ok, text) = run_script(&["--target", "/dev/example"]);
+
+    assert!(!ok, "{text}");
+    assert!(text.contains("refusing: --dry-run is required"), "{text}");
+}
+
+#[test]
+fn recovery_usb_dry_run_requires_target() {
+    let (ok, text) = run_script(&["--dry-run"]);
+
+    assert!(!ok, "{text}");
+    assert!(text.contains("--target <usb-device> is required"), "{text}");
+}
+
+#[test]
+fn recovery_usb_dry_run_rejects_non_device_target() {
+    let (ok, text) = run_script(&["--dry-run", "--target", "usb0"]);
+
+    assert!(!ok, "{text}");
+    assert!(
+        text.contains("target must look like a device path under /dev"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_dry_run_reports_preview_without_writes() {
+    let (ok, text) = run_script(&["--dry-run", "--target", "/dev/example"]);
+
+    assert!(ok, "{text}");
+    assert!(text.contains("base1 recovery USB dry-run"), "{text}");
+    assert!(text.contains("target       : /dev/example"), "{text}");
+    assert!(text.contains("writes       : no"), "{text}");
+    assert!(text.contains("firmware     : Libreboot expected"), "{text}");
+    assert!(
+        text.contains("hardware     : X200-class expected"),
+        "{text}"
+    );
+    assert!(text.contains("bootloader   : GRUB first"), "{text}");
+    assert!(text.contains("usb_media    : preview only"), "{text}");
+    assert!(text.contains("image        : not created"), "{text}");
+    assert!(text.contains("boot_order   : no change"), "{text}");
+    assert!(
+        text.contains("trust        : no host trust escalation"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_dry_run_script_avoids_mutating_tools_and_sensitive_terms() {
+    let script = std::fs::read_to_string("scripts/base1-recovery-usb-dry-run.sh")
+        .expect("recovery USB dry-run script");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only recovery USB dry-run script for Base1 recovery-media planning.

Implements:
- scripts/base1-recovery-usb-dry-run.sh
- --dry-run enforcement
- explicit --target requirement
- Libreboot/X200-class and GRUB-first preview output
- README and recovery USB design updates
- mutating-tool and sensitive-term guard test

Validation:
- cargo test -p phase1 --test base1_recovery_usb_dry_run_script
- cargo test -p phase1 --test base1_recovery_usb_design_docs
- cargo test -p phase1 --test base1_grub_recovery_dry_run_script
- cargo test -p phase1 --test base1_libreboot_validation_bundle
- cargo test -p phase1 --test base1_foundation

Refs #135