### PR TITLE
Add Base1 recovery USB image provenance summary command

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ sh scripts/base1-recovery-usb-hardware-validate.sh
 sh scripts/base1-recovery-usb-hardware-checklist.sh
 sh scripts/base1-recovery-usb-index.sh
 sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-recovery-usb-image-summary.sh
 sh scripts/base1-recovery-usb-image-validate.sh
 sh scripts/base1-recovery-usb-image-report.sh
 sh scripts/base1-recovery-usb-target-summary.sh

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -17,6 +17,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 - `base1/RECOVERY_USB_IMAGE_SUMMARY.md` — Recovery USB image provenance summary.
 - `scripts/base1-recovery-usb-image-report.sh` — Recovery USB image provenance report command.
 - `scripts/base1-recovery-usb-image-validate.sh` — Recovery USB image provenance validation bundle.
+- `scripts/base1-recovery-usb-image-summary.sh` — Recovery USB image provenance summary command.
 - `base1/LIBREBOOT_DOCS_SUMMARY.md` — Libreboot documentation path.
 - `base1/LIBREBOOT_MILESTONE.md` — Libreboot read-only milestone checkpoint.
 - `base1/LIBREBOOT_VALIDATION_REPORT.md` — validation report template.

--- a/base1/RECOVERY_USB_IMAGE_PROVENANCE.md
+++ b/base1/RECOVERY_USB_IMAGE_PROVENANCE.md
@@ -51,6 +51,7 @@ This design does not implement image downloads, signature verification, or media
 
 Run first:
 
+    sh scripts/base1-recovery-usb-image-summary.sh
     sh scripts/base1-recovery-usb-image-validate.sh
     sh scripts/base1-recovery-usb-image-report.sh
     sh scripts/base1-recovery-usb-target-summary.sh

--- a/base1/RECOVERY_USB_IMAGE_SUMMARY.md
+++ b/base1/RECOVERY_USB_IMAGE_SUMMARY.md
@@ -29,6 +29,7 @@ This document is advisory and read-only. It does not download images, write USB 
 
 Run the read-only commands first:
 
+    sh scripts/base1-recovery-usb-image-summary.sh
     sh scripts/base1-recovery-usb-image-validate.sh
     sh scripts/base1-recovery-usb-image-report.sh
     sh scripts/base1-recovery-usb-target-summary.sh

--- a/scripts/base1-recovery-usb-image-summary.sh
+++ b/scripts/base1-recovery-usb-image-summary.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 recovery USB image provenance summary
+
+usage:
+  sh scripts/base1-recovery-usb-image-summary.sh
+
+This command is read-only. It prints the recovery USB image provenance summary
+without downloading images, writing USB media, changing boot settings, writing
+to /boot, modifying disks, changing firmware state, or changing host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+cat <<'EOF'
+base1 recovery USB image provenance summary
+mode                 : read-only
+writes               : no
+downloads            : no
+firmware             : Libreboot expected
+hardware             : X200-class expected
+bootloader           : GRUB first
+media                : external USB planned
+target_identity      : required before writing
+checksum_rule        : exact match required before future writing
+signature_status     : operator-confirmed
+trust                : no host trust escalation
+maturity             : provenance reports, validation bundle, summaries, and documentation
+
+read first:
+1. base1/RECOVERY_USB_IMAGE_SUMMARY.md
+2. base1/RECOVERY_USB_IMAGE_PROVENANCE.md
+3. base1/RECOVERY_USB_TARGET_SUMMARY.md
+4. base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
+5. base1/RECOVERY_USB_COMMAND_INDEX.md
+
+first commands:
+- sh scripts/base1-recovery-usb-image-summary.sh
+- sh scripts/base1-recovery-usb-image-validate.sh
+- sh scripts/base1-recovery-usb-image-report.sh
+- sh scripts/base1-recovery-usb-target-summary.sh
+- sh scripts/base1-recovery-usb-target-validate.sh
+
+not claimed:
+- image download readiness
+- signature verification implementation
+- USB media writing readiness
+- bootable Base1 image readiness
+- destructive installer readiness
+- real-hardware recovery completion
+- real-hardware rollback completion
+EOF

--- a/tests/base1_recovery_usb_image_summary_script.rs
+++ b/tests/base1_recovery_usb_image_summary_script.rs
@@ -1,0 +1,107 @@
+use std::process::Command;
+
+#[test]
+fn recovery_usb_image_summary_script_prints_summary() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-image-summary.sh")
+        .output()
+        .expect("run recovery USB image summary script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("base1 recovery USB image provenance summary"),
+        "{text}"
+    );
+    assert!(text.contains("mode                 : read-only"), "{text}");
+    assert!(text.contains("writes               : no"), "{text}");
+    assert!(text.contains("downloads            : no"), "{text}");
+    assert!(
+        text.contains("firmware             : Libreboot expected"),
+        "{text}"
+    );
+    assert!(
+        text.contains("hardware             : X200-class expected"),
+        "{text}"
+    );
+    assert!(text.contains("bootloader           : GRUB first"), "{text}");
+    assert!(
+        text.contains("checksum_rule        : exact match required before future writing"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_image_summary_script_lists_docs_commands_and_non_claims() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-image-summary.sh")
+        .output()
+        .expect("run recovery USB image summary script");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        text.contains("base1/RECOVERY_USB_IMAGE_SUMMARY.md"),
+        "{text}"
+    );
+    assert!(
+        text.contains("base1/RECOVERY_USB_IMAGE_PROVENANCE.md"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-recovery-usb-image-summary.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-recovery-usb-image-validate.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-recovery-usb-image-report.sh"),
+        "{text}"
+    );
+    assert!(text.contains("image download readiness"), "{text}");
+    assert!(
+        text.contains("signature verification implementation"),
+        "{text}"
+    );
+    assert!(text.contains("USB media writing readiness"), "{text}");
+    assert!(text.contains("real-hardware rollback completion"), "{text}");
+}
+
+#[test]
+fn recovery_usb_image_summary_script_avoids_mutating_tools_and_sensitive_terms() {
+    let script = std::fs::read_to_string("scripts/base1-recovery-usb-image-summary.sh")
+        .expect("recovery USB image summary script");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only image provenance and checksum summary command for Base1 recovery USB planning.

Implements:
- scripts/base1-recovery-usb-image-summary.sh
- image provenance summary output
- docs and first command list
- explicit non-claims for downloads, signatures, media writing, image readiness, recovery, and rollback
- README, image summary, image provenance design, and command index updates
- mutating-tool and sensitive-term guard test

Validation:
- cargo test -p phase1 --test base1_recovery_usb_image_summary_script
- cargo test -p phase1 --test base1_recovery_usb_image_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_image_validation_bundle
- cargo test -p phase1 --test base1_recovery_usb_image_report_script
- cargo test -p phase1 --test base1_foundation

Refs #135