### PR TITLE
Document Base1 recovery USB validation report

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Start here:
 - [`base1/LIBREBOOT_MILESTONE.md`](base1/LIBREBOOT_MILESTONE.md) — Libreboot milestone checkpoint
 - [`base1/RECOVERY_USB_DESIGN.md`](base1/RECOVERY_USB_DESIGN.md) — Recovery USB design
 - [`base1/RECOVERY_USB_COMMAND_INDEX.md`](base1/RECOVERY_USB_COMMAND_INDEX.md) — Recovery USB command index
+- [`base1/RECOVERY_USB_VALIDATION_REPORT.md`](base1/RECOVERY_USB_VALIDATION_REPORT.md) — Recovery USB validation report
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1.md) — Libreboot read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md) — Libreboot read-only checkpoint v1.1 release notes
 - [`base1/LIBREBOOT_DOCS_SUMMARY.md`](base1/LIBREBOOT_DOCS_SUMMARY.md) — Libreboot docs summary

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -7,6 +7,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 ## Recovery USB documents
 
 - `base1/RECOVERY_USB_DESIGN.md` — recovery USB design and safety contract.
+- `base1/RECOVERY_USB_VALIDATION_REPORT.md` — Recovery USB validation report.
 - `base1/LIBREBOOT_DOCS_SUMMARY.md` — Libreboot documentation path.
 - `base1/LIBREBOOT_MILESTONE.md` — Libreboot read-only milestone checkpoint.
 - `base1/LIBREBOOT_VALIDATION_REPORT.md` — validation report template.

--- a/base1/RECOVERY_USB_DESIGN.md
+++ b/base1/RECOVERY_USB_DESIGN.md
@@ -71,3 +71,6 @@ A future recovery USB builder can only exist after the dry-run path, target sele
 
 
 See also: [Recovery USB command index](RECOVERY_USB_COMMAND_INDEX.md).
+
+
+See also: [Recovery USB validation report](RECOVERY_USB_VALIDATION_REPORT.md).

--- a/base1/RECOVERY_USB_VALIDATION_REPORT.md
+++ b/base1/RECOVERY_USB_VALIDATION_REPORT.md
@@ -1,0 +1,68 @@
+# Base1 recovery USB validation report
+
+This report template records operator-visible validation for Base1 recovery USB planning.
+
+This document is advisory and read-only. Do not store passwords, tokens, private keys, recovery phrases, or personal secrets here.
+
+## Target summary
+
+- Recovery media: external USB planned.
+- Firmware profile: Libreboot expected.
+- Hardware profile: X200-class expected.
+- Bootloader expectation: GRUB first.
+- Secure Boot: not assumed.
+- TPM: not assumed.
+- Emergency shell: required.
+- Phase1 state path: /state/phase1 preview.
+- Rollback metadata path: /recovery preview.
+- Current maturity: read-only planning and dry-runs.
+
+## Validation commands
+
+Run and record whether each command completed:
+
+    sh scripts/base1-recovery-usb-index.sh
+    sh scripts/base1-recovery-usb-validate.sh
+    sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
+    sh scripts/base1-libreboot-validate.sh
+    sh scripts/base1-grub-recovery-dry-run.sh --dry-run
+    sh scripts/base1-recovery-dry-run.sh --dry-run
+    sh scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example
+
+## Operator confirmations
+
+Record yes/no/status:
+
+- I can identify the intended USB recovery target.
+- I understand this checkpoint does not write USB media.
+- I can reach the GRUB menu.
+- I know the normal boot path.
+- I know the recovery boot path.
+- I can reach an emergency shell.
+- I know where Phase1 state should live.
+- I know where rollback metadata should live.
+- I understand wireless firmware limitations.
+- I understand clock drift risk.
+- I understand no firmware, GRUB, /boot, disk, or boot-order mutation should be automatic.
+
+## Guardrails
+
+- Do not write USB media.
+- Do not run dd automatically.
+- Do not partition disks.
+- Do not format disks.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not change boot order.
+- Do not flash firmware.
+- Do not remove emergency shell access.
+- Do not store secrets.
+
+## Result
+
+Status: not validated yet.
+
+Notes:
+
+- Add hardware-specific notes here after running read-only checks.

--- a/tests/base1_recovery_usb_validation_report_docs.rs
+++ b/tests/base1_recovery_usb_validation_report_docs.rs
@@ -1,0 +1,77 @@
+#[test]
+fn recovery_usb_validation_report_template_defines_safe_target_summary() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_VALIDATION_REPORT.md")
+        .expect("recovery USB validation report");
+
+    assert!(
+        doc.contains("Base1 recovery USB validation report"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Recovery media: external USB planned"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Firmware profile: Libreboot expected"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Hardware profile: X200-class expected"),
+        "{doc}"
+    );
+    assert!(doc.contains("Bootloader expectation: GRUB first"), "{doc}");
+    assert!(doc.contains("Emergency shell: required"), "{doc}");
+    assert!(
+        doc.contains("Phase1 state path: /state/phase1 preview"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Rollback metadata path: /recovery preview"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("sh scripts/base1-recovery-usb-validate.sh"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_validation_report_preserves_guardrails() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_VALIDATION_REPORT.md")
+        .expect("recovery USB validation report");
+
+    assert!(doc.contains("Do not write USB media"), "{doc}");
+    assert!(doc.contains("Do not run dd automatically"), "{doc}");
+    assert!(doc.contains("Do not partition disks"), "{doc}");
+    assert!(doc.contains("Do not format disks"), "{doc}");
+    assert!(doc.contains("Do not install GRUB automatically"), "{doc}");
+    assert!(doc.contains("Do not write to /boot"), "{doc}");
+    assert!(doc.contains("Do not flash firmware"), "{doc}");
+    assert!(doc.contains("Do not store secrets"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_command_index_links_validation_report() {
+    let index = std::fs::read_to_string("base1/RECOVERY_USB_COMMAND_INDEX.md")
+        .expect("recovery USB command index");
+
+    assert!(
+        index.contains("RECOVERY_USB_VALIDATION_REPORT.md"),
+        "{index}"
+    );
+    assert!(index.contains("Recovery USB validation report"), "{index}");
+}
+
+#[test]
+fn readme_links_recovery_usb_validation_report() {
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        readme.contains("base1/RECOVERY_USB_VALIDATION_REPORT.md"),
+        "{readme}"
+    );
+    assert!(
+        readme.contains("Recovery USB validation report"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds a validation report template for Base1 recovery USB planning.

Implements:
- Recovery USB validation report template
- Operator confirmation checklist
- Guardrails against USB media, GRUB, /boot, disk, firmware, and secret mutation
- README, recovery USB design, and command index links
- Docs tests for validation report coverage

Validation:
- cargo test -p phase1 --test base1_recovery_usb_validation_report_docs
- cargo test -p phase1 --test base1_recovery_usb_validation_bundle
- cargo test -p phase1 --test base1_recovery_usb_command_index_docs
- cargo test -p phase1 --test base1_recovery_usb_design_docs
- cargo test -p phase1 --test base1_foundation

Refs #135