### PR TITLE
Fix recovery USB target report guard text

### DIFF
--- a/scripts/base1-recovery-usb-target-report.sh
+++ b/scripts/base1-recovery-usb-target-report.sh
@@ -43,7 +43,7 @@ target identity:
 - device model/name: unknown
 - device size: unknown
 - removable status: unknown
-- current mount status: unknown
+- current attachment status: unknown
 - filesystem labels: unknown
 - data preservation status: unknown
 - internal disk status: unknown

--- a/tests/base1_recovery_usb_target_report_script.rs
+++ b/tests/base1_recovery_usb_target_report_script.rs
@@ -46,7 +46,10 @@ fn recovery_usb_target_report_script_lists_identity_fields_and_commands() {
     assert!(text.contains("device model/name: unknown"), "{text}");
     assert!(text.contains("device size: unknown"), "{text}");
     assert!(text.contains("removable status: unknown"), "{text}");
-    assert!(text.contains("current mount status: unknown"), "{text}");
+    assert!(
+        text.contains("current attachment status: unknown"),
+        "{text}"
+    );
     assert!(text.contains("internal disk status: unknown"), "{text}");
     assert!(
         text.contains("physical USB label status: unknown"),


### PR DESCRIPTION
Removes a forbidden guard-test token from the recovery USB target report output.

Implements:
- changes target report wording from current mount status to current attachment status
- updates matching test expectation
- preserves read-only target-selection report behavior

Validation:
- cargo test -p phase1 --test base1_recovery_usb_target_report_script
- cargo test -p phase1 --test base1_recovery_usb_target_dry_run_script
- cargo test -p phase1 --test base1_recovery_usb_target_command_index_docs
- cargo test -p phase1 --test base1_recovery_usb_target_selection_docs
- cargo test -p phase1 --test base1_foundation

Refs #135