### PR TITLE
Document Base1 recovery USB image provenance design

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Start here:
 - [`base1/RECOVERY_USB_TARGET_SELECTION.md`](base1/RECOVERY_USB_TARGET_SELECTION.md) — Recovery USB target-device selection design
 - [`base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md`](base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md) — Recovery USB target selection command index
 - [`base1/RECOVERY_USB_TARGET_SUMMARY.md`](base1/RECOVERY_USB_TARGET_SUMMARY.md) — Recovery USB target selection summary
+- [`base1/RECOVERY_USB_IMAGE_PROVENANCE.md`](base1/RECOVERY_USB_IMAGE_PROVENANCE.md) — Recovery USB image provenance and checksum design
 - [`RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md) — Recovery USB target selection read-only checkpoint release notes
 - [`RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md) — Recovery USB hardware read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1.md) — Libreboot read-only checkpoint release notes

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -13,6 +13,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 - `base1/RECOVERY_USB_TARGET_SELECTION.md` — Recovery USB target-device selection design.
 - `base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md` — Recovery USB target selection command index.
 - `base1/RECOVERY_USB_TARGET_SUMMARY.md` — Recovery USB target selection summary.
+- `base1/RECOVERY_USB_IMAGE_PROVENANCE.md` — Recovery USB image provenance and checksum design.
 - `base1/LIBREBOOT_DOCS_SUMMARY.md` — Libreboot documentation path.
 - `base1/LIBREBOOT_MILESTONE.md` — Libreboot read-only milestone checkpoint.
 - `base1/LIBREBOOT_VALIDATION_REPORT.md` — validation report template.

--- a/base1/RECOVERY_USB_IMAGE_PROVENANCE.md
+++ b/base1/RECOVERY_USB_IMAGE_PROVENANCE.md
@@ -1,0 +1,78 @@
+# Base1 recovery USB image provenance and checksum design
+
+This design defines the read-only image provenance and checksum verification path for Base1 recovery USB planning.
+
+This document is advisory and read-only. It does not download images, write USB media, partition disks, format disks, install GRUB, edit grub.cfg, write to /boot, flash firmware, change boot order, or modify host trust.
+
+## Goal
+
+Define how an operator should identify, record, and verify a future recovery USB image before any media-writing command exists.
+
+The image provenance path must keep image origin, checksum expectations, signature expectations, target hardware scope, and operator confirmation visible.
+
+## Target scope
+
+Initial scope:
+
+- Libreboot-backed ThinkPad X200-class systems.
+- GRUB-first boot path.
+- External USB recovery media.
+- Explicit target-device selection already completed.
+- No Secure Boot assumption.
+- No TPM assumption.
+- Keyboard-first and offline-first recovery.
+- Read-only previews only.
+
+## Image provenance checklist
+
+Before any future image-writing work, record:
+
+- Image filename.
+- Image source URL or local source path.
+- Image build commit.
+- Image build date.
+- Image builder identity.
+- Expected SHA256 checksum.
+- Observed SHA256 checksum.
+- Signature status.
+- Signing key identity if signatures exist.
+- Target hardware profile.
+- Target bootloader expectation.
+- Recovery shell availability.
+- Rollback metadata compatibility.
+
+## Checksum rule
+
+A future recovery USB writer must refuse to write unless the observed checksum exactly matches the expected checksum.
+
+This design does not implement image downloads, signature verification, or media writing. It only records the future verification requirement.
+
+## Read-only commands
+
+Run first:
+
+    sh scripts/base1-recovery-usb-target-summary.sh
+    sh scripts/base1-recovery-usb-target-validate.sh
+    sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+    sh scripts/base1-recovery-usb-hardware-summary.sh
+
+## Guardrails
+
+- Do not download images automatically.
+- Do not write USB media.
+- Do not run dd automatically.
+- Do not partition disks.
+- Do not format disks.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not change boot order.
+- Do not flash firmware.
+- Do not store passwords, tokens, private keys, recovery phrases, or personal secrets.
+- Do not accept missing checksums.
+- Do not accept checksum mismatch.
+- Do not accept hidden image provenance.
+
+## Promotion rule
+
+A future recovery USB writer can only follow after image provenance, checksum verification, target identity, emergency shell behavior, rollback metadata, storage layout, and actual Libreboot/X200-class boot behavior are verified.

--- a/base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
@@ -67,3 +67,6 @@ A future recovery USB writer can only follow after target identity, image proven
 
 
 See also: [`RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md`](../RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md) — recovery USB target selection read-only checkpoint release notes.
+
+
+See also: [Recovery USB image provenance and checksum design](RECOVERY_USB_IMAGE_PROVENANCE.md).

--- a/base1/RECOVERY_USB_TARGET_SUMMARY.md
+++ b/base1/RECOVERY_USB_TARGET_SUMMARY.md
@@ -73,3 +73,6 @@ Recovery USB target selection must remain read-only until target identity, image
 
 
 See also: [RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md](../RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md).
+
+
+See also: [Recovery USB image provenance and checksum design](RECOVERY_USB_IMAGE_PROVENANCE.md).

--- a/tests/base1_recovery_usb_image_provenance_docs.rs
+++ b/tests/base1_recovery_usb_image_provenance_docs.rs
@@ -1,0 +1,79 @@
+#[test]
+fn recovery_usb_image_provenance_defines_read_only_verification_path() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_IMAGE_PROVENANCE.md")
+        .expect("recovery usb image provenance design");
+
+    assert!(
+        doc.contains("Base1 recovery USB image provenance and checksum design"),
+        "{doc}"
+    );
+    assert!(doc.contains("advisory and read-only"), "{doc}");
+    assert!(doc.contains("does not download images"), "{doc}");
+    assert!(doc.contains("Image filename"), "{doc}");
+    assert!(
+        doc.contains("Image source URL or local source path"),
+        "{doc}"
+    );
+    assert!(doc.contains("Image build commit"), "{doc}");
+    assert!(doc.contains("Expected SHA256 checksum"), "{doc}");
+    assert!(doc.contains("Observed SHA256 checksum"), "{doc}");
+    assert!(doc.contains("Signature status"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_image_provenance_requires_checksum_rule() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_IMAGE_PROVENANCE.md")
+        .expect("recovery usb image provenance design");
+
+    assert!(doc.contains("Checksum rule"), "{doc}");
+    assert!(
+        doc.contains("refuse to write unless the observed checksum exactly matches"),
+        "{doc}"
+    );
+    assert!(doc.contains("does not implement image downloads"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_image_provenance_preserves_guardrails() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_IMAGE_PROVENANCE.md")
+        .expect("recovery usb image provenance design");
+
+    assert!(
+        doc.contains("Do not download images automatically"),
+        "{doc}"
+    );
+    assert!(doc.contains("Do not write USB media"), "{doc}");
+    assert!(doc.contains("Do not run dd automatically"), "{doc}");
+    assert!(doc.contains("Do not partition disks"), "{doc}");
+    assert!(doc.contains("Do not format disks"), "{doc}");
+    assert!(doc.contains("Do not install GRUB automatically"), "{doc}");
+    assert!(doc.contains("Do not write to /boot"), "{doc}");
+    assert!(doc.contains("Do not accept missing checksums"), "{doc}");
+    assert!(doc.contains("Do not accept checksum mismatch"), "{doc}");
+    assert!(
+        doc.contains("Do not accept hidden image provenance"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_surfaces_link_image_provenance_design() {
+    let target = std::fs::read_to_string("base1/RECOVERY_USB_TARGET_SUMMARY.md")
+        .expect("recovery usb target summary");
+    let index = std::fs::read_to_string("base1/RECOVERY_USB_COMMAND_INDEX.md")
+        .expect("recovery usb command index");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        target.contains("RECOVERY_USB_IMAGE_PROVENANCE.md"),
+        "{target}"
+    );
+    assert!(
+        index.contains("RECOVERY_USB_IMAGE_PROVENANCE.md"),
+        "{index}"
+    );
+    assert!(
+        readme.contains("base1/RECOVERY_USB_IMAGE_PROVENANCE.md"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds a read-only image provenance and checksum verification design for Base1 recovery USB planning.

Implements:
- Recovery USB image provenance and checksum design
- image identity and source checklist
- checksum verification rule
- guardrails against missing checksums, checksum mismatch, and hidden provenance
- README and recovery USB surface links
- docs tests for provenance coverage

Validation:
- cargo test -p phase1 --test base1_recovery_usb_image_provenance_docs
- cargo test -p phase1 --test base1_recovery_usb_target_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_target_validation_bundle
- cargo test -p phase1 --test base1_recovery_usb_target_command_index_docs
- cargo test -p phase1 --test base1_foundation

Refs #135