### PR TITLE
Document Base1 recovery USB image checkpoint release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Start here:
 - [`base1/RECOVERY_USB_IMAGE_PROVENANCE.md`](base1/RECOVERY_USB_IMAGE_PROVENANCE.md) — Recovery USB image provenance and checksum design
 - [`base1/RECOVERY_USB_IMAGE_SUMMARY.md`](base1/RECOVERY_USB_IMAGE_SUMMARY.md) — Recovery USB image provenance summary
 - [`base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md`](base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md) — Recovery USB image provenance command index
+- [`RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md) — Recovery USB image provenance read-only checkpoint release notes
 - [`RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md) — Recovery USB target selection read-only checkpoint release notes
 - [`RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md) — Recovery USB hardware read-only checkpoint release notes
 - [`RELEASE_BASE1_LIBREBOOT_READONLY_V1.md`](RELEASE_BASE1_LIBREBOOT_READONLY_V1.md) — Libreboot read-only checkpoint release notes

--- a/RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md
+++ b/RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md
@@ -1,0 +1,82 @@
+# Base1 recovery USB image provenance read-only checkpoint v1
+
+This checkpoint captures the read-only image provenance and checksum verification path for Base1 recovery USB planning.
+
+## Status
+
+- Checkpoint branch: checkpoint/base1-recovery-usb-image-readonly-v1
+- Checkpoint tag: base1-recovery-usb-image-readonly-v1
+- Firmware profile: Libreboot expected
+- Hardware profile: ThinkPad X200-class expected
+- Bootloader expectation: GRUB first
+- Recovery media: external USB planned
+- Target identity: required before future writing
+- Checksum rule: exact match required before future writing
+- Signature status: operator-confirmed
+- Secure Boot: not assumed
+- TPM: not assumed
+- Current maturity: image provenance reports, validation bundle, summaries, command index, and read-only documentation
+
+## Included documents
+
+- base1/RECOVERY_USB_IMAGE_PROVENANCE.md
+- base1/RECOVERY_USB_IMAGE_SUMMARY.md
+- base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md
+- base1/RECOVERY_USB_TARGET_SUMMARY.md
+- base1/RECOVERY_USB_TARGET_COMMAND_INDEX.md
+- base1/RECOVERY_USB_COMMAND_INDEX.md
+
+## Included commands
+
+- scripts/base1-recovery-usb-image-summary.sh
+- scripts/base1-recovery-usb-image-validate.sh
+- scripts/base1-recovery-usb-image-report.sh
+- scripts/base1-recovery-usb-target-summary.sh
+- scripts/base1-recovery-usb-target-validate.sh
+- scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+
+## Validation
+
+Run:
+
+    cargo test -p phase1 --test base1_recovery_usb_image_command_index_docs
+    cargo test -p phase1 --test base1_recovery_usb_image_summary_script
+    cargo test -p phase1 --test base1_recovery_usb_image_summary_docs
+    cargo test -p phase1 --test base1_recovery_usb_image_validation_bundle
+    cargo test -p phase1 --test base1_recovery_usb_image_report_script
+    cargo test -p phase1 --test base1_recovery_usb_image_provenance_docs
+    cargo test -p phase1 --test base1_foundation
+
+## Guardrails
+
+- Do not download images automatically.
+- Do not write USB media.
+- Do not run dd automatically.
+- Do not partition disks.
+- Do not format disks.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not change boot order.
+- Do not flash firmware.
+- Do not store passwords, tokens, private keys, recovery phrases, or personal secrets.
+- Do not accept missing checksums.
+- Do not accept checksum mismatch.
+- Do not accept hidden image provenance.
+
+## Non-claims
+
+This checkpoint does not claim:
+
+- Image download readiness.
+- Signature verification implementation.
+- USB media writing readiness.
+- Bootable Base1 image readiness.
+- Destructive installer readiness.
+- Hidden image provenance safety beyond read-only guardrails.
+- Real-hardware recovery completion.
+- Real-hardware rollback completion.
+
+## Next milestone
+
+The next milestone should remain read-only unless image provenance, checksum verification, target identity, emergency shell behavior, rollback metadata, storage layout, and actual Libreboot/X200-class boot behavior are verified.

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -74,3 +74,6 @@ The expected read-only path is:
 
 
 See also: [`RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md`](../RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md) — recovery USB hardware read-only checkpoint release notes.
+
+
+See also: [`RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md`](../RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md) — recovery USB image provenance read-only checkpoint release notes.

--- a/base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md
@@ -64,3 +64,6 @@ Every image-provenance document or command must preserve these rules:
 ## Promotion rule
 
 A future recovery USB writer can only follow after image provenance, checksum verification, target identity, emergency shell behavior, rollback metadata, storage layout, and actual Libreboot/X200-class boot behavior are verified.
+
+
+See also: [`RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md`](../RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md) — recovery USB image provenance read-only checkpoint release notes.

--- a/base1/RECOVERY_USB_IMAGE_SUMMARY.md
+++ b/base1/RECOVERY_USB_IMAGE_SUMMARY.md
@@ -78,3 +78,6 @@ Recovery USB image work must remain read-only until image provenance, checksum v
 
 
 See also: [Recovery USB image provenance command index](RECOVERY_USB_IMAGE_COMMAND_INDEX.md).
+
+
+See also: [RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md](../RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md).

--- a/tests/base1_recovery_usb_image_release_notes_docs.rs
+++ b/tests/base1_recovery_usb_image_release_notes_docs.rs
@@ -1,0 +1,85 @@
+#[test]
+fn recovery_usb_image_release_notes_record_checkpoint_status() {
+    let doc = std::fs::read_to_string("RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md")
+        .expect("recovery usb image release notes");
+
+    assert!(
+        doc.contains("Base1 recovery USB image provenance read-only checkpoint v1"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("checkpoint/base1-recovery-usb-image-readonly-v1"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("base1-recovery-usb-image-readonly-v1"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Firmware profile: Libreboot expected"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Hardware profile: ThinkPad X200-class expected"),
+        "{doc}"
+    );
+    assert!(doc.contains("Bootloader expectation: GRUB first"), "{doc}");
+    assert!(
+        doc.contains("Checksum rule: exact match required before future writing"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_image_release_notes_list_surfaces_and_non_claims() {
+    let doc = std::fs::read_to_string("RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md")
+        .expect("recovery usb image release notes");
+
+    assert!(
+        doc.contains("base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-recovery-usb-image-summary.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-recovery-usb-image-validate.sh"),
+        "{doc}"
+    );
+    assert!(doc.contains("Image download readiness"), "{doc}");
+    assert!(
+        doc.contains("Signature verification implementation"),
+        "{doc}"
+    );
+    assert!(doc.contains("Hidden image provenance safety"), "{doc}");
+    assert!(doc.contains("Real-hardware rollback completion"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_image_surfaces_link_release_notes() {
+    let summary = std::fs::read_to_string("base1/RECOVERY_USB_IMAGE_SUMMARY.md")
+        .expect("recovery usb image summary");
+    let index = std::fs::read_to_string("base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md")
+        .expect("recovery usb image command index");
+    let command_index = std::fs::read_to_string("base1/RECOVERY_USB_COMMAND_INDEX.md")
+        .expect("recovery usb command index");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        summary.contains("RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md"),
+        "{summary}"
+    );
+    assert!(
+        index.contains("RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md"),
+        "{index}"
+    );
+    assert!(
+        command_index.contains("RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md"),
+        "{command_index}"
+    );
+    assert!(
+        readme.contains("RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds release notes for the Base1 recovery USB image provenance read-only checkpoint.

Implements:
- RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md
- image provenance docs and commands inventory
- validation command set
- explicit guardrails and non-claims
- README, recovery USB command index, image summary, and image command index links
- docs tests for release notes coverage

Validation:
- cargo test -p phase1 --test base1_recovery_usb_image_release_notes_docs
- cargo test -p phase1 --test base1_recovery_usb_image_command_index_docs
- cargo test -p phase1 --test base1_recovery_usb_image_summary_script
- cargo test -p phase1 --test base1_recovery_usb_image_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_image_validation_bundle
- cargo test -p phase1 --test base1_foundation

Refs #135