### PR TITLE
Document Base1 recovery USB command index

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Start here:
 - [`base1/LIBREBOOT_OPERATOR_CHECKLIST.md`](base1/LIBREBOOT_OPERATOR_CHECKLIST.md) — Libreboot operator checklist
 - [`base1/LIBREBOOT_MILESTONE.md`](base1/LIBREBOOT_MILESTONE.md) — Libreboot milestone checkpoint
 - [`base1/RECOVERY_USB_DESIGN.md`](base1/RECOVERY_USB_DESIGN.md) — Recovery USB design
+- [`base1/RECOVERY_USB_COMMAND_INDEX.md`](base1/RECOVERY_USB_COMMAND_INDEX.md) — Recovery USB command index
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1.md) — Libreboot read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md) — Libreboot read-only checkpoint v1.1 release notes
 - [`base1/LIBREBOOT_DOCS_SUMMARY.md`](base1/LIBREBOOT_DOCS_SUMMARY.md) — Libreboot docs summary

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -1,0 +1,54 @@
+# Base1 recovery USB command index
+
+This index collects the recovery USB planning docs and read-only commands for Base1 recovery-media work.
+
+This document is advisory and read-only. It does not write USB media, partition disks, format disks, install GRUB, edit grub.cfg, write to /boot, flash firmware, change boot order, or modify host trust.
+
+## Recovery USB documents
+
+- `base1/RECOVERY_USB_DESIGN.md` — recovery USB design and safety contract.
+- `base1/LIBREBOOT_DOCS_SUMMARY.md` — Libreboot documentation path.
+- `base1/LIBREBOOT_MILESTONE.md` — Libreboot read-only milestone checkpoint.
+- `base1/LIBREBOOT_VALIDATION_REPORT.md` — validation report template.
+- `RELEASE_BASE1_LIBREBOOT_READONLY_V1.md` — v1 checkpoint release notes.
+- `RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md` — v1.1 patch release notes.
+
+## Recovery USB commands
+
+- `scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example`
+- `scripts/base1-libreboot-validate.sh`
+- `scripts/base1-libreboot-report.sh`
+- `scripts/base1-grub-recovery-dry-run.sh --dry-run`
+- `scripts/base1-recovery-dry-run.sh --dry-run`
+- `scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example`
+
+## Shared guardrails
+
+Every recovery USB document or command must preserve these rules:
+
+- Require dry-run mode for target-specific previews.
+- Make the target device visible.
+- Report writes: no.
+- Do not write USB media.
+- Do not run dd automatically.
+- Do not partition disks.
+- Do not format disks.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not flash firmware.
+- Do not change boot order.
+- Do not store passwords, tokens, private keys, recovery phrases, or personal secrets.
+- Do not remove emergency shell access.
+
+## Operator path
+
+The expected read-only path is:
+
+1. Read the recovery USB design.
+2. Run the Libreboot validation bundle.
+3. Run the recovery USB dry-run with an explicit target.
+4. Confirm emergency shell access.
+5. Confirm rollback metadata location.
+6. Confirm Phase1 state location.
+7. Confirm recovery USB plan without writing media.

--- a/base1/RECOVERY_USB_DESIGN.md
+++ b/base1/RECOVERY_USB_DESIGN.md
@@ -66,3 +66,6 @@ Run read-only checks first:
 ## Promotion rule
 
 A future recovery USB builder can only exist after the dry-run path, target selection, image provenance, checksum verification, rollback metadata, and emergency shell path are documented and tested.
+
+
+See also: [Recovery USB command index](RECOVERY_USB_COMMAND_INDEX.md).

--- a/tests/base1_recovery_usb_command_index_docs.rs
+++ b/tests/base1_recovery_usb_command_index_docs.rs
@@ -1,0 +1,59 @@
+#[test]
+fn recovery_usb_command_index_lists_docs_and_commands() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_COMMAND_INDEX.md")
+        .expect("recovery usb command index");
+
+    assert!(doc.contains("Base1 recovery USB command index"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_DESIGN.md"), "{doc}");
+    assert!(doc.contains("LIBREBOOT_MILESTONE.md"), "{doc}");
+    assert!(doc.contains("LIBREBOOT_VALIDATION_REPORT.md"), "{doc}");
+    assert!(
+        doc.contains("RELEASE_BASE1_LIBREBOOT_READONLY_V1.md"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example"),
+        "{doc}"
+    );
+    assert!(doc.contains("scripts/base1-libreboot-validate.sh"), "{doc}");
+    assert!(
+        doc.contains("scripts/base1-grub-recovery-dry-run.sh --dry-run"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_command_index_preserves_guardrails() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_COMMAND_INDEX.md")
+        .expect("recovery usb command index");
+
+    assert!(doc.contains("Require dry-run mode"), "{doc}");
+    assert!(doc.contains("Make the target device visible"), "{doc}");
+    assert!(doc.contains("Report writes: no"), "{doc}");
+    assert!(doc.contains("Do not write USB media"), "{doc}");
+    assert!(doc.contains("Do not run dd automatically"), "{doc}");
+    assert!(doc.contains("Do not partition disks"), "{doc}");
+    assert!(doc.contains("Do not format disks"), "{doc}");
+    assert!(doc.contains("Do not install GRUB automatically"), "{doc}");
+    assert!(doc.contains("Do not write to /boot"), "{doc}");
+    assert!(doc.contains("Do not store passwords"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_design_and_readme_link_command_index() {
+    let design =
+        std::fs::read_to_string("base1/RECOVERY_USB_DESIGN.md").expect("recovery usb design");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(design.contains("RECOVERY_USB_COMMAND_INDEX.md"), "{design}");
+    assert!(design.contains("Recovery USB command index"), "{design}");
+    assert!(
+        readme.contains("base1/RECOVERY_USB_COMMAND_INDEX.md"),
+        "{readme}"
+    );
+    assert!(readme.contains("Recovery USB command index"), "{readme}");
+}


### PR DESCRIPTION
Adds a command index for Base1 recovery USB planning.

Implements:
- Recovery USB command index
- Links to recovery USB design and related Libreboot validation surfaces
- Read-only recovery USB command list
- Shared recovery USB guardrails
- README and recovery USB design links
- Docs tests for command index coverage

Validation:
- cargo test -p phase1 --test base1_recovery_usb_command_index_docs
- cargo test -p phase1 --test base1_recovery_usb_dry_run_script
- cargo test -p phase1 --test base1_recovery_usb_design_docs
- cargo test -p phase1 --test base1_libreboot_validation_bundle
- cargo test -p phase1 --test base1_foundation

Refs #135