### PR TITLE
Document Base1 recovery USB image provenance summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Start here:
 - [`base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md`](base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md) — Recovery USB target selection command index
 - [`base1/RECOVERY_USB_TARGET_SUMMARY.md`](base1/RECOVERY_USB_TARGET_SUMMARY.md) — Recovery USB target selection summary
 - [`base1/RECOVERY_USB_IMAGE_PROVENANCE.md`](base1/RECOVERY_USB_IMAGE_PROVENANCE.md) — Recovery USB image provenance and checksum design
+- [`base1/RECOVERY_USB_IMAGE_SUMMARY.md`](base1/RECOVERY_USB_IMAGE_SUMMARY.md) — Recovery USB image provenance summary
 - [`RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md) — Recovery USB target selection read-only checkpoint release notes
 - [`RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md) — Recovery USB hardware read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1.md) — Libreboot read-only checkpoint release notes

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -14,6 +14,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 - `base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md` — Recovery USB target selection command index.
 - `base1/RECOVERY_USB_TARGET_SUMMARY.md` — Recovery USB target selection summary.
 - `base1/RECOVERY_USB_IMAGE_PROVENANCE.md` — Recovery USB image provenance and checksum design.
+- `base1/RECOVERY_USB_IMAGE_SUMMARY.md` — Recovery USB image provenance summary.
 - `scripts/base1-recovery-usb-image-report.sh` — Recovery USB image provenance report command.
 - `scripts/base1-recovery-usb-image-validate.sh` — Recovery USB image provenance validation bundle.
 - `base1/LIBREBOOT_DOCS_SUMMARY.md` — Libreboot documentation path.

--- a/base1/RECOVERY_USB_IMAGE_PROVENANCE.md
+++ b/base1/RECOVERY_USB_IMAGE_PROVENANCE.md
@@ -78,3 +78,6 @@ Run first:
 ## Promotion rule
 
 A future recovery USB writer can only follow after image provenance, checksum verification, target identity, emergency shell behavior, rollback metadata, storage layout, and actual Libreboot/X200-class boot behavior are verified.
+
+
+See also: [Recovery USB image provenance summary](RECOVERY_USB_IMAGE_SUMMARY.md).

--- a/base1/RECOVERY_USB_IMAGE_SUMMARY.md
+++ b/base1/RECOVERY_USB_IMAGE_SUMMARY.md
@@ -1,0 +1,76 @@
+# Base1 recovery USB image provenance summary
+
+This summary ties together the read-only image provenance and checksum verification path for Base1 recovery USB planning.
+
+This document is advisory and read-only. It does not download images, write USB media, partition disks, format disks, install GRUB, edit grub.cfg, write to /boot, flash firmware, change boot order, or modify host trust.
+
+## Target scope
+
+- Firmware profile: Libreboot expected.
+- Hardware profile: ThinkPad X200-class expected.
+- Bootloader expectation: GRUB first.
+- Recovery media: external USB planned.
+- Target identity: required before writing.
+- Checksum rule: exact match required before future writing.
+- Signature status: operator-confirmed.
+- Secure Boot: not assumed.
+- TPM: not assumed.
+- Current maturity: image provenance reports, validation bundle, summaries, and read-only documentation.
+
+## Read first
+
+1. `base1/RECOVERY_USB_IMAGE_PROVENANCE.md`
+2. `base1/RECOVERY_USB_IMAGE_SUMMARY.md`
+3. `base1/RECOVERY_USB_TARGET_SUMMARY.md`
+4. `base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md`
+5. `base1/RECOVERY_USB_COMMAND_INDEX.md`
+
+## First commands
+
+Run the read-only commands first:
+
+    sh scripts/base1-recovery-usb-image-validate.sh
+    sh scripts/base1-recovery-usb-image-report.sh
+    sh scripts/base1-recovery-usb-target-summary.sh
+    sh scripts/base1-recovery-usb-target-validate.sh
+    sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+
+## Image provenance fields
+
+The current image provenance path records:
+
+- Image filename.
+- Image source URL or local source path.
+- Image build commit.
+- Image build date.
+- Image builder identity.
+- Expected SHA256 checksum.
+- Observed SHA256 checksum.
+- Checksum match status.
+- Signature status.
+- Signing key identity.
+- Target hardware profile.
+- Target bootloader expectation.
+- Recovery shell availability.
+- Rollback metadata compatibility.
+
+## Verification rule
+
+Future media writing must refuse when checksum data is missing or mismatched.
+
+## Still not claimed
+
+This summary does not claim:
+
+- Image download readiness.
+- Signature verification implementation.
+- USB media writing readiness.
+- Bootable Base1 image readiness.
+- Destructive installer readiness.
+- Hidden image provenance safety beyond read-only guardrails.
+- Real-hardware recovery completion.
+- Real-hardware rollback completion.
+
+## Promotion rule
+
+Recovery USB image work must remain read-only until image provenance, checksum verification, target identity, emergency shell behavior, rollback metadata, storage layout, and actual Libreboot/X200-class boot behavior are verified.

--- a/base1/RECOVERY_USB_TARGET_SUMMARY.md
+++ b/base1/RECOVERY_USB_TARGET_SUMMARY.md
@@ -78,3 +78,6 @@ See also: [RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md](../RELEASE_BASE1_RE
 
 
 See also: [Recovery USB image provenance and checksum design](RECOVERY_USB_IMAGE_PROVENANCE.md).
+
+
+See also: [Recovery USB image provenance summary](RECOVERY_USB_IMAGE_SUMMARY.md).

--- a/tests/base1_recovery_usb_image_summary_docs.rs
+++ b/tests/base1_recovery_usb_image_summary_docs.rs
@@ -1,0 +1,91 @@
+#[test]
+fn recovery_usb_image_summary_lists_core_docs_and_commands() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_IMAGE_SUMMARY.md")
+        .expect("recovery usb image summary");
+
+    assert!(
+        doc.contains("Base1 recovery USB image provenance summary"),
+        "{doc}"
+    );
+    assert!(doc.contains("RECOVERY_USB_IMAGE_PROVENANCE.md"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_IMAGE_SUMMARY.md"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_TARGET_SUMMARY.md"), "{doc}");
+    assert!(
+        doc.contains("RECOVERY_USB_TARGET_COMMAND_INDEX.md"),
+        "{doc}"
+    );
+    assert!(doc.contains("RECOVERY_USB_COMMAND_INDEX.md"), "{doc}");
+    assert!(
+        doc.contains("sh scripts/base1-recovery-usb-image-validate.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("sh scripts/base1-recovery-usb-image-report.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains(
+            "sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example"
+        ),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_image_summary_records_provenance_fields_and_rules() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_IMAGE_SUMMARY.md")
+        .expect("recovery usb image summary");
+
+    assert!(doc.contains("Image filename"), "{doc}");
+    assert!(
+        doc.contains("Image source URL or local source path"),
+        "{doc}"
+    );
+    assert!(doc.contains("Image build commit"), "{doc}");
+    assert!(doc.contains("Expected SHA256 checksum"), "{doc}");
+    assert!(doc.contains("Observed SHA256 checksum"), "{doc}");
+    assert!(doc.contains("Checksum match status"), "{doc}");
+    assert!(doc.contains("Signature status"), "{doc}");
+    assert!(doc.contains("Future media writing must refuse"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_image_summary_preserves_non_claims_and_promotion_rule() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_IMAGE_SUMMARY.md")
+        .expect("recovery usb image summary");
+
+    assert!(doc.contains("Image download readiness"), "{doc}");
+    assert!(
+        doc.contains("Signature verification implementation"),
+        "{doc}"
+    );
+    assert!(doc.contains("USB media writing readiness"), "{doc}");
+    assert!(doc.contains("Bootable Base1 image readiness"), "{doc}");
+    assert!(doc.contains("Destructive installer readiness"), "{doc}");
+    assert!(doc.contains("Hidden image provenance safety"), "{doc}");
+    assert!(doc.contains("Real-hardware recovery completion"), "{doc}");
+    assert!(doc.contains("Real-hardware rollback completion"), "{doc}");
+    assert!(doc.contains("must remain read-only"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_image_surfaces_link_image_summary() {
+    let provenance = std::fs::read_to_string("base1/RECOVERY_USB_IMAGE_PROVENANCE.md")
+        .expect("recovery usb image provenance");
+    let target = std::fs::read_to_string("base1/RECOVERY_USB_TARGET_SUMMARY.md")
+        .expect("recovery usb target summary");
+    let index = std::fs::read_to_string("base1/RECOVERY_USB_COMMAND_INDEX.md")
+        .expect("recovery usb command index");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        provenance.contains("RECOVERY_USB_IMAGE_SUMMARY.md"),
+        "{provenance}"
+    );
+    assert!(target.contains("RECOVERY_USB_IMAGE_SUMMARY.md"), "{target}");
+    assert!(index.contains("RECOVERY_USB_IMAGE_SUMMARY.md"), "{index}");
+    assert!(
+        readme.contains("base1/RECOVERY_USB_IMAGE_SUMMARY.md"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds a read-only image provenance and checksum summary for Base1 recovery USB planning.

Implements:
- Recovery USB image provenance summary
- image provenance doc and command path
- provenance field summary
- checksum refusal rule visibility
- explicit non-claims and promotion rule
- README and recovery USB surface links
- docs tests for image summary coverage

Validation:
- cargo test -p phase1 --test base1_recovery_usb_image_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_image_validation_bundle
- cargo test -p phase1 --test base1_recovery_usb_image_report_script
- cargo test -p phase1 --test base1_recovery_usb_image_provenance_docs
- cargo test -p phase1 --test base1_foundation

Refs #135