### PR TITLE
Document Base1 recovery USB hardware checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Start here:
 - [`base1/RECOVERY_USB_DESIGN.md`](base1/RECOVERY_USB_DESIGN.md) — Recovery USB design
 - [`base1/RECOVERY_USB_COMMAND_INDEX.md`](base1/RECOVERY_USB_COMMAND_INDEX.md) — Recovery USB command index
 - [`base1/RECOVERY_USB_VALIDATION_REPORT.md`](base1/RECOVERY_USB_VALIDATION_REPORT.md) — Recovery USB validation report
+- [`base1/RECOVERY_USB_HARDWARE_CHECKLIST.md`](base1/RECOVERY_USB_HARDWARE_CHECKLIST.md) — Recovery USB hardware validation checklist
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1.md) — Libreboot read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md) — Libreboot read-only checkpoint v1.1 release notes
 - [`base1/LIBREBOOT_DOCS_SUMMARY.md`](base1/LIBREBOOT_DOCS_SUMMARY.md) — Libreboot docs summary

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -8,6 +8,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 
 - `base1/RECOVERY_USB_DESIGN.md` — recovery USB design and safety contract.
 - `base1/RECOVERY_USB_VALIDATION_REPORT.md` — Recovery USB validation report.
+- `base1/RECOVERY_USB_HARDWARE_CHECKLIST.md` — Recovery USB hardware validation checklist.
 - `base1/LIBREBOOT_DOCS_SUMMARY.md` — Libreboot documentation path.
 - `base1/LIBREBOOT_MILESTONE.md` — Libreboot read-only milestone checkpoint.
 - `base1/LIBREBOOT_VALIDATION_REPORT.md` — validation report template.

--- a/base1/RECOVERY_USB_DESIGN.md
+++ b/base1/RECOVERY_USB_DESIGN.md
@@ -74,3 +74,6 @@ See also: [Recovery USB command index](RECOVERY_USB_COMMAND_INDEX.md).
 
 
 See also: [Recovery USB validation report](RECOVERY_USB_VALIDATION_REPORT.md).
+
+
+See also: [Recovery USB hardware validation checklist](RECOVERY_USB_HARDWARE_CHECKLIST.md).

--- a/base1/RECOVERY_USB_HARDWARE_CHECKLIST.md
+++ b/base1/RECOVERY_USB_HARDWARE_CHECKLIST.md
@@ -1,0 +1,76 @@
+# Base1 recovery USB hardware validation checklist
+
+This checklist records the first real-hardware validation path for Base1 recovery USB planning.
+
+This document is advisory and read-only. It does not write USB media, partition disks, format disks, install GRUB, edit grub.cfg, write to /boot, flash firmware, change boot order, or modify host trust.
+
+## Target
+
+Initial target:
+
+- Firmware profile: Libreboot.
+- Hardware profile: ThinkPad X200-class.
+- Bootloader expectation: GRUB first.
+- Recovery media: external USB.
+- Secure Boot: not assumed.
+- TPM: not assumed.
+- Recovery posture: keyboard-first and offline-first.
+- Current maturity: operator checklist only.
+
+## Before hardware validation
+
+Confirm:
+
+- The target machine is the intended Libreboot-backed X200-class system.
+- The USB device is physically identified.
+- The USB device is not a data drive that needs preservation.
+- The operator can reach the GRUB menu.
+- The operator can reach a fallback shell or emergency shell.
+- The operator knows the normal boot path.
+- The operator knows the recovery boot path.
+
+## Read-only validation commands
+
+Run these before any future USB-writing work:
+
+    sh scripts/base1-recovery-usb-index.sh
+    sh scripts/base1-recovery-usb-validate.sh
+    sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
+    sh scripts/base1-libreboot-validate.sh
+    sh scripts/base1-grub-recovery-dry-run.sh --dry-run
+    sh scripts/base1-recovery-dry-run.sh --dry-run
+
+## Hardware observations to record
+
+Record yes/no/notes:
+
+- GRUB menu reachable.
+- USB boot option visible.
+- External USB device physically labeled.
+- Keyboard works in boot menu.
+- Display is readable in boot/recovery mode.
+- Emergency shell path is known.
+- Recovery path is known.
+- Phase1 state path is known.
+- Rollback metadata path is known.
+- Wireless limitations are known.
+- Clock drift risk is known.
+- Power/battery behavior is known.
+
+## Guardrails
+
+- Do not write USB media in this checklist.
+- Do not run dd automatically.
+- Do not partition disks.
+- Do not format disks.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not change boot order.
+- Do not flash firmware.
+- Do not store passwords, tokens, private keys, recovery phrases, or personal secrets.
+- Do not claim hardware recovery readiness until the checklist is completed on the target machine.
+
+## Promotion rule
+
+A recovery USB media builder can only follow after this checklist, the validation report, target-device selection, image provenance, checksum verification, emergency shell path, and rollback metadata path are documented and tested.

--- a/base1/RECOVERY_USB_VALIDATION_REPORT.md
+++ b/base1/RECOVERY_USB_VALIDATION_REPORT.md
@@ -66,3 +66,6 @@ Status: not validated yet.
 Notes:
 
 - Add hardware-specific notes here after running read-only checks.
+
+
+See also: [Recovery USB hardware validation checklist](RECOVERY_USB_HARDWARE_CHECKLIST.md).

--- a/tests/base1_recovery_usb_hardware_checklist_docs.rs
+++ b/tests/base1_recovery_usb_hardware_checklist_docs.rs
@@ -1,0 +1,82 @@
+#[test]
+fn recovery_usb_hardware_checklist_defines_target_and_read_only_path() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_HARDWARE_CHECKLIST.md")
+        .expect("recovery usb hardware checklist");
+
+    assert!(
+        doc.contains("Base1 recovery USB hardware validation checklist"),
+        "{doc}"
+    );
+    assert!(doc.contains("advisory and read-only"), "{doc}");
+    assert!(doc.contains("Firmware profile: Libreboot"), "{doc}");
+    assert!(
+        doc.contains("Hardware profile: ThinkPad X200-class"),
+        "{doc}"
+    );
+    assert!(doc.contains("Bootloader expectation: GRUB first"), "{doc}");
+    assert!(doc.contains("Recovery media: external USB"), "{doc}");
+    assert!(
+        doc.contains("Current maturity: operator checklist only"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("sh scripts/base1-recovery-usb-validate.sh"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_hardware_checklist_records_hardware_observations() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_HARDWARE_CHECKLIST.md")
+        .expect("recovery usb hardware checklist");
+
+    assert!(doc.contains("GRUB menu reachable"), "{doc}");
+    assert!(doc.contains("USB boot option visible"), "{doc}");
+    assert!(doc.contains("Keyboard works in boot menu"), "{doc}");
+    assert!(doc.contains("Display is readable"), "{doc}");
+    assert!(doc.contains("Emergency shell path is known"), "{doc}");
+    assert!(doc.contains("Rollback metadata path is known"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_hardware_checklist_preserves_guardrails() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_HARDWARE_CHECKLIST.md")
+        .expect("recovery usb hardware checklist");
+
+    assert!(doc.contains("Do not write USB media"), "{doc}");
+    assert!(doc.contains("Do not run dd automatically"), "{doc}");
+    assert!(doc.contains("Do not partition disks"), "{doc}");
+    assert!(doc.contains("Do not format disks"), "{doc}");
+    assert!(doc.contains("Do not install GRUB automatically"), "{doc}");
+    assert!(doc.contains("Do not edit grub.cfg automatically"), "{doc}");
+    assert!(doc.contains("Do not write to /boot"), "{doc}");
+    assert!(doc.contains("Do not change boot order"), "{doc}");
+    assert!(doc.contains("Do not flash firmware"), "{doc}");
+    assert!(doc.contains("Do not store passwords"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_surfaces_link_hardware_checklist() {
+    let index = std::fs::read_to_string("base1/RECOVERY_USB_COMMAND_INDEX.md")
+        .expect("recovery usb command index");
+    let report = std::fs::read_to_string("base1/RECOVERY_USB_VALIDATION_REPORT.md")
+        .expect("recovery usb validation report");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        index.contains("RECOVERY_USB_HARDWARE_CHECKLIST.md"),
+        "{index}"
+    );
+    assert!(
+        index.contains("Recovery USB hardware validation checklist"),
+        "{index}"
+    );
+    assert!(
+        report.contains("RECOVERY_USB_HARDWARE_CHECKLIST.md"),
+        "{report}"
+    );
+    assert!(
+        readme.contains("base1/RECOVERY_USB_HARDWARE_CHECKLIST.md"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds a read-only hardware validation checklist for Base1 recovery USB planning.

Implements:
- Recovery USB hardware validation checklist
- Libreboot/X200-class and GRUB-first target observations
- hardware observation checklist
- README, recovery USB design, command index, and validation report links
- docs tests for checklist coverage and guardrails

Validation:
- cargo test -p phase1 --test base1_recovery_usb_hardware_checklist_docs
- cargo test -p phase1 --test base1_recovery_usb_validation_report_docs
- cargo test -p phase1 --test base1_recovery_usb_command_index_docs
- cargo test -p phase1 --test base1_recovery_usb_validation_bundle
- cargo test -p phase1 --test base1_foundation

Refs #135