### PR TITLE
Document Base1 recovery USB target selection design

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Start here:
 - [`base1/RECOVERY_USB_VALIDATION_REPORT.md`](base1/RECOVERY_USB_VALIDATION_REPORT.md) — Recovery USB validation report
 - [`base1/RECOVERY_USB_HARDWARE_CHECKLIST.md`](base1/RECOVERY_USB_HARDWARE_CHECKLIST.md) — Recovery USB hardware validation checklist
 - [`base1/RECOVERY_USB_HARDWARE_SUMMARY.md`](base1/RECOVERY_USB_HARDWARE_SUMMARY.md) — Recovery USB hardware validation summary
+- [`base1/RECOVERY_USB_TARGET_SELECTION.md`](base1/RECOVERY_USB_TARGET_SELECTION.md) — Recovery USB target-device selection design
 - [`RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md) — Recovery USB hardware read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1.md) — Libreboot read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md) — Libreboot read-only checkpoint v1.1 release notes

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -10,6 +10,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 - `base1/RECOVERY_USB_VALIDATION_REPORT.md` — Recovery USB validation report.
 - `base1/RECOVERY_USB_HARDWARE_CHECKLIST.md` — Recovery USB hardware validation checklist.
 - `base1/RECOVERY_USB_HARDWARE_SUMMARY.md` — Recovery USB hardware validation summary.
+- `base1/RECOVERY_USB_TARGET_SELECTION.md` — Recovery USB target-device selection design.
 - `base1/LIBREBOOT_DOCS_SUMMARY.md` — Libreboot documentation path.
 - `base1/LIBREBOOT_MILESTONE.md` — Libreboot read-only milestone checkpoint.
 - `base1/LIBREBOOT_VALIDATION_REPORT.md` — validation report template.

--- a/base1/RECOVERY_USB_DESIGN.md
+++ b/base1/RECOVERY_USB_DESIGN.md
@@ -80,3 +80,6 @@ See also: [Recovery USB hardware validation checklist](RECOVERY_USB_HARDWARE_CHE
 
 
 See also: [Recovery USB hardware validation summary](RECOVERY_USB_HARDWARE_SUMMARY.md).
+
+
+See also: [Recovery USB target-device selection design](RECOVERY_USB_TARGET_SELECTION.md).

--- a/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
+++ b/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
@@ -71,3 +71,6 @@ Recovery USB work must remain read-only until target-device selection, image pro
 
 
 See also: [RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md](../RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md).
+
+
+See also: [Recovery USB target-device selection design](RECOVERY_USB_TARGET_SELECTION.md).

--- a/base1/RECOVERY_USB_TARGET_SELECTION.md
+++ b/base1/RECOVERY_USB_TARGET_SELECTION.md
@@ -1,0 +1,75 @@
+# Base1 recovery USB target-device selection design
+
+This design defines the read-only target-device selection path for Base1 recovery USB planning.
+
+This document is advisory and read-only. It does not write USB media, partition disks, format disks, install GRUB, edit grub.cfg, write to /boot, flash firmware, change boot order, or modify host trust.
+
+## Goal
+
+Define how an operator should identify and confirm a recovery USB target before any future media-writing command exists.
+
+The target-device selection path must make device identity visible, preserve operator confirmation, and prevent accidental writes to the host disk or personal data drives.
+
+## Target scope
+
+Initial scope:
+
+- Libreboot-backed ThinkPad X200-class systems.
+- GRUB-first boot path.
+- External USB recovery media.
+- No Secure Boot assumption.
+- No TPM assumption.
+- Keyboard-first and offline-first recovery.
+- Read-only previews only.
+
+## Device identity checklist
+
+Before selecting a target, record:
+
+- Device path.
+- Device model/name.
+- Device size.
+- Removable status.
+- Current mount status.
+- Current filesystem labels if visible.
+- Whether the device contains data that must be preserved.
+- Whether the device is the internal system disk.
+- Whether the operator physically labeled the USB device.
+
+## Required confirmation language
+
+A future mutating command must require an explicit confirmation phrase before writing media.
+
+Required phrase:
+
+I understand this will write recovery USB media to the selected device
+
+This design does not implement that mutating command. It only records the future confirmation requirement.
+
+## Read-only commands
+
+Run first:
+
+    sh scripts/base1-recovery-usb-hardware-summary.sh
+    sh scripts/base1-recovery-usb-hardware-validate.sh
+    sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
+    sh scripts/base1-recovery-usb-index.sh
+
+## Guardrails
+
+- Do not write USB media.
+- Do not run dd automatically.
+- Do not partition disks.
+- Do not format disks.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not change boot order.
+- Do not flash firmware.
+- Do not store passwords, tokens, private keys, recovery phrases, or personal secrets.
+- Do not allow hidden target selection.
+- Do not default to the internal system disk.
+
+## Promotion rule
+
+A future recovery USB writer can only follow after target identity, image provenance, checksum verification, emergency shell behavior, rollback metadata, storage layout, and actual Libreboot/X200-class boot behavior are verified.

--- a/tests/base1_recovery_usb_target_selection_docs.rs
+++ b/tests/base1_recovery_usb_target_selection_docs.rs
@@ -1,0 +1,76 @@
+#[test]
+fn recovery_usb_target_selection_defines_read_only_device_identity_path() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_TARGET_SELECTION.md")
+        .expect("recovery usb target selection design");
+
+    assert!(
+        doc.contains("Base1 recovery USB target-device selection design"),
+        "{doc}"
+    );
+    assert!(doc.contains("advisory and read-only"), "{doc}");
+    assert!(doc.contains("Device path"), "{doc}");
+    assert!(doc.contains("Device model/name"), "{doc}");
+    assert!(doc.contains("Device size"), "{doc}");
+    assert!(doc.contains("Removable status"), "{doc}");
+    assert!(doc.contains("Current mount status"), "{doc}");
+    assert!(doc.contains("physically labeled the USB device"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_target_selection_requires_future_confirmation_phrase() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_TARGET_SELECTION.md")
+        .expect("recovery usb target selection design");
+
+    assert!(doc.contains("Required confirmation language"), "{doc}");
+    assert!(
+        doc.contains("I understand this will write recovery USB media to the selected device"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("does not implement that mutating command"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_target_selection_preserves_guardrails() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_TARGET_SELECTION.md")
+        .expect("recovery usb target selection design");
+
+    assert!(doc.contains("Do not write USB media"), "{doc}");
+    assert!(doc.contains("Do not run dd automatically"), "{doc}");
+    assert!(doc.contains("Do not partition disks"), "{doc}");
+    assert!(doc.contains("Do not format disks"), "{doc}");
+    assert!(doc.contains("Do not install GRUB automatically"), "{doc}");
+    assert!(doc.contains("Do not write to /boot"), "{doc}");
+    assert!(
+        doc.contains("Do not allow hidden target selection"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Do not default to the internal system disk"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_surfaces_link_target_selection_design() {
+    let summary = std::fs::read_to_string("base1/RECOVERY_USB_HARDWARE_SUMMARY.md")
+        .expect("recovery usb hardware summary");
+    let index = std::fs::read_to_string("base1/RECOVERY_USB_COMMAND_INDEX.md")
+        .expect("recovery usb command index");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        summary.contains("RECOVERY_USB_TARGET_SELECTION.md"),
+        "{summary}"
+    );
+    assert!(
+        index.contains("RECOVERY_USB_TARGET_SELECTION.md"),
+        "{index}"
+    );
+    assert!(
+        readme.contains("base1/RECOVERY_USB_TARGET_SELECTION.md"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds a read-only target-device selection design for Base1 recovery USB planning.

Implements:
- Recovery USB target-device selection design
- device identity checklist
- future explicit confirmation phrase
- guardrails against hidden target selection and internal disk defaults
- README and recovery USB surface links
- docs tests for target-selection coverage

Validation:
- cargo test -p phase1 --test base1_recovery_usb_target_selection_docs
- cargo test -p phase1 --test base1_recovery_usb_hardware_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_hardware_summary_script
- cargo test -p phase1 --test base1_recovery_usb_hardware_validation_bundle
- cargo test -p phase1 --test base1_foundation

Refs #135