### PR TITLE
Document Base1 recovery USB target checkpoint release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Start here:
 - [`base1/RECOVERY_USB_TARGET_SELECTION.md`](base1/RECOVERY_USB_TARGET_SELECTION.md) — Recovery USB target-device selection design
 - [`base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md`](base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md) — Recovery USB target selection command index
 - [`base1/RECOVERY_USB_TARGET_SUMMARY.md`](base1/RECOVERY_USB_TARGET_SUMMARY.md) — Recovery USB target selection summary
+- [`RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md) — Recovery USB target selection read-only checkpoint release notes
 - [`RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md) — Recovery USB hardware read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1.md) — Libreboot read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1_1.md) — Libreboot read-only checkpoint v1.1 release notes

--- a/RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md
+++ b/RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md
@@ -1,0 +1,77 @@
+# Base1 recovery USB target selection read-only checkpoint v1
+
+This checkpoint captures the read-only target-device selection path for Base1 recovery USB planning.
+
+## Status
+
+- Checkpoint branch: checkpoint/base1-recovery-usb-target-readonly-v1
+- Checkpoint tag: base1-recovery-usb-target-readonly-v1
+- Firmware profile: Libreboot expected
+- Hardware profile: ThinkPad X200-class expected
+- Bootloader expectation: GRUB first
+- Recovery media: external USB planned
+- Target selection mode: explicit device path only
+- Secure Boot: not assumed
+- TPM: not assumed
+- Current maturity: target identity previews, reports, validation bundle, summaries, and read-only documentation
+
+## Included documents
+
+- base1/RECOVERY_USB_TARGET_SELECTION.md
+- base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
+- base1/RECOVERY_USB_TARGET_SUMMARY.md
+- base1/RECOVERY_USB_HARDWARE_SUMMARY.md
+- base1/RECOVERY_USB_COMMAND_INDEX.md
+- base1/RECOVERY_USB_VALIDATION_REPORT.md
+
+## Included commands
+
+- scripts/base1-recovery-usb-target-summary.sh
+- scripts/base1-recovery-usb-target-validate.sh
+- scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+- scripts/base1-recovery-usb-target-report.sh
+- scripts/base1-recovery-usb-hardware-summary.sh
+- scripts/base1-recovery-usb-hardware-validate.sh
+
+## Validation
+
+Run:
+
+    cargo test -p phase1 --test base1_recovery_usb_target_summary_script
+    cargo test -p phase1 --test base1_recovery_usb_target_summary_docs
+    cargo test -p phase1 --test base1_recovery_usb_target_validation_bundle
+    cargo test -p phase1 --test base1_recovery_usb_target_report_script
+    cargo test -p phase1 --test base1_recovery_usb_target_dry_run_script
+    cargo test -p phase1 --test base1_recovery_usb_target_command_index_docs
+    cargo test -p phase1 --test base1_foundation
+
+## Guardrails
+
+- Do not write USB media.
+- Do not run dd automatically.
+- Do not partition disks.
+- Do not format disks.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not change boot order.
+- Do not flash firmware.
+- Do not store passwords, tokens, private keys, recovery phrases, or personal secrets.
+- Do not allow hidden target selection.
+- Do not default to the internal system disk.
+
+## Non-claims
+
+This checkpoint does not claim:
+
+- USB media writing readiness.
+- Bootable Base1 image readiness.
+- Destructive installer readiness.
+- Hidden target discovery safety.
+- Automatic internal-disk protection beyond read-only guardrails.
+- Real-hardware recovery completion.
+- Real-hardware rollback completion.
+
+## Next milestone
+
+The next milestone should remain read-only unless target identity, image provenance, checksum verification, emergency shell behavior, rollback metadata, storage layout, and actual Libreboot/X200-class boot behavior are verified.

--- a/base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
@@ -64,3 +64,6 @@ Every target-selection document or command must preserve these rules:
 ## Promotion rule
 
 A future recovery USB writer can only follow after target identity, image provenance, checksum verification, emergency shell behavior, rollback metadata, storage layout, and actual Libreboot/X200-class boot behavior are verified.
+
+
+See also: [`RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md`](../RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md) — recovery USB target selection read-only checkpoint release notes.

--- a/base1/RECOVERY_USB_TARGET_SUMMARY.md
+++ b/base1/RECOVERY_USB_TARGET_SUMMARY.md
@@ -70,3 +70,6 @@ This summary does not claim:
 ## Promotion rule
 
 Recovery USB target selection must remain read-only until target identity, image provenance, checksum verification, emergency shell behavior, rollback metadata, storage layout, and actual Libreboot/X200-class boot behavior are verified.
+
+
+See also: [RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md](../RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md).

--- a/tests/base1_recovery_usb_target_release_notes_docs.rs
+++ b/tests/base1_recovery_usb_target_release_notes_docs.rs
@@ -1,0 +1,73 @@
+#[test]
+fn recovery_usb_target_release_notes_record_checkpoint_status() {
+    let doc = std::fs::read_to_string("RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md")
+        .expect("recovery usb target release notes");
+
+    assert!(
+        doc.contains("Base1 recovery USB target selection read-only checkpoint v1"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("checkpoint/base1-recovery-usb-target-readonly-v1"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("base1-recovery-usb-target-readonly-v1"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Firmware profile: Libreboot expected"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Hardware profile: ThinkPad X200-class expected"),
+        "{doc}"
+    );
+    assert!(doc.contains("Bootloader expectation: GRUB first"), "{doc}");
+    assert!(doc.contains("explicit device path only"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_target_release_notes_list_surfaces_and_non_claims() {
+    let doc = std::fs::read_to_string("RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md")
+        .expect("recovery usb target release notes");
+
+    assert!(
+        doc.contains("base1/RECOVERY_USB_TARGET_SUMMARY.md"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-recovery-usb-target-summary.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-recovery-usb-target-validate.sh"),
+        "{doc}"
+    );
+    assert!(doc.contains("USB media writing readiness"), "{doc}");
+    assert!(doc.contains("Hidden target discovery safety"), "{doc}");
+    assert!(doc.contains("Real-hardware recovery completion"), "{doc}");
+    assert!(doc.contains("Real-hardware rollback completion"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_target_surfaces_link_release_notes() {
+    let summary = std::fs::read_to_string("base1/RECOVERY_USB_TARGET_SUMMARY.md")
+        .expect("recovery usb target summary");
+    let index = std::fs::read_to_string("base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md")
+        .expect("recovery usb target command index");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        summary.contains("RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md"),
+        "{summary}"
+    );
+    assert!(
+        index.contains("RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md"),
+        "{index}"
+    );
+    assert!(
+        readme.contains("RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds release notes for the Base1 recovery USB target selection read-only checkpoint.

Implements:
- RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md
- target selection docs and commands inventory
- validation command set
- explicit guardrails and non-claims
- README, target summary, and target command index links
- docs tests for release notes coverage

Validation:
- cargo test -p phase1 --test base1_recovery_usb_target_release_notes_docs
- cargo test -p phase1 --test base1_recovery_usb_target_summary_script
- cargo test -p phase1 --test base1_recovery_usb_target_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_target_validation_bundle
- cargo test -p phase1 --test base1_recovery_usb_target_report_script
- cargo test -p phase1 --test base1_foundation

Refs #135