### PR TITLE
Add Base1 recovery USB target selection dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ sh scripts/base1-recovery-usb-hardware-report.sh
 sh scripts/base1-recovery-usb-hardware-validate.sh
 sh scripts/base1-recovery-usb-hardware-checklist.sh
 sh scripts/base1-recovery-usb-index.sh
+sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
 sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
 sh scripts/base1-libreboot-milestone.sh
 sh scripts/base1-libreboot-docs.sh

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -25,6 +25,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 - `scripts/base1-recovery-usb-hardware-checklist.sh`
 - `scripts/base1-recovery-usb-validate.sh`
 - `scripts/base1-recovery-usb-index.sh`
+- `scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example`
 - `scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example`
 - `scripts/base1-libreboot-validate.sh`
 - `scripts/base1-libreboot-report.sh`

--- a/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
+++ b/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
@@ -27,6 +27,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 
 Run the read-only commands first:
 
+    sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
     sh scripts/base1-recovery-usb-hardware-summary.sh
     sh scripts/base1-recovery-usb-index.sh
     sh scripts/base1-recovery-usb-hardware-checklist.sh

--- a/base1/RECOVERY_USB_TARGET_SELECTION.md
+++ b/base1/RECOVERY_USB_TARGET_SELECTION.md
@@ -50,6 +50,7 @@ This design does not implement that mutating command. It only records the future
 
 Run first:
 
+    sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
     sh scripts/base1-recovery-usb-hardware-summary.sh
     sh scripts/base1-recovery-usb-hardware-validate.sh
     sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example

--- a/scripts/base1-recovery-usb-target-dry-run.sh
+++ b/scripts/base1-recovery-usb-target-dry-run.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 recovery USB target selection dry-run
+
+usage:
+  sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target <usb-device>
+
+This command is read-only. It previews target-device identity checks without
+writing USB media, changing boot settings, writing to /boot, modifying disks,
+flashing firmware, or changing host trust.
+EOF
+}
+
+dry_run=0
+target=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --target)
+      if [ "$#" -lt 2 ]; then
+        echo "error: --target requires a value" >&2
+        exit 2
+      fi
+      target="$2"
+      shift 2
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      show_help >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$dry_run" -ne 1 ]; then
+  echo "refusing: --dry-run is required" >&2
+  exit 2
+fi
+
+if [ -z "$target" ]; then
+  echo "error: --target <usb-device> is required" >&2
+  exit 2
+fi
+
+case "$target" in
+  /dev/*|/dev/disk/*)
+    ;;
+  *)
+    echo "error: target must look like a device path under /dev" >&2
+    exit 2
+    ;;
+esac
+
+cat <<EOF
+base1 recovery USB target selection dry-run
+target             : $target
+writes             : no
+mode               : read-only
+firmware           : Libreboot expected
+hardware           : X200-class expected
+bootloader         : GRUB first
+usb_media          : target identity preview only
+device_path        : visible
+device_model       : operator-confirmed
+device_size        : operator-confirmed
+removable_status   : operator-confirmed
+current_state      : operator-confirmed
+filesystem_labels  : operator-confirmed
+data_preservation  : operator-confirmed
+internal_disk      : must be no
+physical_label     : operator-confirmed
+confirmation       : not accepted in dry-run
+trust              : no host trust escalation
+status             : target selection dry-run complete
+EOF

--- a/tests/base1_recovery_usb_target_dry_run_script.rs
+++ b/tests/base1_recovery_usb_target_dry_run_script.rs
@@ -1,0 +1,105 @@
+use std::process::Command;
+
+fn run_script(args: &[&str]) -> (bool, String) {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-target-dry-run.sh")
+        .args(args)
+        .output()
+        .expect("run recovery USB target dry-run script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    (output.status.success(), text)
+}
+
+#[test]
+fn recovery_usb_target_dry_run_requires_dry_run_flag() {
+    let (ok, text) = run_script(&["--target", "/dev/example"]);
+
+    assert!(!ok, "{text}");
+    assert!(text.contains("refusing: --dry-run is required"), "{text}");
+}
+
+#[test]
+fn recovery_usb_target_dry_run_requires_target() {
+    let (ok, text) = run_script(&["--dry-run"]);
+
+    assert!(!ok, "{text}");
+    assert!(text.contains("--target <usb-device> is required"), "{text}");
+}
+
+#[test]
+fn recovery_usb_target_dry_run_rejects_non_device_target() {
+    let (ok, text) = run_script(&["--dry-run", "--target", "usb0"]);
+
+    assert!(!ok, "{text}");
+    assert!(
+        text.contains("target must look like a device path under /dev"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_target_dry_run_reports_identity_preview_without_writes() {
+    let (ok, text) = run_script(&["--dry-run", "--target", "/dev/example"]);
+
+    assert!(ok, "{text}");
+    assert!(
+        text.contains("base1 recovery USB target selection dry-run"),
+        "{text}"
+    );
+    assert!(text.contains("target             : /dev/example"), "{text}");
+    assert!(text.contains("writes             : no"), "{text}");
+    assert!(text.contains("mode               : read-only"), "{text}");
+    assert!(
+        text.contains("firmware           : Libreboot expected"),
+        "{text}"
+    );
+    assert!(
+        text.contains("hardware           : X200-class expected"),
+        "{text}"
+    );
+    assert!(text.contains("bootloader         : GRUB first"), "{text}");
+    assert!(text.contains("device_path        : visible"), "{text}");
+    assert!(text.contains("internal_disk      : must be no"), "{text}");
+    assert!(
+        text.contains("confirmation       : not accepted in dry-run"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_target_dry_run_script_avoids_mutating_tools_and_sensitive_terms() {
+    let script = std::fs::read_to_string("scripts/base1-recovery-usb-target-dry-run.sh")
+        .expect("recovery USB target dry-run script");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only target-device selection dry-run for Base1 recovery USB planning.

Implements:
- scripts/base1-recovery-usb-target-dry-run.sh
- --dry-run enforcement
- explicit --target requirement
- target identity preview fields
- internal disk and operator-confirmation guardrails
- README, target selection, command index, and hardware summary updates
- mutating-tool and sensitive-term guard test

Validation:
- cargo test -p phase1 --test base1_recovery_usb_target_dry_run_script
- cargo test -p phase1 --test base1_recovery_usb_target_selection_docs
- cargo test -p phase1 --test base1_recovery_usb_hardware_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_hardware_validation_bundle
- cargo test -p phase1 --test base1_foundation

Refs #135