### PR TITLE
Document Base1 recovery USB target command index

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Start here:
 - [`base1/RECOVERY_USB_HARDWARE_CHECKLIST.md`](base1/RECOVERY_USB_HARDWARE_CHECKLIST.md) — Recovery USB hardware validation checklist
 - [`base1/RECOVERY_USB_HARDWARE_SUMMARY.md`](base1/RECOVERY_USB_HARDWARE_SUMMARY.md) — Recovery USB hardware validation summary
 - [`base1/RECOVERY_USB_TARGET_SELECTION.md`](base1/RECOVERY_USB_TARGET_SELECTION.md) — Recovery USB target-device selection design
+- [`base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md`](base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md) — Recovery USB target selection command index
 - [`RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md) — Recovery USB hardware read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1.md) — Libreboot read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md) — Libreboot read-only checkpoint v1.1 release notes

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -11,6 +11,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 - `base1/RECOVERY_USB_HARDWARE_CHECKLIST.md` — Recovery USB hardware validation checklist.
 - `base1/RECOVERY_USB_HARDWARE_SUMMARY.md` — Recovery USB hardware validation summary.
 - `base1/RECOVERY_USB_TARGET_SELECTION.md` — Recovery USB target-device selection design.
+- `base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md` — Recovery USB target selection command index.
 - `base1/LIBREBOOT_DOCS_SUMMARY.md` — Libreboot documentation path.
 - `base1/LIBREBOOT_MILESTONE.md` — Libreboot read-only milestone checkpoint.
 - `base1/LIBREBOOT_VALIDATION_REPORT.md` — validation report template.

--- a/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
+++ b/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
@@ -75,3 +75,6 @@ See also: [RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md](../RELEASE_BASE1_
 
 
 See also: [Recovery USB target-device selection design](RECOVERY_USB_TARGET_SELECTION.md).
+
+
+See also: [Recovery USB target selection command index](RECOVERY_USB_TARGET_COMMAND_INDEX.md).

--- a/base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
@@ -1,0 +1,62 @@
+# Base1 recovery USB target selection command index
+
+This index collects the read-only target-device selection documents and commands for Base1 recovery USB planning.
+
+This document is advisory and read-only. It does not write USB media, partition disks, format disks, install GRUB, edit grub.cfg, write to /boot, flash firmware, change boot order, or modify host trust.
+
+## Target selection documents
+
+- `base1/RECOVERY_USB_TARGET_SELECTION.md` — target-device selection design.
+- `base1/RECOVERY_USB_HARDWARE_SUMMARY.md` — recovery USB hardware validation summary.
+- `base1/RECOVERY_USB_HARDWARE_CHECKLIST.md` — hardware observation checklist.
+- `base1/RECOVERY_USB_COMMAND_INDEX.md` — broader recovery USB command index.
+- `base1/RECOVERY_USB_VALIDATION_REPORT.md` — validation report template.
+
+## Target selection commands
+
+- `scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example`
+- `scripts/base1-recovery-usb-hardware-summary.sh`
+- `scripts/base1-recovery-usb-hardware-checklist.sh`
+- `scripts/base1-recovery-usb-hardware-validate.sh`
+- `scripts/base1-recovery-usb-hardware-report.sh`
+- `scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example`
+
+## Target identity fields
+
+A target selection preview must keep these fields operator-visible:
+
+- Device path.
+- Device model/name.
+- Device size.
+- Removable status.
+- Current mount status.
+- Filesystem labels if visible.
+- Data preservation status.
+- Internal disk status.
+- Physical USB label status.
+- Confirmation status.
+
+## Shared guardrails
+
+Every target-selection document or command must preserve these rules:
+
+- Require dry-run mode for target-specific previews.
+- Require an explicit target device path.
+- Make target identity visible.
+- Report writes: no.
+- Do not write USB media.
+- Do not run dd automatically.
+- Do not partition disks.
+- Do not format disks.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not flash firmware.
+- Do not change boot order.
+- Do not store passwords, tokens, private keys, recovery phrases, or personal secrets.
+- Do not allow hidden target selection.
+- Do not default to the internal system disk.
+
+## Promotion rule
+
+A future recovery USB writer can only follow after target identity, image provenance, checksum verification, emergency shell behavior, rollback metadata, storage layout, and actual Libreboot/X200-class boot behavior are verified.

--- a/base1/RECOVERY_USB_TARGET_SELECTION.md
+++ b/base1/RECOVERY_USB_TARGET_SELECTION.md
@@ -74,3 +74,6 @@ Run first:
 ## Promotion rule
 
 A future recovery USB writer can only follow after target identity, image provenance, checksum verification, emergency shell behavior, rollback metadata, storage layout, and actual Libreboot/X200-class boot behavior are verified.
+
+
+See also: [Recovery USB target selection command index](RECOVERY_USB_TARGET_COMMAND_INDEX.md).

--- a/tests/base1_recovery_usb_target_command_index_docs.rs
+++ b/tests/base1_recovery_usb_target_command_index_docs.rs
@@ -1,0 +1,98 @@
+#[test]
+fn recovery_usb_target_command_index_lists_docs_and_commands() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md")
+        .expect("recovery usb target command index");
+
+    assert!(
+        doc.contains("Base1 recovery USB target selection command index"),
+        "{doc}"
+    );
+    assert!(doc.contains("RECOVERY_USB_TARGET_SELECTION.md"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_HARDWARE_SUMMARY.md"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_HARDWARE_CHECKLIST.md"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_COMMAND_INDEX.md"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_VALIDATION_REPORT.md"), "{doc}");
+    assert!(
+        doc.contains(
+            "scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example"
+        ),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-recovery-usb-hardware-validate.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_target_command_index_preserves_identity_fields() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md")
+        .expect("recovery usb target command index");
+
+    assert!(doc.contains("Device path"), "{doc}");
+    assert!(doc.contains("Device model/name"), "{doc}");
+    assert!(doc.contains("Device size"), "{doc}");
+    assert!(doc.contains("Removable status"), "{doc}");
+    assert!(doc.contains("Current mount status"), "{doc}");
+    assert!(doc.contains("Internal disk status"), "{doc}");
+    assert!(doc.contains("Physical USB label status"), "{doc}");
+    assert!(doc.contains("Confirmation status"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_target_command_index_preserves_guardrails() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md")
+        .expect("recovery usb target command index");
+
+    assert!(doc.contains("Require dry-run mode"), "{doc}");
+    assert!(
+        doc.contains("Require an explicit target device path"),
+        "{doc}"
+    );
+    assert!(doc.contains("Report writes: no"), "{doc}");
+    assert!(doc.contains("Do not write USB media"), "{doc}");
+    assert!(doc.contains("Do not run dd automatically"), "{doc}");
+    assert!(doc.contains("Do not partition disks"), "{doc}");
+    assert!(doc.contains("Do not format disks"), "{doc}");
+    assert!(doc.contains("Do not install GRUB automatically"), "{doc}");
+    assert!(
+        doc.contains("Do not allow hidden target selection"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Do not default to the internal system disk"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_surfaces_link_target_command_index() {
+    let target = std::fs::read_to_string("base1/RECOVERY_USB_TARGET_SELECTION.md")
+        .expect("recovery usb target selection");
+    let index = std::fs::read_to_string("base1/RECOVERY_USB_COMMAND_INDEX.md")
+        .expect("recovery usb command index");
+    let summary = std::fs::read_to_string("base1/RECOVERY_USB_HARDWARE_SUMMARY.md")
+        .expect("recovery usb hardware summary");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        target.contains("RECOVERY_USB_TARGET_COMMAND_INDEX.md"),
+        "{target}"
+    );
+    assert!(
+        index.contains("RECOVERY_USB_TARGET_COMMAND_INDEX.md"),
+        "{index}"
+    );
+    assert!(
+        summary.contains("RECOVERY_USB_TARGET_COMMAND_INDEX.md"),
+        "{summary}"
+    );
+    assert!(
+        readme.contains("base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds a command index for Base1 recovery USB target-device selection.

Implements:
- Recovery USB target selection command index
- target selection docs and command list
- target identity fields
- shared target-selection guardrails
- README and recovery USB surface links
- docs tests for command index coverage

Validation:
- cargo test -p phase1 --test base1_recovery_usb_target_command_index_docs
- cargo test -p phase1 --test base1_recovery_usb_target_dry_run_script
- cargo test -p phase1 --test base1_recovery_usb_target_selection_docs
- cargo test -p phase1 --test base1_recovery_usb_hardware_summary_docs
- cargo test -p phase1 --test base1_foundation

Refs #135