### PR TITLE
Add Base1 recovery USB target selection report

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ sh scripts/base1-recovery-usb-hardware-validate.sh
 sh scripts/base1-recovery-usb-hardware-checklist.sh
 sh scripts/base1-recovery-usb-index.sh
 sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-recovery-usb-target-report.sh
 sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
 sh scripts/base1-libreboot-milestone.sh
 sh scripts/base1-libreboot-docs.sh

--- a/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
+++ b/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
@@ -28,6 +28,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 Run the read-only commands first:
 
     sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+    sh scripts/base1-recovery-usb-target-report.sh
     sh scripts/base1-recovery-usb-hardware-summary.sh
     sh scripts/base1-recovery-usb-index.sh
     sh scripts/base1-recovery-usb-hardware-checklist.sh

--- a/base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
@@ -15,6 +15,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 ## Target selection commands
 
 - `scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example`
+- `scripts/base1-recovery-usb-target-report.sh`
 - `scripts/base1-recovery-usb-hardware-summary.sh`
 - `scripts/base1-recovery-usb-hardware-checklist.sh`
 - `scripts/base1-recovery-usb-hardware-validate.sh`

--- a/base1/RECOVERY_USB_TARGET_SELECTION.md
+++ b/base1/RECOVERY_USB_TARGET_SELECTION.md
@@ -51,6 +51,7 @@ This design does not implement that mutating command. It only records the future
 Run first:
 
     sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+    sh scripts/base1-recovery-usb-target-report.sh
     sh scripts/base1-recovery-usb-hardware-summary.sh
     sh scripts/base1-recovery-usb-hardware-validate.sh
     sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example

--- a/scripts/base1-recovery-usb-target-report.sh
+++ b/scripts/base1-recovery-usb-target-report.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 recovery USB target selection report
+
+usage:
+  sh scripts/base1-recovery-usb-target-report.sh
+
+This command is read-only. It prints a target-device selection report template
+without writing USB media, changing boot settings, writing to /boot, modifying
+disks, flashing firmware, or changing host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+cat <<'EOF'
+base1 recovery USB target selection report
+mode               : read-only
+writes             : no
+firmware           : Libreboot expected
+hardware           : X200-class expected
+bootloader         : GRUB first
+media              : external USB planned
+trust              : no host trust escalation
+
+target identity:
+- device path: unknown
+- device model/name: unknown
+- device size: unknown
+- removable status: unknown
+- current mount status: unknown
+- filesystem labels: unknown
+- data preservation status: unknown
+- internal disk status: unknown
+- physical USB label status: unknown
+- operator confirmation status: not accepted in report mode
+
+required future confirmation phrase:
+I understand this will write recovery USB media to the selected device
+
+validation commands:
+- sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+- sh scripts/base1-recovery-usb-target-report.sh
+- sh scripts/base1-recovery-usb-hardware-summary.sh
+- sh scripts/base1-recovery-usb-hardware-validate.sh
+
+status: target selection not completed
+EOF

--- a/tests/base1_recovery_usb_target_report_script.rs
+++ b/tests/base1_recovery_usb_target_report_script.rs
@@ -1,0 +1,100 @@
+use std::process::Command;
+
+#[test]
+fn recovery_usb_target_report_script_prints_report_template() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-target-report.sh")
+        .output()
+        .expect("run recovery USB target report script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("base1 recovery USB target selection report"),
+        "{text}"
+    );
+    assert!(text.contains("mode               : read-only"), "{text}");
+    assert!(text.contains("writes             : no"), "{text}");
+    assert!(
+        text.contains("firmware           : Libreboot expected"),
+        "{text}"
+    );
+    assert!(
+        text.contains("hardware           : X200-class expected"),
+        "{text}"
+    );
+    assert!(text.contains("bootloader         : GRUB first"), "{text}");
+    assert!(
+        text.contains("trust              : no host trust escalation"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_target_report_script_lists_identity_fields_and_commands() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-target-report.sh")
+        .output()
+        .expect("run recovery USB target report script");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(text.contains("device path: unknown"), "{text}");
+    assert!(text.contains("device model/name: unknown"), "{text}");
+    assert!(text.contains("device size: unknown"), "{text}");
+    assert!(text.contains("removable status: unknown"), "{text}");
+    assert!(text.contains("current mount status: unknown"), "{text}");
+    assert!(text.contains("internal disk status: unknown"), "{text}");
+    assert!(
+        text.contains("physical USB label status: unknown"),
+        "{text}"
+    );
+    assert!(
+        text.contains("I understand this will write recovery USB media to the selected device"),
+        "{text}"
+    );
+    assert!(
+        text.contains(
+            "sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example"
+        ),
+        "{text}"
+    );
+    assert!(text.contains("target selection not completed"), "{text}");
+}
+
+#[test]
+fn recovery_usb_target_report_script_avoids_mutating_tools_and_sensitive_terms() {
+    let script = std::fs::read_to_string("scripts/base1-recovery-usb-target-report.sh")
+        .expect("recovery USB target report script");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only target-device selection report command for Base1 recovery USB planning.

Implements:
- scripts/base1-recovery-usb-target-report.sh
- target identity report template
- future confirmation phrase visibility
- README, target selection, target command index, and hardware summary updates
- mutating-tool and sensitive-term guard test

Validation:
- cargo test -p phase1 --test base1_recovery_usb_target_report_script
- cargo test -p phase1 --test base1_recovery_usb_target_dry_run_script
- cargo test -p phase1 --test base1_recovery_usb_target_command_index_docs
- cargo test -p phase1 --test base1_recovery_usb_target_selection_docs
- cargo test -p phase1 --test base1_foundation

Refs #135