### PR TITLE
Document Base1 recovery USB hardware checkpoint release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Start here:
 - [`base1/RECOVERY_USB_VALIDATION_REPORT.md`](base1/RECOVERY_USB_VALIDATION_REPORT.md) — Recovery USB validation report
 - [`base1/RECOVERY_USB_HARDWARE_CHECKLIST.md`](base1/RECOVERY_USB_HARDWARE_CHECKLIST.md) — Recovery USB hardware validation checklist
 - [`base1/RECOVERY_USB_HARDWARE_SUMMARY.md`](base1/RECOVERY_USB_HARDWARE_SUMMARY.md) — Recovery USB hardware validation summary
+- [`RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md) — Recovery USB hardware read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1.md) — Libreboot read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md) — Libreboot read-only checkpoint v1.1 release notes
 - [`base1/LIBREBOOT_DOCS_SUMMARY.md`](base1/LIBREBOOT_DOCS_SUMMARY.md) — Libreboot docs summary

--- a/RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md
+++ b/RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md
@@ -1,0 +1,75 @@
+# Base1 recovery USB hardware read-only checkpoint v1
+
+This checkpoint captures the read-only hardware validation path for Base1 recovery USB planning.
+
+## Status
+
+- Checkpoint branch: checkpoint/base1-recovery-usb-hardware-readonly-v1
+- Checkpoint tag: base1-recovery-usb-hardware-readonly-v1
+- Firmware profile: Libreboot expected
+- Hardware profile: ThinkPad X200-class expected
+- Bootloader expectation: GRUB first
+- Recovery media: external USB planned
+- Secure Boot: not assumed
+- TPM: not assumed
+- Current maturity: documentation, checklist, reports, and read-only dry-runs
+
+## Included documents
+
+- base1/RECOVERY_USB_DESIGN.md
+- base1/RECOVERY_USB_COMMAND_INDEX.md
+- base1/RECOVERY_USB_HARDWARE_CHECKLIST.md
+- base1/RECOVERY_USB_VALIDATION_REPORT.md
+- base1/RECOVERY_USB_HARDWARE_SUMMARY.md
+- base1/LIBREBOOT_MILESTONE.md
+
+## Included commands
+
+- scripts/base1-recovery-usb-index.sh
+- scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
+- scripts/base1-recovery-usb-validate.sh
+- scripts/base1-recovery-usb-hardware-checklist.sh
+- scripts/base1-recovery-usb-hardware-validate.sh
+- scripts/base1-recovery-usb-hardware-report.sh
+- scripts/base1-recovery-usb-hardware-summary.sh
+
+## Validation
+
+Run:
+
+    cargo test -p phase1 --test base1_recovery_usb_hardware_summary_script
+    cargo test -p phase1 --test base1_recovery_usb_hardware_summary_docs
+    cargo test -p phase1 --test base1_recovery_usb_hardware_report_script
+    cargo test -p phase1 --test base1_recovery_usb_hardware_validation_bundle
+    cargo test -p phase1 --test base1_recovery_usb_hardware_checklist_script
+    cargo test -p phase1 --test base1_recovery_usb_hardware_checklist_docs
+    cargo test -p phase1 --test base1_foundation
+
+## Guardrails
+
+- Do not write USB media.
+- Do not run dd automatically.
+- Do not partition disks.
+- Do not format disks.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not change boot order.
+- Do not flash firmware.
+- Do not store passwords, tokens, private keys, recovery phrases, or personal secrets.
+
+## Non-claims
+
+This checkpoint does not claim:
+
+- USB media writing readiness.
+- Bootable Base1 image readiness.
+- Destructive installer readiness.
+- Daily-driver readiness.
+- Automatic GRUB repair.
+- Real-hardware recovery completion.
+- Real-hardware rollback completion.
+
+## Next milestone
+
+The next milestone should remain read-only unless the target USB device, image provenance, checksum verification, emergency shell behavior, rollback metadata, storage layout, and actual Libreboot/X200-class boot behavior are verified.

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -61,3 +61,6 @@ The expected read-only path is:
 5. Confirm rollback metadata location.
 6. Confirm Phase1 state location.
 7. Confirm recovery USB plan without writing media.
+
+
+See also: [`RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md`](../RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md) — recovery USB hardware read-only checkpoint release notes.

--- a/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
+++ b/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
@@ -68,3 +68,6 @@ This summary does not claim:
 ## Promotion rule
 
 Recovery USB work must remain read-only until target-device selection, image provenance, checksum verification, emergency shell behavior, rollback metadata, storage layout, and actual Libreboot/X200-class boot behavior are verified.
+
+
+See also: [RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md](../RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md).

--- a/tests/base1_recovery_usb_hardware_release_notes_docs.rs
+++ b/tests/base1_recovery_usb_hardware_release_notes_docs.rs
@@ -1,0 +1,76 @@
+#[test]
+fn recovery_usb_hardware_release_notes_record_checkpoint_status() {
+    let doc = std::fs::read_to_string("RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md")
+        .expect("recovery usb hardware release notes");
+
+    assert!(
+        doc.contains("Base1 recovery USB hardware read-only checkpoint v1"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("checkpoint/base1-recovery-usb-hardware-readonly-v1"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("base1-recovery-usb-hardware-readonly-v1"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Firmware profile: Libreboot expected"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Hardware profile: ThinkPad X200-class expected"),
+        "{doc}"
+    );
+    assert!(doc.contains("Bootloader expectation: GRUB first"), "{doc}");
+    assert!(
+        doc.contains("documentation, checklist, reports, and read-only dry-runs"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_hardware_release_notes_list_surfaces_and_non_claims() {
+    let doc = std::fs::read_to_string("RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md")
+        .expect("recovery usb hardware release notes");
+
+    assert!(
+        doc.contains("base1/RECOVERY_USB_HARDWARE_SUMMARY.md"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-recovery-usb-hardware-summary.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-recovery-usb-hardware-validate.sh"),
+        "{doc}"
+    );
+    assert!(doc.contains("USB media writing readiness"), "{doc}");
+    assert!(doc.contains("Bootable Base1 image readiness"), "{doc}");
+    assert!(doc.contains("Real-hardware recovery completion"), "{doc}");
+    assert!(doc.contains("Real-hardware rollback completion"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_hardware_surfaces_link_release_notes() {
+    let summary = std::fs::read_to_string("base1/RECOVERY_USB_HARDWARE_SUMMARY.md")
+        .expect("recovery usb hardware summary");
+    let index = std::fs::read_to_string("base1/RECOVERY_USB_COMMAND_INDEX.md")
+        .expect("recovery usb command index");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        summary.contains("RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md"),
+        "{summary}"
+    );
+    assert!(
+        index.contains("RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md"),
+        "{index}"
+    );
+    assert!(
+        readme.contains("RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds release notes for the Base1 recovery USB hardware read-only checkpoint.

Implements:
- RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md
- completed docs and commands inventory
- validation command set
- explicit guardrails and non-claims
- README, recovery USB command index, and hardware summary links
- docs tests for release notes coverage

Validation:
- cargo test -p phase1 --test base1_recovery_usb_hardware_release_notes_docs
- cargo test -p phase1 --test base1_recovery_usb_hardware_summary_script
- cargo test -p phase1 --test base1_recovery_usb_hardware_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_hardware_report_script
- cargo test -p phase1 --test base1_recovery_usb_hardware_validation_bundle
- cargo test -p phase1 --test base1_foundation

Refs #135