### PR TITLE
Add Base1 recovery USB hardware report command

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ sh scripts/base1-libreboot-preflight.sh
 sh scripts/base1-libreboot-report.sh
 sh scripts/base1-libreboot-validate.sh
 sh scripts/base1-recovery-usb-validate.sh
+sh scripts/base1-recovery-usb-hardware-report.sh
 sh scripts/base1-recovery-usb-hardware-validate.sh
 sh scripts/base1-recovery-usb-hardware-checklist.sh
 sh scripts/base1-recovery-usb-index.sh

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -17,6 +17,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 
 ## Recovery USB commands
 
+- `scripts/base1-recovery-usb-hardware-report.sh`
 - `scripts/base1-recovery-usb-hardware-validate.sh`
 - `scripts/base1-recovery-usb-hardware-checklist.sh`
 - `scripts/base1-recovery-usb-validate.sh`

--- a/base1/RECOVERY_USB_HARDWARE_CHECKLIST.md
+++ b/base1/RECOVERY_USB_HARDWARE_CHECKLIST.md
@@ -33,6 +33,7 @@ Confirm:
 
 Run these before any future USB-writing work:
 
+    sh scripts/base1-recovery-usb-hardware-report.sh
     sh scripts/base1-recovery-usb-hardware-validate.sh
     sh scripts/base1-recovery-usb-hardware-checklist.sh
     sh scripts/base1-recovery-usb-index.sh

--- a/base1/RECOVERY_USB_VALIDATION_REPORT.md
+++ b/base1/RECOVERY_USB_VALIDATION_REPORT.md
@@ -22,6 +22,7 @@ This document is advisory and read-only. Do not store passwords, tokens, private
 Run and record whether each command completed:
 
     sh scripts/base1-recovery-usb-index.sh
+    sh scripts/base1-recovery-usb-hardware-report.sh
     sh scripts/base1-recovery-usb-hardware-validate.sh
     sh scripts/base1-recovery-usb-validate.sh
     sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example

--- a/scripts/base1-recovery-usb-hardware-report.sh
+++ b/scripts/base1-recovery-usb-hardware-report.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 recovery USB hardware validation report
+
+usage:
+  sh scripts/base1-recovery-usb-hardware-report.sh
+
+This command is read-only. It prints a hardware validation report template
+without writing USB media, changing boot settings, writing to /boot, modifying
+disks, changing firmware state, or changing host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+cat <<'EOF'
+base1 recovery USB hardware validation report
+mode       : read-only
+writes     : no
+firmware   : Libreboot expected
+hardware   : X200-class expected
+bootloader : GRUB first
+media      : external USB planned
+secureboot : not assumed
+tpm        : not assumed
+trust      : no host trust escalation
+
+hardware observations:
+- GRUB menu reachable: unknown
+- USB boot option visible: unknown
+- external USB device labeled: unknown
+- keyboard works in boot menu: unknown
+- display readable in recovery mode: unknown
+- emergency shell reachable: unknown
+- normal boot path known: unknown
+- recovery boot path known: unknown
+- Phase1 state path known: unknown
+- rollback metadata path known: unknown
+- wireless limitations known: unknown
+- clock drift risk known: unknown
+- power and battery behavior known: unknown
+
+validation commands:
+- sh scripts/base1-recovery-usb-hardware-validate.sh
+- sh scripts/base1-recovery-usb-hardware-checklist.sh
+- sh scripts/base1-recovery-usb-validate.sh
+- sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
+
+status: hardware validation not completed
+EOF

--- a/tests/base1_recovery_usb_hardware_report_script.rs
+++ b/tests/base1_recovery_usb_hardware_report_script.rs
@@ -1,0 +1,94 @@
+use std::process::Command;
+
+#[test]
+fn recovery_usb_hardware_report_script_prints_report_template() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-hardware-report.sh")
+        .output()
+        .expect("run recovery USB hardware report script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("base1 recovery USB hardware validation report"),
+        "{text}"
+    );
+    assert!(text.contains("mode       : read-only"), "{text}");
+    assert!(text.contains("writes     : no"), "{text}");
+    assert!(text.contains("firmware   : Libreboot expected"), "{text}");
+    assert!(text.contains("hardware   : X200-class expected"), "{text}");
+    assert!(text.contains("bootloader : GRUB first"), "{text}");
+    assert!(text.contains("media      : external USB planned"), "{text}");
+    assert!(
+        text.contains("trust      : no host trust escalation"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_hardware_report_script_lists_observations_and_commands() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-hardware-report.sh")
+        .output()
+        .expect("run recovery USB hardware report script");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(text.contains("GRUB menu reachable: unknown"), "{text}");
+    assert!(text.contains("USB boot option visible: unknown"), "{text}");
+    assert!(
+        text.contains("emergency shell reachable: unknown"),
+        "{text}"
+    );
+    assert!(text.contains("Phase1 state path known: unknown"), "{text}");
+    assert!(
+        text.contains("rollback metadata path known: unknown"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-recovery-usb-hardware-validate.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example"),
+        "{text}"
+    );
+    assert!(text.contains("hardware validation not completed"), "{text}");
+}
+
+#[test]
+fn recovery_usb_hardware_report_script_avoids_mutating_tools_and_sensitive_terms() {
+    let script = std::fs::read_to_string("scripts/base1-recovery-usb-hardware-report.sh")
+        .expect("recovery USB hardware report script");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only recovery USB hardware validation report command for Base1 recovery-media planning.

Implements:
- scripts/base1-recovery-usb-hardware-report.sh
- hardware validation report template output
- Libreboot/X200-class and GRUB-first target summary
- hardware observation placeholders
- README, recovery USB checklist, command index, and validation report updates
- mutating-tool and sensitive-term guard test

Validation:
- cargo test -p phase1 --test base1_recovery_usb_hardware_report_script
- cargo test -p phase1 --test base1_recovery_usb_hardware_validation_bundle
- cargo test -p phase1 --test base1_recovery_usb_hardware_checklist_script
- cargo test -p phase1 --test base1_recovery_usb_hardware_checklist_docs
- cargo test -p phase1 --test base1_foundation

Refs #135