### PR TITLE
Add Base1 recovery USB image provenance validation bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ sh scripts/base1-recovery-usb-hardware-validate.sh
 sh scripts/base1-recovery-usb-hardware-checklist.sh
 sh scripts/base1-recovery-usb-index.sh
 sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-recovery-usb-image-validate.sh
 sh scripts/base1-recovery-usb-image-report.sh
 sh scripts/base1-recovery-usb-target-summary.sh
 sh scripts/base1-recovery-usb-target-validate.sh

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -15,6 +15,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 - `base1/RECOVERY_USB_TARGET_SUMMARY.md` — Recovery USB target selection summary.
 - `base1/RECOVERY_USB_IMAGE_PROVENANCE.md` — Recovery USB image provenance and checksum design.
 - `scripts/base1-recovery-usb-image-report.sh` — Recovery USB image provenance report command.
+- `scripts/base1-recovery-usb-image-validate.sh` — Recovery USB image provenance validation bundle.
 - `base1/LIBREBOOT_DOCS_SUMMARY.md` — Libreboot documentation path.
 - `base1/LIBREBOOT_MILESTONE.md` — Libreboot read-only milestone checkpoint.
 - `base1/LIBREBOOT_VALIDATION_REPORT.md` — validation report template.

--- a/base1/RECOVERY_USB_IMAGE_PROVENANCE.md
+++ b/base1/RECOVERY_USB_IMAGE_PROVENANCE.md
@@ -51,6 +51,7 @@ This design does not implement image downloads, signature verification, or media
 
 Run first:
 
+    sh scripts/base1-recovery-usb-image-validate.sh
     sh scripts/base1-recovery-usb-image-report.sh
     sh scripts/base1-recovery-usb-target-summary.sh
     sh scripts/base1-recovery-usb-target-validate.sh

--- a/base1/RECOVERY_USB_TARGET_SUMMARY.md
+++ b/base1/RECOVERY_USB_TARGET_SUMMARY.md
@@ -27,6 +27,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 
 Run the read-only commands first:
 
+    sh scripts/base1-recovery-usb-image-validate.sh
     sh scripts/base1-recovery-usb-image-report.sh
     sh scripts/base1-recovery-usb-target-summary.sh
     sh scripts/base1-recovery-usb-target-validate.sh

--- a/scripts/base1-recovery-usb-image-validate.sh
+++ b/scripts/base1-recovery-usb-image-validate.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 recovery USB image provenance validation bundle
+
+usage:
+  sh scripts/base1-recovery-usb-image-validate.sh
+
+This command is read-only. It runs image provenance and checksum preview
+commands without downloading images, writing USB media, changing boot settings,
+writing to /boot, modifying disks, changing firmware state, or changing host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+run_cmd() {
+  echo
+  echo "$ $*"
+  "$@"
+}
+
+cat <<'EOF'
+base1 recovery USB image provenance validation bundle
+mode                 : read-only
+writes               : no
+downloads            : no
+firmware             : Libreboot expected
+hardware             : X200-class expected
+bootloader           : GRUB first
+media                : external USB planned
+target_identity      : required before writing
+checksum_rule        : exact match required before future writing
+signature_status     : operator-confirmed
+trust                : no host trust escalation
+EOF
+
+run_cmd sh scripts/base1-recovery-usb-image-report.sh
+run_cmd sh scripts/base1-recovery-usb-target-summary.sh
+run_cmd sh scripts/base1-recovery-usb-target-validate.sh
+run_cmd sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+run_cmd sh scripts/base1-recovery-usb-hardware-summary.sh
+
+echo
+echo "base1 recovery USB image provenance validation bundle complete"

--- a/tests/base1_recovery_usb_image_validation_bundle.rs
+++ b/tests/base1_recovery_usb_image_validation_bundle.rs
@@ -1,0 +1,101 @@
+use std::process::Command;
+
+#[test]
+fn recovery_usb_image_validation_bundle_runs_read_only_previews() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-image-validate.sh")
+        .output()
+        .expect("run recovery USB image validation bundle");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("base1 recovery USB image provenance validation bundle"),
+        "{text}"
+    );
+    assert!(text.contains("mode                 : read-only"), "{text}");
+    assert!(text.contains("writes               : no"), "{text}");
+    assert!(text.contains("downloads            : no"), "{text}");
+    assert!(
+        text.contains("firmware             : Libreboot expected"),
+        "{text}"
+    );
+    assert!(
+        text.contains("hardware             : X200-class expected"),
+        "{text}"
+    );
+    assert!(text.contains("bootloader           : GRUB first"), "{text}");
+    assert!(
+        text.contains("checksum_rule        : exact match required before future writing"),
+        "{text}"
+    );
+    assert!(
+        text.contains("base1 recovery USB image provenance report"),
+        "{text}"
+    );
+    assert!(
+        text.contains("base1 recovery USB target selection summary"),
+        "{text}"
+    );
+    assert!(
+        text.contains("base1 recovery USB target selection validation bundle"),
+        "{text}"
+    );
+    assert!(
+        text.contains("base1 recovery USB image provenance validation bundle complete"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_image_validation_bundle_help_is_read_only() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-image-validate.sh")
+        .arg("--help")
+        .output()
+        .expect("run recovery USB image validation help");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("read-only"), "{text}");
+    assert!(text.contains("without downloading images"), "{text}");
+    assert!(text.contains("host trust"), "{text}");
+}
+
+#[test]
+fn recovery_usb_image_validation_bundle_avoids_mutating_tools_and_sensitive_terms() {
+    let script = std::fs::read_to_string("scripts/base1-recovery-usb-image-validate.sh")
+        .expect("recovery USB image validation bundle");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only image provenance and checksum validation bundle for Base1 recovery USB planning.

Implements:
- scripts/base1-recovery-usb-image-validate.sh
- grouped image report, target summary, target validation, and hardware summary runner
- checksum rule and signature status summary
- README, image provenance design, command index, and target summary updates
- mutating-tool and sensitive-term guard test

Validation:
- cargo test -p phase1 --test base1_recovery_usb_image_validation_bundle
- cargo test -p phase1 --test base1_recovery_usb_image_report_script
- cargo test -p phase1 --test base1_recovery_usb_image_provenance_docs
- cargo test -p phase1 --test base1_recovery_usb_target_summary_docs
- cargo test -p phase1 --test base1_foundation

Refs #135