### PR TITLE
Add Base1 recovery USB hardware validation bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ sh scripts/base1-libreboot-preflight.sh
 sh scripts/base1-libreboot-report.sh
 sh scripts/base1-libreboot-validate.sh
 sh scripts/base1-recovery-usb-validate.sh
+sh scripts/base1-recovery-usb-hardware-validate.sh
 sh scripts/base1-recovery-usb-hardware-checklist.sh
 sh scripts/base1-recovery-usb-index.sh
 sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -17,6 +17,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 
 ## Recovery USB commands
 
+- `scripts/base1-recovery-usb-hardware-validate.sh`
 - `scripts/base1-recovery-usb-hardware-checklist.sh`
 - `scripts/base1-recovery-usb-validate.sh`
 - `scripts/base1-recovery-usb-index.sh`

--- a/base1/RECOVERY_USB_HARDWARE_CHECKLIST.md
+++ b/base1/RECOVERY_USB_HARDWARE_CHECKLIST.md
@@ -33,6 +33,7 @@ Confirm:
 
 Run these before any future USB-writing work:
 
+    sh scripts/base1-recovery-usb-hardware-validate.sh
     sh scripts/base1-recovery-usb-hardware-checklist.sh
     sh scripts/base1-recovery-usb-index.sh
     sh scripts/base1-recovery-usb-validate.sh

--- a/base1/RECOVERY_USB_VALIDATION_REPORT.md
+++ b/base1/RECOVERY_USB_VALIDATION_REPORT.md
@@ -22,6 +22,7 @@ This document is advisory and read-only. Do not store passwords, tokens, private
 Run and record whether each command completed:
 
     sh scripts/base1-recovery-usb-index.sh
+    sh scripts/base1-recovery-usb-hardware-validate.sh
     sh scripts/base1-recovery-usb-validate.sh
     sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
     sh scripts/base1-libreboot-validate.sh

--- a/scripts/base1-recovery-usb-hardware-validate.sh
+++ b/scripts/base1-recovery-usb-hardware-validate.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 recovery USB hardware validation bundle
+
+usage:
+  sh scripts/base1-recovery-usb-hardware-validate.sh
+
+This command is read-only. It runs recovery USB hardware checklist and preview
+commands without writing USB media, changing boot settings, writing to /boot,
+modifying disks, flashing firmware, or changing host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+run_cmd() {
+  echo
+  echo "$ $*"
+  "$@"
+}
+
+cat <<'EOF'
+base1 recovery USB hardware validation bundle
+mode       : read-only
+writes     : no
+firmware   : Libreboot expected
+hardware   : X200-class expected
+bootloader : GRUB first
+media      : external USB planned
+secureboot : not assumed
+tpm        : not assumed
+trust      : no host trust escalation
+status     : hardware validation preview only
+EOF
+
+run_cmd sh scripts/base1-recovery-usb-hardware-checklist.sh
+run_cmd sh scripts/base1-recovery-usb-index.sh
+run_cmd sh scripts/base1-recovery-usb-validate.sh
+run_cmd sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
+run_cmd sh scripts/base1-libreboot-validate.sh
+run_cmd sh scripts/base1-grub-recovery-dry-run.sh --dry-run
+
+echo
+echo "base1 recovery USB hardware validation bundle complete"

--- a/tests/base1_recovery_usb_hardware_validation_bundle.rs
+++ b/tests/base1_recovery_usb_hardware_validation_bundle.rs
@@ -1,0 +1,89 @@
+use std::process::Command;
+
+#[test]
+fn recovery_usb_hardware_validation_bundle_runs_read_only_previews() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-hardware-validate.sh")
+        .output()
+        .expect("run recovery USB hardware validation bundle");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("base1 recovery USB hardware validation bundle"),
+        "{text}"
+    );
+    assert!(text.contains("mode       : read-only"), "{text}");
+    assert!(text.contains("writes     : no"), "{text}");
+    assert!(text.contains("firmware   : Libreboot expected"), "{text}");
+    assert!(text.contains("hardware   : X200-class expected"), "{text}");
+    assert!(text.contains("bootloader : GRUB first"), "{text}");
+    assert!(
+        text.contains("base1 recovery USB hardware checklist"),
+        "{text}"
+    );
+    assert!(text.contains("base1 recovery USB command index"), "{text}");
+    assert!(
+        text.contains("base1 recovery USB validation bundle"),
+        "{text}"
+    );
+    assert!(text.contains("base1 recovery USB dry-run"), "{text}");
+    assert!(
+        text.contains("base1 recovery USB hardware validation bundle complete"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_hardware_validation_bundle_help_is_read_only() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-hardware-validate.sh")
+        .arg("--help")
+        .output()
+        .expect("run recovery USB hardware validation help");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("read-only"), "{text}");
+    assert!(text.contains("without writing USB media"), "{text}");
+    assert!(text.contains("flashing firmware"), "{text}");
+    assert!(text.contains("host trust"), "{text}");
+}
+
+#[test]
+fn recovery_usb_hardware_validation_bundle_avoids_mutating_tools_and_sensitive_terms() {
+    let script = std::fs::read_to_string("scripts/base1-recovery-usb-hardware-validate.sh")
+        .expect("recovery USB hardware validation bundle");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only recovery USB hardware validation bundle for Base1 recovery-media planning.

Implements:
- scripts/base1-recovery-usb-hardware-validate.sh
- grouped hardware checklist and recovery USB preview command runner
- Libreboot/X200-class and GRUB-first validation summary
- README, recovery USB checklist, command index, and validation report updates
- mutating-tool and sensitive-term guard test

Validation:
- cargo test -p phase1 --test base1_recovery_usb_hardware_validation_bundle
- cargo test -p phase1 --test base1_recovery_usb_hardware_checklist_script
- cargo test -p phase1 --test base1_recovery_usb_hardware_checklist_docs
- cargo test -p phase1 --test base1_recovery_usb_validation_report_docs
- cargo test -p phase1 --test base1_foundation

Refs #135