### PR TITLE
Document Base1 recovery USB hardware summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Start here:
 - [`base1/RECOVERY_USB_COMMAND_INDEX.md`](base1/RECOVERY_USB_COMMAND_INDEX.md) — Recovery USB command index
 - [`base1/RECOVERY_USB_VALIDATION_REPORT.md`](base1/RECOVERY_USB_VALIDATION_REPORT.md) — Recovery USB validation report
 - [`base1/RECOVERY_USB_HARDWARE_CHECKLIST.md`](base1/RECOVERY_USB_HARDWARE_CHECKLIST.md) — Recovery USB hardware validation checklist
+- [`base1/RECOVERY_USB_HARDWARE_SUMMARY.md`](base1/RECOVERY_USB_HARDWARE_SUMMARY.md) — Recovery USB hardware validation summary
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1.md) — Libreboot read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md) — Libreboot read-only checkpoint v1.1 release notes
 - [`base1/LIBREBOOT_DOCS_SUMMARY.md`](base1/LIBREBOOT_DOCS_SUMMARY.md) — Libreboot docs summary

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -9,6 +9,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 - `base1/RECOVERY_USB_DESIGN.md` — recovery USB design and safety contract.
 - `base1/RECOVERY_USB_VALIDATION_REPORT.md` — Recovery USB validation report.
 - `base1/RECOVERY_USB_HARDWARE_CHECKLIST.md` — Recovery USB hardware validation checklist.
+- `base1/RECOVERY_USB_HARDWARE_SUMMARY.md` — Recovery USB hardware validation summary.
 - `base1/LIBREBOOT_DOCS_SUMMARY.md` — Libreboot documentation path.
 - `base1/LIBREBOOT_MILESTONE.md` — Libreboot read-only milestone checkpoint.
 - `base1/LIBREBOOT_VALIDATION_REPORT.md` — validation report template.

--- a/base1/RECOVERY_USB_DESIGN.md
+++ b/base1/RECOVERY_USB_DESIGN.md
@@ -77,3 +77,6 @@ See also: [Recovery USB validation report](RECOVERY_USB_VALIDATION_REPORT.md).
 
 
 See also: [Recovery USB hardware validation checklist](RECOVERY_USB_HARDWARE_CHECKLIST.md).
+
+
+See also: [Recovery USB hardware validation summary](RECOVERY_USB_HARDWARE_SUMMARY.md).

--- a/base1/RECOVERY_USB_HARDWARE_CHECKLIST.md
+++ b/base1/RECOVERY_USB_HARDWARE_CHECKLIST.md
@@ -77,3 +77,6 @@ Record yes/no/notes:
 ## Promotion rule
 
 A recovery USB media builder can only follow after this checklist, the validation report, target-device selection, image provenance, checksum verification, emergency shell path, and rollback metadata path are documented and tested.
+
+
+See also: [Recovery USB hardware validation summary](RECOVERY_USB_HARDWARE_SUMMARY.md).

--- a/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
+++ b/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
@@ -1,0 +1,69 @@
+# Base1 recovery USB hardware validation summary
+
+This summary ties together the read-only recovery USB hardware validation path for Base1.
+
+This document is advisory and read-only. It does not write USB media, partition disks, format disks, install GRUB, edit grub.cfg, write to /boot, flash firmware, change boot order, or modify host trust.
+
+## Target
+
+- Firmware profile: Libreboot expected.
+- Hardware profile: ThinkPad X200-class expected.
+- Bootloader expectation: GRUB first.
+- Recovery media: external USB planned.
+- Secure Boot: not assumed.
+- TPM: not assumed.
+- Recovery posture: keyboard-first and offline-first.
+- Current maturity: documentation, checklist, reports, and read-only dry-runs.
+
+## Read first
+
+1. `base1/RECOVERY_USB_DESIGN.md`
+2. `base1/RECOVERY_USB_COMMAND_INDEX.md`
+3. `base1/RECOVERY_USB_HARDWARE_CHECKLIST.md`
+4. `base1/RECOVERY_USB_VALIDATION_REPORT.md`
+5. `base1/LIBREBOOT_MILESTONE.md`
+
+## First commands
+
+Run the read-only commands first:
+
+    sh scripts/base1-recovery-usb-index.sh
+    sh scripts/base1-recovery-usb-hardware-checklist.sh
+    sh scripts/base1-recovery-usb-hardware-validate.sh
+    sh scripts/base1-recovery-usb-hardware-report.sh
+    sh scripts/base1-recovery-usb-validate.sh
+    sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
+
+## Hardware observations
+
+The current hardware path records:
+
+- GRUB menu reachability.
+- USB boot option visibility.
+- External USB device labeling.
+- Keyboard behavior in boot menu.
+- Display readability in recovery mode.
+- Emergency shell path.
+- Normal boot path.
+- Recovery boot path.
+- Phase1 state path.
+- Rollback metadata path.
+- Wireless limitations.
+- Clock drift risk.
+- Power and battery behavior.
+
+## Still not claimed
+
+This summary does not claim:
+
+- USB media writing readiness.
+- Bootable Base1 image readiness.
+- Destructive installer readiness.
+- Daily-driver readiness.
+- Automatic GRUB repair.
+- Real-hardware recovery completion.
+- Real-hardware rollback completion.
+
+## Promotion rule
+
+Recovery USB work must remain read-only until target-device selection, image provenance, checksum verification, emergency shell behavior, rollback metadata, storage layout, and actual Libreboot/X200-class boot behavior are verified.

--- a/base1/RECOVERY_USB_VALIDATION_REPORT.md
+++ b/base1/RECOVERY_USB_VALIDATION_REPORT.md
@@ -71,3 +71,6 @@ Notes:
 
 
 See also: [Recovery USB hardware validation checklist](RECOVERY_USB_HARDWARE_CHECKLIST.md).
+
+
+See also: [Recovery USB hardware validation summary](RECOVERY_USB_HARDWARE_SUMMARY.md).

--- a/tests/base1_recovery_usb_hardware_summary_docs.rs
+++ b/tests/base1_recovery_usb_hardware_summary_docs.rs
@@ -1,0 +1,76 @@
+#[test]
+fn recovery_usb_hardware_summary_lists_core_docs_and_commands() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_HARDWARE_SUMMARY.md")
+        .expect("recovery USB hardware summary");
+
+    assert!(
+        doc.contains("Base1 recovery USB hardware validation summary"),
+        "{doc}"
+    );
+    assert!(doc.contains("RECOVERY_USB_DESIGN.md"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_COMMAND_INDEX.md"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_HARDWARE_CHECKLIST.md"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_VALIDATION_REPORT.md"), "{doc}");
+    assert!(doc.contains("LIBREBOOT_MILESTONE.md"), "{doc}");
+    assert!(
+        doc.contains("sh scripts/base1-recovery-usb-hardware-validate.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("sh scripts/base1-recovery-usb-hardware-report.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_hardware_summary_preserves_guardrails_and_non_claims() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_HARDWARE_SUMMARY.md")
+        .expect("recovery USB hardware summary");
+
+    assert!(doc.contains("does not write USB media"), "{doc}");
+    assert!(
+        doc.contains("does not write USB media") || doc.contains("USB media writing readiness"),
+        "{doc}"
+    );
+    assert!(doc.contains("Bootable Base1 image readiness"), "{doc}");
+    assert!(doc.contains("Automatic GRUB repair"), "{doc}");
+    assert!(doc.contains("Real-hardware recovery completion"), "{doc}");
+    assert!(doc.contains("Real-hardware rollback completion"), "{doc}");
+    assert!(doc.contains("remain read-only"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_indexes_link_hardware_summary() {
+    let index = std::fs::read_to_string("base1/RECOVERY_USB_COMMAND_INDEX.md")
+        .expect("recovery usb command index");
+    let checklist = std::fs::read_to_string("base1/RECOVERY_USB_HARDWARE_CHECKLIST.md")
+        .expect("recovery usb hardware checklist");
+    let report = std::fs::read_to_string("base1/RECOVERY_USB_VALIDATION_REPORT.md")
+        .expect("recovery usb validation report");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        index.contains("RECOVERY_USB_HARDWARE_SUMMARY.md"),
+        "{index}"
+    );
+    assert!(
+        index.contains("Recovery USB hardware validation summary"),
+        "{index}"
+    );
+    assert!(
+        checklist.contains("RECOVERY_USB_HARDWARE_SUMMARY.md"),
+        "{checklist}"
+    );
+    assert!(
+        report.contains("RECOVERY_USB_HARDWARE_SUMMARY.md"),
+        "{report}"
+    );
+    assert!(
+        readme.contains("base1/RECOVERY_USB_HARDWARE_SUMMARY.md"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds a read-only hardware validation summary for Base1 recovery USB planning.

Implements:
- Recovery USB hardware validation summary
- Links to recovery USB design, command index, checklist, validation report, and Libreboot milestone
- First read-only command sequence
- hardware observation summary
- explicit non-claims and promotion rule
- README and recovery USB surface links
- docs tests for summary coverage

Validation:
- cargo test -p phase1 --test base1_recovery_usb_hardware_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_hardware_report_script
- cargo test -p phase1 --test base1_recovery_usb_hardware_validation_bundle
- cargo test -p phase1 --test base1_recovery_usb_hardware_checklist_docs
- cargo test -p phase1 --test base1_foundation

Refs #135