### PR TITLE
Document Base1 recovery USB target summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Start here:
 - [`base1/RECOVERY_USB_HARDWARE_SUMMARY.md`](base1/RECOVERY_USB_HARDWARE_SUMMARY.md) — Recovery USB hardware validation summary
 - [`base1/RECOVERY_USB_TARGET_SELECTION.md`](base1/RECOVERY_USB_TARGET_SELECTION.md) — Recovery USB target-device selection design
 - [`base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md`](base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md) — Recovery USB target selection command index
+- [`base1/RECOVERY_USB_TARGET_SUMMARY.md`](base1/RECOVERY_USB_TARGET_SUMMARY.md) — Recovery USB target selection summary
 - [`RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md) — Recovery USB hardware read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1.md) — Libreboot read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md) — Libreboot read-only checkpoint v1.1 release notes

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -12,6 +12,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 - `base1/RECOVERY_USB_HARDWARE_SUMMARY.md` — Recovery USB hardware validation summary.
 - `base1/RECOVERY_USB_TARGET_SELECTION.md` — Recovery USB target-device selection design.
 - `base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md` — Recovery USB target selection command index.
+- `base1/RECOVERY_USB_TARGET_SUMMARY.md` — Recovery USB target selection summary.
 - `base1/LIBREBOOT_DOCS_SUMMARY.md` — Libreboot documentation path.
 - `base1/LIBREBOOT_MILESTONE.md` — Libreboot read-only milestone checkpoint.
 - `base1/LIBREBOOT_VALIDATION_REPORT.md` — validation report template.

--- a/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
+++ b/base1/RECOVERY_USB_HARDWARE_SUMMARY.md
@@ -80,3 +80,6 @@ See also: [Recovery USB target-device selection design](RECOVERY_USB_TARGET_SELE
 
 
 See also: [Recovery USB target selection command index](RECOVERY_USB_TARGET_COMMAND_INDEX.md).
+
+
+See also: [Recovery USB target selection summary](RECOVERY_USB_TARGET_SUMMARY.md).

--- a/base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
@@ -7,6 +7,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 ## Target selection documents
 
 - `base1/RECOVERY_USB_TARGET_SELECTION.md` — target-device selection design.
+- `base1/RECOVERY_USB_TARGET_SUMMARY.md` — Recovery USB target selection summary.
 - `base1/RECOVERY_USB_HARDWARE_SUMMARY.md` — recovery USB hardware validation summary.
 - `base1/RECOVERY_USB_HARDWARE_CHECKLIST.md` — hardware observation checklist.
 - `base1/RECOVERY_USB_COMMAND_INDEX.md` — broader recovery USB command index.

--- a/base1/RECOVERY_USB_TARGET_SELECTION.md
+++ b/base1/RECOVERY_USB_TARGET_SELECTION.md
@@ -79,3 +79,6 @@ A future recovery USB writer can only follow after target identity, image proven
 
 
 See also: [Recovery USB target selection command index](RECOVERY_USB_TARGET_COMMAND_INDEX.md).
+
+
+See also: [Recovery USB target selection summary](RECOVERY_USB_TARGET_SUMMARY.md).

--- a/base1/RECOVERY_USB_TARGET_SUMMARY.md
+++ b/base1/RECOVERY_USB_TARGET_SUMMARY.md
@@ -1,0 +1,71 @@
+# Base1 recovery USB target selection summary
+
+This summary ties together the read-only target-device selection path for Base1 recovery USB planning.
+
+This document is advisory and read-only. It does not write USB media, partition disks, format disks, install GRUB, edit grub.cfg, write to /boot, flash firmware, change boot order, or modify host trust.
+
+## Target scope
+
+- Firmware profile: Libreboot expected.
+- Hardware profile: ThinkPad X200-class expected.
+- Bootloader expectation: GRUB first.
+- Recovery media: external USB planned.
+- Target selection mode: explicit device path only.
+- Secure Boot: not assumed.
+- TPM: not assumed.
+- Current maturity: target identity previews, reports, validation bundle, and read-only documentation.
+
+## Read first
+
+1. `base1/RECOVERY_USB_TARGET_SELECTION.md`
+2. `base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md`
+3. `base1/RECOVERY_USB_HARDWARE_SUMMARY.md`
+4. `base1/RECOVERY_USB_COMMAND_INDEX.md`
+5. `base1/RECOVERY_USB_VALIDATION_REPORT.md`
+
+## First commands
+
+Run the read-only commands first:
+
+    sh scripts/base1-recovery-usb-target-validate.sh
+    sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+    sh scripts/base1-recovery-usb-target-report.sh
+    sh scripts/base1-recovery-usb-hardware-summary.sh
+    sh scripts/base1-recovery-usb-hardware-validate.sh
+
+## Target identity fields
+
+The current target-selection path records:
+
+- Device path.
+- Device model/name.
+- Device size.
+- Removable status.
+- Current attachment status.
+- Filesystem labels if visible.
+- Data preservation status.
+- Internal disk status.
+- Physical USB label status.
+- Operator confirmation status.
+
+## Future confirmation phrase
+
+A future mutating recovery USB writer must require this exact operator phrase before writing media:
+
+I understand this will write recovery USB media to the selected device
+
+## Still not claimed
+
+This summary does not claim:
+
+- USB media writing readiness.
+- Bootable Base1 image readiness.
+- Destructive installer readiness.
+- Hidden target discovery safety.
+- Automatic internal-disk protection beyond read-only guardrails.
+- Real-hardware recovery completion.
+- Real-hardware rollback completion.
+
+## Promotion rule
+
+Recovery USB target selection must remain read-only until target identity, image provenance, checksum verification, emergency shell behavior, rollback metadata, storage layout, and actual Libreboot/X200-class boot behavior are verified.

--- a/tests/base1_recovery_usb_target_summary_docs.rs
+++ b/tests/base1_recovery_usb_target_summary_docs.rs
@@ -1,0 +1,89 @@
+#[test]
+fn recovery_usb_target_summary_lists_core_docs_and_commands() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_TARGET_SUMMARY.md")
+        .expect("recovery usb target summary");
+
+    assert!(
+        doc.contains("Base1 recovery USB target selection summary"),
+        "{doc}"
+    );
+    assert!(doc.contains("RECOVERY_USB_TARGET_SELECTION.md"), "{doc}");
+    assert!(
+        doc.contains("RECOVERY_USB_TARGET_COMMAND_INDEX.md"),
+        "{doc}"
+    );
+    assert!(doc.contains("RECOVERY_USB_HARDWARE_SUMMARY.md"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_COMMAND_INDEX.md"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_VALIDATION_REPORT.md"), "{doc}");
+    assert!(
+        doc.contains("sh scripts/base1-recovery-usb-target-validate.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains(
+            "sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example"
+        ),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("sh scripts/base1-recovery-usb-target-report.sh"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_target_summary_records_identity_fields_and_confirmation() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_TARGET_SUMMARY.md")
+        .expect("recovery usb target summary");
+
+    assert!(doc.contains("Device path"), "{doc}");
+    assert!(doc.contains("Device model/name"), "{doc}");
+    assert!(doc.contains("Device size"), "{doc}");
+    assert!(doc.contains("Removable status"), "{doc}");
+    assert!(doc.contains("Current attachment status"), "{doc}");
+    assert!(doc.contains("Internal disk status"), "{doc}");
+    assert!(doc.contains("Operator confirmation status"), "{doc}");
+    assert!(
+        doc.contains("I understand this will write recovery USB media to the selected device"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_target_summary_preserves_non_claims_and_promotion_rule() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_TARGET_SUMMARY.md")
+        .expect("recovery usb target summary");
+
+    assert!(doc.contains("USB media writing readiness"), "{doc}");
+    assert!(doc.contains("Bootable Base1 image readiness"), "{doc}");
+    assert!(doc.contains("Destructive installer readiness"), "{doc}");
+    assert!(doc.contains("Hidden target discovery safety"), "{doc}");
+    assert!(doc.contains("Real-hardware recovery completion"), "{doc}");
+    assert!(doc.contains("Real-hardware rollback completion"), "{doc}");
+    assert!(doc.contains("must remain read-only"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_target_surfaces_link_target_summary() {
+    let target = std::fs::read_to_string("base1/RECOVERY_USB_TARGET_SELECTION.md")
+        .expect("recovery usb target selection");
+    let index = std::fs::read_to_string("base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md")
+        .expect("recovery usb target command index");
+    let hardware = std::fs::read_to_string("base1/RECOVERY_USB_HARDWARE_SUMMARY.md")
+        .expect("recovery usb hardware summary");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        target.contains("RECOVERY_USB_TARGET_SUMMARY.md"),
+        "{target}"
+    );
+    assert!(index.contains("RECOVERY_USB_TARGET_SUMMARY.md"), "{index}");
+    assert!(
+        hardware.contains("RECOVERY_USB_TARGET_SUMMARY.md"),
+        "{hardware}"
+    );
+    assert!(
+        readme.contains("base1/RECOVERY_USB_TARGET_SUMMARY.md"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds a read-only target-device selection summary for Base1 recovery USB planning.

Implements:
- Recovery USB target selection summary
- target-selection doc and command path
- target identity field summary
- future confirmation phrase visibility
- explicit non-claims and promotion rule
- README and recovery USB surface links
- docs tests for target summary coverage

Validation:
- cargo test -p phase1 --test base1_recovery_usb_target_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_target_validation_bundle
- cargo test -p phase1 --test base1_recovery_usb_target_report_script
- cargo test -p phase1 --test base1_recovery_usb_target_command_index_docs
- cargo test -p phase1 --test base1_foundation

Refs #135