### PR TITLE
Add Base1 recovery USB validation bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ sh scripts/base1-preflight.sh
 sh scripts/base1-libreboot-preflight.sh
 sh scripts/base1-libreboot-report.sh
 sh scripts/base1-libreboot-validate.sh
+sh scripts/base1-recovery-usb-validate.sh
 sh scripts/base1-recovery-usb-index.sh
 sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
 sh scripts/base1-libreboot-milestone.sh

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -15,6 +15,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 
 ## Recovery USB commands
 
+- `scripts/base1-recovery-usb-validate.sh`
 - `scripts/base1-recovery-usb-index.sh`
 - `scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example`
 - `scripts/base1-libreboot-validate.sh`

--- a/base1/RECOVERY_USB_DESIGN.md
+++ b/base1/RECOVERY_USB_DESIGN.md
@@ -44,6 +44,7 @@ Run read-only checks first:
     sh scripts/base1-libreboot-docs.sh
     sh scripts/base1-libreboot-milestone.sh
     sh scripts/base1-libreboot-validate.sh
+    sh scripts/base1-recovery-usb-validate.sh
     sh scripts/base1-recovery-usb-index.sh
     sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
     sh scripts/base1-grub-recovery-dry-run.sh --dry-run

--- a/scripts/base1-recovery-usb-validate.sh
+++ b/scripts/base1-recovery-usb-validate.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 recovery USB validation bundle
+
+usage:
+  sh scripts/base1-recovery-usb-validate.sh
+
+This command is read-only. It runs recovery USB planning previews without
+writing USB media, changing boot settings, writing to /boot, modifying disks,
+or changing host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+run_cmd() {
+  echo
+  echo "$ $*"
+  "$@"
+}
+
+cat <<'EOF'
+base1 recovery USB validation bundle
+mode      : read-only
+writes    : no
+firmware  : Libreboot expected
+hardware  : X200-class expected
+bootloader: GRUB first
+target    : /dev/example preview
+trust     : no host trust escalation
+EOF
+
+run_cmd sh scripts/base1-recovery-usb-index.sh
+run_cmd sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
+run_cmd sh scripts/base1-libreboot-validate.sh
+run_cmd sh scripts/base1-grub-recovery-dry-run.sh --dry-run
+run_cmd sh scripts/base1-recovery-dry-run.sh --dry-run
+run_cmd sh scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example
+
+echo
+echo "base1 recovery USB validation bundle complete"

--- a/tests/base1_recovery_usb_validation_bundle.rs
+++ b/tests/base1_recovery_usb_validation_bundle.rs
@@ -1,0 +1,81 @@
+use std::process::Command;
+
+#[test]
+fn recovery_usb_validation_bundle_runs_read_only_previews() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-validate.sh")
+        .output()
+        .expect("run recovery USB validation bundle");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("base1 recovery USB validation bundle"),
+        "{text}"
+    );
+    assert!(text.contains("mode      : read-only"), "{text}");
+    assert!(text.contains("writes    : no"), "{text}");
+    assert!(text.contains("firmware  : Libreboot expected"), "{text}");
+    assert!(text.contains("hardware  : X200-class expected"), "{text}");
+    assert!(text.contains("bootloader: GRUB first"), "{text}");
+    assert!(text.contains("base1 recovery USB command index"), "{text}");
+    assert!(text.contains("base1 recovery USB dry-run"), "{text}");
+    assert!(text.contains("base1 libreboot validation bundle"), "{text}");
+    assert!(
+        text.contains("base1 recovery USB validation bundle complete"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_validation_bundle_help_is_read_only() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-validate.sh")
+        .arg("--help")
+        .output()
+        .expect("run recovery USB validation help");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("read-only"), "{text}");
+    assert!(text.contains("without"), "{text}");
+    assert!(text.contains("host trust"), "{text}");
+}
+
+#[test]
+fn recovery_usb_validation_bundle_avoids_mutating_tools_and_sensitive_terms() {
+    let script = std::fs::read_to_string("scripts/base1-recovery-usb-validate.sh")
+        .expect("recovery USB validation bundle");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only recovery USB validation bundle for Base1 recovery-media planning.

Implements:
- scripts/base1-recovery-usb-validate.sh
- grouped recovery USB preview command runner
- Libreboot/X200-class and GRUB-first validation summary
- README, recovery USB design, and command index updates
- mutating-tool and sensitive-term guard test

Validation:
- cargo test -p phase1 --test base1_recovery_usb_validation_bundle
- cargo test -p phase1 --test base1_recovery_usb_index_script
- cargo test -p phase1 --test base1_recovery_usb_command_index_docs
- cargo test -p phase1 --test base1_recovery_usb_dry_run_script
- cargo test -p phase1 --test base1_foundation

Refs #135