### PR TITLE
Add Base1 recovery USB target selection validation bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ sh scripts/base1-recovery-usb-hardware-validate.sh
 sh scripts/base1-recovery-usb-hardware-checklist.sh
 sh scripts/base1-recovery-usb-index.sh
 sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-recovery-usb-target-validate.sh
 sh scripts/base1-recovery-usb-target-report.sh
 sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example
 sh scripts/base1-libreboot-milestone.sh

--- a/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
+++ b/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
@@ -28,6 +28,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 Run the read-only commands first:
 
     sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+    sh scripts/base1-recovery-usb-target-validate.sh
     sh scripts/base1-recovery-usb-target-report.sh
     sh scripts/base1-recovery-usb-hardware-summary.sh
     sh scripts/base1-recovery-usb-index.sh

--- a/base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
@@ -15,6 +15,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 ## Target selection commands
 
 - `scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example`
+- `scripts/base1-recovery-usb-target-validate.sh`
 - `scripts/base1-recovery-usb-target-report.sh`
 - `scripts/base1-recovery-usb-hardware-summary.sh`
 - `scripts/base1-recovery-usb-hardware-checklist.sh`

--- a/base1/RECOVERY_USB_TARGET_SELECTION.md
+++ b/base1/RECOVERY_USB_TARGET_SELECTION.md
@@ -51,6 +51,7 @@ This design does not implement that mutating command. It only records the future
 Run first:
 
     sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+    sh scripts/base1-recovery-usb-target-validate.sh
     sh scripts/base1-recovery-usb-target-report.sh
     sh scripts/base1-recovery-usb-hardware-summary.sh
     sh scripts/base1-recovery-usb-hardware-validate.sh

--- a/scripts/base1-recovery-usb-target-validate.sh
+++ b/scripts/base1-recovery-usb-target-validate.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 recovery USB target selection validation bundle
+
+usage:
+  sh scripts/base1-recovery-usb-target-validate.sh
+
+This command is read-only. It runs target-device selection previews without
+writing USB media, changing boot settings, writing to /boot, modifying disks,
+changing firmware state, or changing host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+run_cmd() {
+  echo
+  echo "$ $*"
+  "$@"
+}
+
+cat <<'EOF'
+base1 recovery USB target selection validation bundle
+mode               : read-only
+writes             : no
+firmware           : Libreboot expected
+hardware           : X200-class expected
+bootloader         : GRUB first
+media              : external USB planned
+target             : /dev/example preview
+identity           : operator-confirmed
+internal_disk      : must be no
+confirmation       : not accepted in validation bundle
+trust              : no host trust escalation
+EOF
+
+run_cmd sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+run_cmd sh scripts/base1-recovery-usb-target-report.sh
+run_cmd sh scripts/base1-recovery-usb-hardware-summary.sh
+run_cmd sh scripts/base1-recovery-usb-hardware-validate.sh
+run_cmd sh scripts/base1-recovery-usb-index.sh
+
+echo
+echo "base1 recovery USB target selection validation bundle complete"

--- a/tests/base1_recovery_usb_target_validation_bundle.rs
+++ b/tests/base1_recovery_usb_target_validation_bundle.rs
@@ -1,0 +1,101 @@
+use std::process::Command;
+
+#[test]
+fn recovery_usb_target_validation_bundle_runs_read_only_previews() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-target-validate.sh")
+        .output()
+        .expect("run recovery USB target validation bundle");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("base1 recovery USB target selection validation bundle"),
+        "{text}"
+    );
+    assert!(text.contains("mode               : read-only"), "{text}");
+    assert!(text.contains("writes             : no"), "{text}");
+    assert!(
+        text.contains("firmware           : Libreboot expected"),
+        "{text}"
+    );
+    assert!(
+        text.contains("hardware           : X200-class expected"),
+        "{text}"
+    );
+    assert!(text.contains("bootloader         : GRUB first"), "{text}");
+    assert!(
+        text.contains("target             : /dev/example preview"),
+        "{text}"
+    );
+    assert!(text.contains("internal_disk      : must be no"), "{text}");
+    assert!(
+        text.contains("base1 recovery USB target selection dry-run"),
+        "{text}"
+    );
+    assert!(
+        text.contains("base1 recovery USB target selection report"),
+        "{text}"
+    );
+    assert!(
+        text.contains("base1 recovery USB hardware validation summary"),
+        "{text}"
+    );
+    assert!(
+        text.contains("base1 recovery USB target selection validation bundle complete"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_target_validation_bundle_help_is_read_only() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-target-validate.sh")
+        .arg("--help")
+        .output()
+        .expect("run recovery USB target validation help");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("read-only"), "{text}");
+    assert!(text.contains("without"), "{text}");
+    assert!(text.contains("host trust"), "{text}");
+}
+
+#[test]
+fn recovery_usb_target_validation_bundle_avoids_mutating_tools_and_sensitive_terms() {
+    let script = std::fs::read_to_string("scripts/base1-recovery-usb-target-validate.sh")
+        .expect("recovery USB target validation bundle");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only target-device selection validation bundle for Base1 recovery USB planning.

Implements:
- scripts/base1-recovery-usb-target-validate.sh
- grouped target dry-run, report, hardware summary, and validation command runner
- target identity and internal-disk guardrail summary
- README, target selection, target command index, and hardware summary updates
- mutating-tool and sensitive-term guard test

Validation:
- cargo test -p phase1 --test base1_recovery_usb_target_validation_bundle
- cargo test -p phase1 --test base1_recovery_usb_target_report_script
- cargo test -p phase1 --test base1_recovery_usb_target_dry_run_script
- cargo test -p phase1 --test base1_recovery_usb_target_command_index_docs
- cargo test -p phase1 --test base1_foundation

Refs #135