### PR TITLE
Add Base1 recovery USB image provenance report

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ sh scripts/base1-recovery-usb-hardware-validate.sh
 sh scripts/base1-recovery-usb-hardware-checklist.sh
 sh scripts/base1-recovery-usb-index.sh
 sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-recovery-usb-image-report.sh
 sh scripts/base1-recovery-usb-target-summary.sh
 sh scripts/base1-recovery-usb-target-validate.sh
 sh scripts/base1-recovery-usb-target-report.sh

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -14,6 +14,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 - `base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md` — Recovery USB target selection command index.
 - `base1/RECOVERY_USB_TARGET_SUMMARY.md` — Recovery USB target selection summary.
 - `base1/RECOVERY_USB_IMAGE_PROVENANCE.md` — Recovery USB image provenance and checksum design.
+- `scripts/base1-recovery-usb-image-report.sh` — Recovery USB image provenance report command.
 - `base1/LIBREBOOT_DOCS_SUMMARY.md` — Libreboot documentation path.
 - `base1/LIBREBOOT_MILESTONE.md` — Libreboot read-only milestone checkpoint.
 - `base1/LIBREBOOT_VALIDATION_REPORT.md` — validation report template.

--- a/base1/RECOVERY_USB_IMAGE_PROVENANCE.md
+++ b/base1/RECOVERY_USB_IMAGE_PROVENANCE.md
@@ -51,6 +51,7 @@ This design does not implement image downloads, signature verification, or media
 
 Run first:
 
+    sh scripts/base1-recovery-usb-image-report.sh
     sh scripts/base1-recovery-usb-target-summary.sh
     sh scripts/base1-recovery-usb-target-validate.sh
     sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example

--- a/base1/RECOVERY_USB_TARGET_SUMMARY.md
+++ b/base1/RECOVERY_USB_TARGET_SUMMARY.md
@@ -27,6 +27,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 
 Run the read-only commands first:
 
+    sh scripts/base1-recovery-usb-image-report.sh
     sh scripts/base1-recovery-usb-target-summary.sh
     sh scripts/base1-recovery-usb-target-validate.sh
     sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example

--- a/scripts/base1-recovery-usb-image-report.sh
+++ b/scripts/base1-recovery-usb-image-report.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 recovery USB image provenance report
+
+usage:
+  sh scripts/base1-recovery-usb-image-report.sh
+
+This command is read-only. It prints an image provenance and checksum report
+template without downloading images, writing USB media, changing boot settings,
+writing to /boot, modifying disks, changing firmware state, or changing host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+cat <<'EOF'
+base1 recovery USB image provenance report
+mode                 : read-only
+writes               : no
+firmware             : Libreboot expected
+hardware             : X200-class expected
+bootloader           : GRUB first
+media                : external USB planned
+target_identity      : required before writing
+trust                : no host trust escalation
+
+image provenance:
+- image filename: unknown
+- image source URL or local path: unknown
+- image build commit: unknown
+- image build date: unknown
+- image builder identity: unknown
+- expected SHA256 checksum: unknown
+- observed SHA256 checksum: unknown
+- checksum match: unknown
+- signature status: unknown
+- signing key identity: unknown
+- target hardware profile: unknown
+- target bootloader expectation: GRUB first
+- recovery shell availability: unknown
+- rollback metadata compatibility: unknown
+
+verification rule:
+future media writing must refuse when checksum data is missing or mismatched
+
+validation commands:
+- sh scripts/base1-recovery-usb-image-report.sh
+- sh scripts/base1-recovery-usb-target-summary.sh
+- sh scripts/base1-recovery-usb-target-validate.sh
+- sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+
+status: image provenance not verified
+EOF

--- a/tests/base1_recovery_usb_image_report_script.rs
+++ b/tests/base1_recovery_usb_image_report_script.rs
@@ -1,0 +1,91 @@
+use std::process::Command;
+
+#[test]
+fn recovery_usb_image_report_script_prints_report_template() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-image-report.sh")
+        .output()
+        .expect("run recovery USB image report script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("base1 recovery USB image provenance report"),
+        "{text}"
+    );
+    assert!(text.contains("mode                 : read-only"), "{text}");
+    assert!(text.contains("writes               : no"), "{text}");
+    assert!(
+        text.contains("firmware             : Libreboot expected"),
+        "{text}"
+    );
+    assert!(
+        text.contains("hardware             : X200-class expected"),
+        "{text}"
+    );
+    assert!(text.contains("bootloader           : GRUB first"), "{text}");
+    assert!(
+        text.contains("trust                : no host trust escalation"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_image_report_script_lists_provenance_and_checksums() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-image-report.sh")
+        .output()
+        .expect("run recovery USB image report script");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(text.contains("image filename: unknown"), "{text}");
+    assert!(
+        text.contains("image source URL or local path: unknown"),
+        "{text}"
+    );
+    assert!(text.contains("image build commit: unknown"), "{text}");
+    assert!(text.contains("expected SHA256 checksum: unknown"), "{text}");
+    assert!(text.contains("observed SHA256 checksum: unknown"), "{text}");
+    assert!(text.contains("checksum match: unknown"), "{text}");
+    assert!(text.contains("signature status: unknown"), "{text}");
+    assert!(text.contains("future media writing must refuse"), "{text}");
+    assert!(text.contains("image provenance not verified"), "{text}");
+}
+
+#[test]
+fn recovery_usb_image_report_script_avoids_mutating_tools_and_sensitive_terms() {
+    let script = std::fs::read_to_string("scripts/base1-recovery-usb-image-report.sh")
+        .expect("recovery USB image report script");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only image provenance and checksum report command for Base1 recovery USB planning.

Implements:
- scripts/base1-recovery-usb-image-report.sh
- image provenance report template
- checksum and signature status placeholders
- future checksum refusal rule visibility
- README, image provenance design, command index, and target summary updates
- mutating-tool and sensitive-term guard test

Validation:
- cargo test -p phase1 --test base1_recovery_usb_image_report_script
- cargo test -p phase1 --test base1_recovery_usb_image_provenance_docs
- cargo test -p phase1 --test base1_recovery_usb_target_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_target_validation_bundle
- cargo test -p phase1 --test base1_foundation

Refs #135