### PR TITLE
Add Base1 recovery USB target summary command

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ sh scripts/base1-recovery-usb-hardware-validate.sh
 sh scripts/base1-recovery-usb-hardware-checklist.sh
 sh scripts/base1-recovery-usb-index.sh
 sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-recovery-usb-target-summary.sh
 sh scripts/base1-recovery-usb-target-validate.sh
 sh scripts/base1-recovery-usb-target-report.sh
 sh scripts/base1-recovery-usb-dry-run.sh --dry-run --target /dev/example

--- a/base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
@@ -16,6 +16,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 ## Target selection commands
 
 - `scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example`
+- `scripts/base1-recovery-usb-target-summary.sh`
 - `scripts/base1-recovery-usb-target-validate.sh`
 - `scripts/base1-recovery-usb-target-report.sh`
 - `scripts/base1-recovery-usb-hardware-summary.sh`

--- a/base1/RECOVERY_USB_TARGET_SUMMARY.md
+++ b/base1/RECOVERY_USB_TARGET_SUMMARY.md
@@ -27,6 +27,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 
 Run the read-only commands first:
 
+    sh scripts/base1-recovery-usb-target-summary.sh
     sh scripts/base1-recovery-usb-target-validate.sh
     sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
     sh scripts/base1-recovery-usb-target-report.sh

--- a/scripts/base1-recovery-usb-target-summary.sh
+++ b/scripts/base1-recovery-usb-target-summary.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 recovery USB target selection summary
+
+usage:
+  sh scripts/base1-recovery-usb-target-summary.sh
+
+This command is read-only. It prints the recovery USB target selection summary
+without writing USB media, changing boot settings, writing to /boot, modifying
+disks, changing firmware state, or changing host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+cat <<'EOF'
+base1 recovery USB target selection summary
+mode               : read-only
+writes             : no
+firmware           : Libreboot expected
+hardware           : X200-class expected
+bootloader         : GRUB first
+media              : external USB planned
+target_mode        : explicit device path only
+trust              : no host trust escalation
+maturity           : target identity previews, reports, validation bundle, and documentation
+
+read first:
+1. base1/RECOVERY_USB_TARGET_SUMMARY.md
+2. base1/RECOVERY_USB_TARGET_SELECTION.md
+3. base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
+4. base1/RECOVERY_USB_HARDWARE_SUMMARY.md
+5. base1/RECOVERY_USB_COMMAND_INDEX.md
+
+first commands:
+- sh scripts/base1-recovery-usb-target-summary.sh
+- sh scripts/base1-recovery-usb-target-validate.sh
+- sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+- sh scripts/base1-recovery-usb-target-report.sh
+- sh scripts/base1-recovery-usb-hardware-summary.sh
+
+not claimed:
+- USB media writing readiness
+- bootable Base1 image readiness
+- destructive installer readiness
+- hidden target discovery safety
+- real-hardware recovery completion
+- real-hardware rollback completion
+EOF

--- a/tests/base1_recovery_usb_target_summary_script.rs
+++ b/tests/base1_recovery_usb_target_summary_script.rs
@@ -1,0 +1,113 @@
+use std::process::Command;
+
+#[test]
+fn recovery_usb_target_summary_script_prints_summary() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-target-summary.sh")
+        .output()
+        .expect("run recovery USB target summary script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("base1 recovery USB target selection summary"),
+        "{text}"
+    );
+    assert!(text.contains("mode               : read-only"), "{text}");
+    assert!(text.contains("writes             : no"), "{text}");
+    assert!(
+        text.contains("firmware           : Libreboot expected"),
+        "{text}"
+    );
+    assert!(
+        text.contains("hardware           : X200-class expected"),
+        "{text}"
+    );
+    assert!(text.contains("bootloader         : GRUB first"), "{text}");
+    assert!(
+        text.contains("target_mode        : explicit device path only"),
+        "{text}"
+    );
+    assert!(
+        text.contains("trust              : no host trust escalation"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_target_summary_script_lists_docs_commands_and_non_claims() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-target-summary.sh")
+        .output()
+        .expect("run recovery USB target summary script");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        text.contains("base1/RECOVERY_USB_TARGET_SUMMARY.md"),
+        "{text}"
+    );
+    assert!(
+        text.contains("base1/RECOVERY_USB_TARGET_SELECTION.md"),
+        "{text}"
+    );
+    assert!(
+        text.contains("base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-recovery-usb-target-summary.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-recovery-usb-target-validate.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains(
+            "sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example"
+        ),
+        "{text}"
+    );
+    assert!(text.contains("USB media writing readiness"), "{text}");
+    assert!(text.contains("bootable Base1 image readiness"), "{text}");
+    assert!(text.contains("hidden target discovery safety"), "{text}");
+    assert!(text.contains("real-hardware rollback completion"), "{text}");
+}
+
+#[test]
+fn recovery_usb_target_summary_script_avoids_mutating_tools_and_sensitive_terms() {
+    let script = std::fs::read_to_string("scripts/base1-recovery-usb-target-summary.sh")
+        .expect("recovery USB target summary script");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only target-device selection summary command for Base1 recovery USB planning.

Implements:
- scripts/base1-recovery-usb-target-summary.sh
- target selection summary output
- docs and first command list
- explicit non-claims for media writing, image readiness, hidden target discovery, recovery, and rollback
- README, target summary, and target command index updates
- mutating-tool and sensitive-term guard test

Validation:
- cargo test -p phase1 --test base1_recovery_usb_target_summary_script
- cargo test -p phase1 --test base1_recovery_usb_target_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_target_validation_bundle
- cargo test -p phase1 --test base1_recovery_usb_target_report_script
- cargo test -p phase1 --test base1_foundation

Refs #135