### PR TITLE
Add Base1 recovery USB hardware summary command

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ sh scripts/base1-libreboot-preflight.sh
 sh scripts/base1-libreboot-report.sh
 sh scripts/base1-libreboot-validate.sh
 sh scripts/base1-recovery-usb-validate.sh
+sh scripts/base1-recovery-usb-hardware-summary.sh
 sh scripts/base1-recovery-usb-hardware-report.sh
 sh scripts/base1-recovery-usb-hardware-validate.sh
 sh scripts/base1-recovery-usb-hardware-checklist.sh

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -18,6 +18,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 
 ## Recovery USB commands
 
+- `scripts/base1-recovery-usb-hardware-summary.sh`
 - `scripts/base1-recovery-usb-hardware-report.sh`
 - `scripts/base1-recovery-usb-hardware-validate.sh`
 - `scripts/base1-recovery-usb-hardware-checklist.sh`

--- a/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
+++ b/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
@@ -27,6 +27,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 
 Run the read-only commands first:
 
+    sh scripts/base1-recovery-usb-hardware-summary.sh
     sh scripts/base1-recovery-usb-index.sh
     sh scripts/base1-recovery-usb-hardware-checklist.sh
     sh scripts/base1-recovery-usb-hardware-validate.sh

--- a/scripts/base1-recovery-usb-hardware-summary.sh
+++ b/scripts/base1-recovery-usb-hardware-summary.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 recovery USB hardware summary
+
+usage:
+  sh scripts/base1-recovery-usb-hardware-summary.sh
+
+This command is read-only. It prints the recovery USB hardware validation
+summary without writing USB media, changing boot settings, writing to /boot,
+modifying disks, flashing firmware, or changing host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+cat <<'EOF'
+base1 recovery USB hardware validation summary
+mode       : read-only
+writes     : no
+firmware   : Libreboot expected
+hardware   : X200-class expected
+bootloader : GRUB first
+media      : external USB planned
+secureboot : not assumed
+tpm        : not assumed
+trust      : no host trust escalation
+maturity   : docs, checklist, reports, and dry-runs
+
+read first:
+1. base1/RECOVERY_USB_DESIGN.md
+2. base1/RECOVERY_USB_COMMAND_INDEX.md
+3. base1/RECOVERY_USB_HARDWARE_CHECKLIST.md
+4. base1/RECOVERY_USB_VALIDATION_REPORT.md
+5. base1/RECOVERY_USB_HARDWARE_SUMMARY.md
+
+first commands:
+- sh scripts/base1-recovery-usb-hardware-summary.sh
+- sh scripts/base1-recovery-usb-hardware-checklist.sh
+- sh scripts/base1-recovery-usb-hardware-validate.sh
+- sh scripts/base1-recovery-usb-hardware-report.sh
+- sh scripts/base1-recovery-usb-validate.sh
+- sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
+
+not claimed:
+- USB media writing readiness
+- bootable Base1 image readiness
+- destructive installer readiness
+- automatic GRUB repair
+- real-hardware recovery completion
+- real-hardware rollback completion
+EOF

--- a/tests/base1_recovery_usb_hardware_summary_script.rs
+++ b/tests/base1_recovery_usb_hardware_summary_script.rs
@@ -1,0 +1,93 @@
+use std::process::Command;
+
+#[test]
+fn recovery_usb_hardware_summary_script_prints_summary() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-hardware-summary.sh")
+        .output()
+        .expect("run recovery USB hardware summary script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("base1 recovery USB hardware validation summary"),
+        "{text}"
+    );
+    assert!(text.contains("mode       : read-only"), "{text}");
+    assert!(text.contains("writes     : no"), "{text}");
+    assert!(text.contains("firmware   : Libreboot expected"), "{text}");
+    assert!(text.contains("hardware   : X200-class expected"), "{text}");
+    assert!(text.contains("bootloader : GRUB first"), "{text}");
+    assert!(
+        text.contains("maturity   : docs, checklist, reports, and dry-runs"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_hardware_summary_script_lists_docs_commands_and_non_claims() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-hardware-summary.sh")
+        .output()
+        .expect("run recovery USB hardware summary script");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        text.contains("base1/RECOVERY_USB_HARDWARE_SUMMARY.md"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-recovery-usb-hardware-summary.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-recovery-usb-hardware-validate.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-recovery-usb-hardware-report.sh"),
+        "{text}"
+    );
+    assert!(text.contains("USB media writing readiness"), "{text}");
+    assert!(text.contains("bootable Base1 image readiness"), "{text}");
+    assert!(text.contains("real-hardware recovery completion"), "{text}");
+    assert!(text.contains("real-hardware rollback completion"), "{text}");
+}
+
+#[test]
+fn recovery_usb_hardware_summary_script_avoids_mutating_tools_and_sensitive_terms() {
+    let script = std::fs::read_to_string("scripts/base1-recovery-usb-hardware-summary.sh")
+        .expect("recovery USB hardware summary script");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only recovery USB hardware validation summary command for Base1 recovery-media planning.

Implements:
- scripts/base1-recovery-usb-hardware-summary.sh
- hardware validation summary output
- docs and first command list
- explicit non-claims for media, image, installer, recovery, and rollback readiness
- README, recovery USB command index, and hardware summary updates
- mutating-tool and sensitive-term guard test

Validation:
- cargo test -p phase1 --test base1_recovery_usb_hardware_summary_script
- cargo test -p phase1 --test base1_recovery_usb_hardware_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_hardware_report_script
- cargo test -p phase1 --test base1_recovery_usb_hardware_validation_bundle
- cargo test -p phase1 --test base1_foundation

Refs #135