### PR TITLE
Add Base1 recovery USB hardware checklist command

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ sh scripts/base1-libreboot-preflight.sh
 sh scripts/base1-libreboot-report.sh
 sh scripts/base1-libreboot-validate.sh
 sh scripts/base1-recovery-usb-validate.sh
+sh scripts/base1-recovery-usb-hardware-checklist.sh
 sh scripts/base1-recovery-usb-index.sh
 sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
 sh scripts/base1-libreboot-milestone.sh

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -17,6 +17,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 
 ## Recovery USB commands
 
+- `scripts/base1-recovery-usb-hardware-checklist.sh`
 - `scripts/base1-recovery-usb-validate.sh`
 - `scripts/base1-recovery-usb-index.sh`
 - `scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example`

--- a/base1/RECOVERY_USB_HARDWARE_CHECKLIST.md
+++ b/base1/RECOVERY_USB_HARDWARE_CHECKLIST.md
@@ -33,6 +33,7 @@ Confirm:
 
 Run these before any future USB-writing work:
 
+    sh scripts/base1-recovery-usb-hardware-checklist.sh
     sh scripts/base1-recovery-usb-index.sh
     sh scripts/base1-recovery-usb-validate.sh
     sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example

--- a/scripts/base1-recovery-usb-hardware-checklist.sh
+++ b/scripts/base1-recovery-usb-hardware-checklist.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 recovery USB hardware checklist
+
+usage:
+  sh scripts/base1-recovery-usb-hardware-checklist.sh
+
+This command is read-only. It prints the recovery USB hardware validation
+checklist without writing USB media, changing boot settings, writing to /boot,
+modifying disks, flashing firmware, or changing host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+cat <<'EOF'
+base1 recovery USB hardware checklist
+mode       : read-only
+writes     : no
+firmware   : Libreboot expected
+hardware   : X200-class expected
+bootloader : GRUB first
+media      : external USB planned
+secureboot : not assumed
+tpm        : not assumed
+trust      : no host trust escalation
+
+confirm before hardware validation:
+- target machine is Libreboot-backed X200-class
+- USB device is physically identified
+- USB device is not a data drive needing preservation
+- GRUB menu is reachable
+- fallback or emergency shell path is known
+- normal boot path is known
+- recovery boot path is known
+
+record observations:
+- GRUB menu reachable: unknown
+- USB boot option visible: unknown
+- external USB device labeled: unknown
+- keyboard works in boot menu: unknown
+- display readable in recovery mode: unknown
+- emergency shell path known: unknown
+- Phase1 state path known: unknown
+- rollback metadata path known: unknown
+- wireless limitations known: unknown
+- clock drift risk known: unknown
+
+status: checklist not completed on hardware
+EOF

--- a/tests/base1_recovery_usb_hardware_checklist_script.rs
+++ b/tests/base1_recovery_usb_hardware_checklist_script.rs
@@ -1,0 +1,100 @@
+use std::process::Command;
+
+#[test]
+fn recovery_usb_hardware_checklist_script_prints_read_only_checklist() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-hardware-checklist.sh")
+        .output()
+        .expect("run recovery USB hardware checklist script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("base1 recovery USB hardware checklist"),
+        "{text}"
+    );
+    assert!(text.contains("mode       : read-only"), "{text}");
+    assert!(text.contains("writes     : no"), "{text}");
+    assert!(text.contains("firmware   : Libreboot expected"), "{text}");
+    assert!(text.contains("hardware   : X200-class expected"), "{text}");
+    assert!(text.contains("bootloader : GRUB first"), "{text}");
+    assert!(text.contains("media      : external USB planned"), "{text}");
+    assert!(
+        text.contains("trust      : no host trust escalation"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_hardware_checklist_script_lists_observations() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-hardware-checklist.sh")
+        .output()
+        .expect("run recovery USB hardware checklist script");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(text.contains("GRUB menu reachable: unknown"), "{text}");
+    assert!(text.contains("USB boot option visible: unknown"), "{text}");
+    assert!(
+        text.contains("external USB device labeled: unknown"),
+        "{text}"
+    );
+    assert!(
+        text.contains("keyboard works in boot menu: unknown"),
+        "{text}"
+    );
+    assert!(
+        text.contains("display readable in recovery mode: unknown"),
+        "{text}"
+    );
+    assert!(
+        text.contains("emergency shell path known: unknown"),
+        "{text}"
+    );
+    assert!(
+        text.contains("rollback metadata path known: unknown"),
+        "{text}"
+    );
+    assert!(
+        text.contains("checklist not completed on hardware"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_hardware_checklist_script_avoids_mutating_tools_and_sensitive_terms() {
+    let script = std::fs::read_to_string("scripts/base1-recovery-usb-hardware-checklist.sh")
+        .expect("recovery USB hardware checklist script");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only recovery USB hardware checklist command for Base1 recovery-media planning.

Implements:
- scripts/base1-recovery-usb-hardware-checklist.sh
- read-only hardware checklist output
- Libreboot/X200-class and GRUB-first target summary
- hardware observation placeholders
- README, recovery USB checklist, and command index updates
- mutating-tool and sensitive-term guard test

Validation:
- cargo test -p phase1 --test base1_recovery_usb_hardware_checklist_script
- cargo test -p phase1 --test base1_recovery_usb_hardware_checklist_docs
- cargo test -p phase1 --test base1_recovery_usb_validation_report_docs
- cargo test -p phase1 --test base1_recovery_usb_command_index_docs
- cargo test -p phase1 --test base1_foundation

Refs #135