### PR TITLE
Document Base1 recovery USB image command index

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ Start here:
 - [`base1/RECOVERY_USB_TARGET_SUMMARY.md`](base1/RECOVERY_USB_TARGET_SUMMARY.md) — Recovery USB target selection summary
 - [`base1/RECOVERY_USB_IMAGE_PROVENANCE.md`](base1/RECOVERY_USB_IMAGE_PROVENANCE.md) — Recovery USB image provenance and checksum design
 - [`base1/RECOVERY_USB_IMAGE_SUMMARY.md`](base1/RECOVERY_USB_IMAGE_SUMMARY.md) — Recovery USB image provenance summary
+- [`base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md`](base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md) — Recovery USB image provenance command index
 - [`RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md) — Recovery USB target selection read-only checkpoint release notes
 - [`RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md) — Recovery USB hardware read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1.md) — Libreboot read-only checkpoint release notes

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -15,6 +15,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 - `base1/RECOVERY_USB_TARGET_SUMMARY.md` — Recovery USB target selection summary.
 - `base1/RECOVERY_USB_IMAGE_PROVENANCE.md` — Recovery USB image provenance and checksum design.
 - `base1/RECOVERY_USB_IMAGE_SUMMARY.md` — Recovery USB image provenance summary.
+- `base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md` — Recovery USB image provenance command index.
 - `scripts/base1-recovery-usb-image-report.sh` — Recovery USB image provenance report command.
 - `scripts/base1-recovery-usb-image-validate.sh` — Recovery USB image provenance validation bundle.
 - `scripts/base1-recovery-usb-image-summary.sh` — Recovery USB image provenance summary command.

--- a/base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md
@@ -1,0 +1,66 @@
+# Base1 recovery USB image provenance command index
+
+This index collects the read-only image provenance and checksum documents and commands for Base1 recovery USB planning.
+
+This document is advisory and read-only. It does not download images, write USB media, partition disks, format disks, install GRUB, edit grub.cfg, write to /boot, flash firmware, change boot order, or modify host trust.
+
+## Image provenance documents
+
+- `base1/RECOVERY_USB_IMAGE_PROVENANCE.md` — image provenance and checksum verification design.
+- `base1/RECOVERY_USB_IMAGE_SUMMARY.md` — image provenance summary.
+- `base1/RECOVERY_USB_TARGET_SUMMARY.md` — target-device selection summary.
+- `base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md` — target-device command index.
+- `base1/RECOVERY_USB_COMMAND_INDEX.md` — broader recovery USB command index.
+
+## Image provenance commands
+
+- `scripts/base1-recovery-usb-image-summary.sh`
+- `scripts/base1-recovery-usb-image-validate.sh`
+- `scripts/base1-recovery-usb-image-report.sh`
+- `scripts/base1-recovery-usb-target-summary.sh`
+- `scripts/base1-recovery-usb-target-validate.sh`
+- `scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example`
+
+## Image provenance fields
+
+An image provenance preview must keep these fields operator-visible:
+
+- Image filename.
+- Image source URL or local source path.
+- Image build commit.
+- Image build date.
+- Image builder identity.
+- Expected SHA256 checksum.
+- Observed SHA256 checksum.
+- Checksum match status.
+- Signature status.
+- Signing key identity.
+- Target hardware profile.
+- Target bootloader expectation.
+- Recovery shell availability.
+- Rollback metadata compatibility.
+
+## Shared guardrails
+
+Every image-provenance document or command must preserve these rules:
+
+- Report downloads: no.
+- Report writes: no.
+- Do not download images automatically.
+- Do not write USB media.
+- Do not run dd automatically.
+- Do not partition disks.
+- Do not format disks.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not flash firmware.
+- Do not change boot order.
+- Do not store passwords, tokens, private keys, recovery phrases, or personal secrets.
+- Do not accept missing checksums.
+- Do not accept checksum mismatch.
+- Do not accept hidden image provenance.
+
+## Promotion rule
+
+A future recovery USB writer can only follow after image provenance, checksum verification, target identity, emergency shell behavior, rollback metadata, storage layout, and actual Libreboot/X200-class boot behavior are verified.

--- a/base1/RECOVERY_USB_IMAGE_PROVENANCE.md
+++ b/base1/RECOVERY_USB_IMAGE_PROVENANCE.md
@@ -82,3 +82,6 @@ A future recovery USB writer can only follow after image provenance, checksum ve
 
 
 See also: [Recovery USB image provenance summary](RECOVERY_USB_IMAGE_SUMMARY.md).
+
+
+See also: [Recovery USB image provenance command index](RECOVERY_USB_IMAGE_COMMAND_INDEX.md).

--- a/base1/RECOVERY_USB_IMAGE_SUMMARY.md
+++ b/base1/RECOVERY_USB_IMAGE_SUMMARY.md
@@ -75,3 +75,6 @@ This summary does not claim:
 ## Promotion rule
 
 Recovery USB image work must remain read-only until image provenance, checksum verification, target identity, emergency shell behavior, rollback metadata, storage layout, and actual Libreboot/X200-class boot behavior are verified.
+
+
+See also: [Recovery USB image provenance command index](RECOVERY_USB_IMAGE_COMMAND_INDEX.md).

--- a/tests/base1_recovery_usb_image_command_index_docs.rs
+++ b/tests/base1_recovery_usb_image_command_index_docs.rs
@@ -1,0 +1,101 @@
+#[test]
+fn recovery_usb_image_command_index_lists_docs_and_commands() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md")
+        .expect("recovery usb image command index");
+
+    assert!(
+        doc.contains("Base1 recovery USB image provenance command index"),
+        "{doc}"
+    );
+    assert!(doc.contains("RECOVERY_USB_IMAGE_PROVENANCE.md"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_IMAGE_SUMMARY.md"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_TARGET_SUMMARY.md"), "{doc}");
+    assert!(
+        doc.contains("RECOVERY_USB_TARGET_COMMAND_INDEX.md"),
+        "{doc}"
+    );
+    assert!(doc.contains("RECOVERY_USB_COMMAND_INDEX.md"), "{doc}");
+    assert!(
+        doc.contains("scripts/base1-recovery-usb-image-summary.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-recovery-usb-image-validate.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-recovery-usb-image-report.sh"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_image_command_index_preserves_provenance_fields() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md")
+        .expect("recovery usb image command index");
+
+    assert!(doc.contains("Image filename"), "{doc}");
+    assert!(
+        doc.contains("Image source URL or local source path"),
+        "{doc}"
+    );
+    assert!(doc.contains("Image build commit"), "{doc}");
+    assert!(doc.contains("Expected SHA256 checksum"), "{doc}");
+    assert!(doc.contains("Observed SHA256 checksum"), "{doc}");
+    assert!(doc.contains("Checksum match status"), "{doc}");
+    assert!(doc.contains("Signature status"), "{doc}");
+    assert!(doc.contains("Rollback metadata compatibility"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_image_command_index_preserves_guardrails() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md")
+        .expect("recovery usb image command index");
+
+    assert!(doc.contains("Report downloads: no"), "{doc}");
+    assert!(doc.contains("Report writes: no"), "{doc}");
+    assert!(
+        doc.contains("Do not download images automatically"),
+        "{doc}"
+    );
+    assert!(doc.contains("Do not write USB media"), "{doc}");
+    assert!(doc.contains("Do not run dd automatically"), "{doc}");
+    assert!(doc.contains("Do not partition disks"), "{doc}");
+    assert!(doc.contains("Do not format disks"), "{doc}");
+    assert!(doc.contains("Do not install GRUB automatically"), "{doc}");
+    assert!(doc.contains("Do not write to /boot"), "{doc}");
+    assert!(doc.contains("Do not accept missing checksums"), "{doc}");
+    assert!(doc.contains("Do not accept checksum mismatch"), "{doc}");
+    assert!(
+        doc.contains("Do not accept hidden image provenance"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_image_surfaces_link_image_command_index() {
+    let provenance = std::fs::read_to_string("base1/RECOVERY_USB_IMAGE_PROVENANCE.md")
+        .expect("recovery usb image provenance");
+    let summary = std::fs::read_to_string("base1/RECOVERY_USB_IMAGE_SUMMARY.md")
+        .expect("recovery usb image summary");
+    let index = std::fs::read_to_string("base1/RECOVERY_USB_COMMAND_INDEX.md")
+        .expect("recovery usb command index");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        provenance.contains("RECOVERY_USB_IMAGE_COMMAND_INDEX.md"),
+        "{provenance}"
+    );
+    assert!(
+        summary.contains("RECOVERY_USB_IMAGE_COMMAND_INDEX.md"),
+        "{summary}"
+    );
+    assert!(
+        index.contains("RECOVERY_USB_IMAGE_COMMAND_INDEX.md"),
+        "{index}"
+    );
+    assert!(
+        readme.contains("base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds a command index for Base1 recovery USB image provenance and checksum planning.

Implements:
- Recovery USB image provenance command index
- image provenance docs and command list
- image provenance field summary
- shared checksum/provenance guardrails
- README and recovery USB surface links
- docs tests for command index coverage

Validation:
- cargo test -p phase1 --test base1_recovery_usb_image_command_index_docs
- cargo test -p phase1 --test base1_recovery_usb_image_summary_script
- cargo test -p phase1 --test base1_recovery_usb_image_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_image_validation_bundle
- cargo test -p phase1 --test base1_foundation

Refs #135