### PR TITLE
Document Base1 recovery USB emergency shell design

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Start here:
 - [`base1/RECOVERY_USB_IMAGE_PROVENANCE.md`](base1/RECOVERY_USB_IMAGE_PROVENANCE.md) — Recovery USB image provenance and checksum design
 - [`base1/RECOVERY_USB_IMAGE_SUMMARY.md`](base1/RECOVERY_USB_IMAGE_SUMMARY.md) — Recovery USB image provenance summary
 - [`base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md`](base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md) — Recovery USB image provenance command index
+- [`base1/RECOVERY_USB_EMERGENCY_SHELL.md`](base1/RECOVERY_USB_EMERGENCY_SHELL.md) — Recovery USB emergency shell behavior design
 - [`RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md) — Recovery USB image provenance read-only checkpoint release notes
 - [`RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md) — Recovery USB target selection read-only checkpoint release notes
 - [`RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md) — Recovery USB hardware read-only checkpoint release notes

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -16,6 +16,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 - `base1/RECOVERY_USB_IMAGE_PROVENANCE.md` — Recovery USB image provenance and checksum design.
 - `base1/RECOVERY_USB_IMAGE_SUMMARY.md` — Recovery USB image provenance summary.
 - `base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md` — Recovery USB image provenance command index.
+- `base1/RECOVERY_USB_EMERGENCY_SHELL.md` — Recovery USB emergency shell behavior design.
 - `scripts/base1-recovery-usb-image-report.sh` — Recovery USB image provenance report command.
 - `scripts/base1-recovery-usb-image-validate.sh` — Recovery USB image provenance validation bundle.
 - `scripts/base1-recovery-usb-image-summary.sh` — Recovery USB image provenance summary command.

--- a/base1/RECOVERY_USB_EMERGENCY_SHELL.md
+++ b/base1/RECOVERY_USB_EMERGENCY_SHELL.md
@@ -1,0 +1,80 @@
+# Base1 recovery USB emergency shell behavior design
+
+This design defines the read-only emergency shell behavior path for Base1 recovery USB planning.
+
+This document is advisory and read-only. It does not write USB media, partition disks, format disks, install GRUB, edit grub.cfg, write to /boot, flash firmware, change boot order, launch privileged shells, or modify host trust.
+
+## Goal
+
+Define how an operator should reason about emergency shell behavior before any recovery USB media-writing or boot-time recovery automation exists.
+
+The emergency shell path must keep fallback access visible, preserve operator control, and avoid hiding host/Base1 authority boundaries.
+
+## Target scope
+
+Initial scope:
+
+- Libreboot-backed ThinkPad X200-class systems.
+- GRUB-first boot path.
+- External USB recovery media.
+- Target identity already visible.
+- Image provenance and checksum expectations already visible.
+- No Secure Boot assumption.
+- No TPM assumption.
+- Keyboard-first and offline-first recovery.
+- Read-only previews only.
+
+## Emergency shell checklist
+
+Before any future recovery automation, record:
+
+- Emergency shell entry path.
+- Keyboard availability.
+- Display readability.
+- Root/admin boundary.
+- Phase1 auto-launch status.
+- Phase1 state path.
+- Rollback metadata path.
+- Recovery media boot path.
+- Network availability.
+- Offline recovery capability.
+- Log collection path.
+- Exit/reboot path.
+
+## Required behavior
+
+A future recovery environment must not remove emergency shell access.
+
+The shell path should be explicit, operator-visible, and documented before any automatic recovery flow can be promoted.
+
+This design does not launch a shell, grant privileges, edit boot settings, or change recovery behavior.
+
+## Read-only commands
+
+Run first:
+
+    sh scripts/base1-recovery-usb-image-summary.sh
+    sh scripts/base1-recovery-usb-image-validate.sh
+    sh scripts/base1-recovery-usb-target-summary.sh
+    sh scripts/base1-recovery-usb-hardware-summary.sh
+    sh scripts/base1-recovery-dry-run.sh --dry-run
+
+## Guardrails
+
+- Do not launch privileged shells automatically.
+- Do not remove emergency shell access.
+- Do not hide root/admin boundaries.
+- Do not write USB media.
+- Do not run dd automatically.
+- Do not partition disks.
+- Do not format disks.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not change boot order.
+- Do not flash firmware.
+- Do not store passwords, tokens, private keys, recovery phrases, or personal secrets.
+
+## Promotion rule
+
+A future recovery USB environment can only promote emergency shell behavior after shell entry, exit, state access, rollback metadata, log collection, storage layout, and actual Libreboot/X200-class boot behavior are verified.

--- a/base1/RECOVERY_USB_IMAGE_PROVENANCE.md
+++ b/base1/RECOVERY_USB_IMAGE_PROVENANCE.md
@@ -85,3 +85,6 @@ See also: [Recovery USB image provenance summary](RECOVERY_USB_IMAGE_SUMMARY.md)
 
 
 See also: [Recovery USB image provenance command index](RECOVERY_USB_IMAGE_COMMAND_INDEX.md).
+
+
+See also: [Recovery USB emergency shell behavior design](RECOVERY_USB_EMERGENCY_SHELL.md).

--- a/base1/RECOVERY_USB_IMAGE_SUMMARY.md
+++ b/base1/RECOVERY_USB_IMAGE_SUMMARY.md
@@ -81,3 +81,6 @@ See also: [Recovery USB image provenance command index](RECOVERY_USB_IMAGE_COMMA
 
 
 See also: [RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md](../RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md).
+
+
+See also: [Recovery USB emergency shell behavior design](RECOVERY_USB_EMERGENCY_SHELL.md).

--- a/tests/base1_recovery_usb_emergency_shell_docs.rs
+++ b/tests/base1_recovery_usb_emergency_shell_docs.rs
@@ -1,0 +1,83 @@
+#[test]
+fn recovery_usb_emergency_shell_defines_read_only_behavior_path() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_EMERGENCY_SHELL.md")
+        .expect("recovery usb emergency shell design");
+
+    assert!(
+        doc.contains("Base1 recovery USB emergency shell behavior design"),
+        "{doc}"
+    );
+    assert!(doc.contains("advisory and read-only"), "{doc}");
+    assert!(doc.contains("does not write USB media"), "{doc}");
+    assert!(doc.contains("does not launch a shell"), "{doc}");
+    assert!(doc.contains("Emergency shell entry path"), "{doc}");
+    assert!(doc.contains("Keyboard availability"), "{doc}");
+    assert!(doc.contains("Display readability"), "{doc}");
+    assert!(doc.contains("Root/admin boundary"), "{doc}");
+    assert!(doc.contains("Rollback metadata path"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_emergency_shell_preserves_required_behavior_and_guardrails() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_EMERGENCY_SHELL.md")
+        .expect("recovery usb emergency shell design");
+
+    assert!(
+        doc.contains("must not remove emergency shell access"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Do not launch privileged shells automatically"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Do not remove emergency shell access"),
+        "{doc}"
+    );
+    assert!(doc.contains("Do not hide root/admin boundaries"), "{doc}");
+    assert!(doc.contains("Do not write USB media"), "{doc}");
+    assert!(doc.contains("Do not write to /boot"), "{doc}");
+    assert!(doc.contains("Do not store passwords"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_emergency_shell_links_existing_surfaces() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_EMERGENCY_SHELL.md")
+        .expect("recovery usb emergency shell design");
+
+    assert!(
+        doc.contains("sh scripts/base1-recovery-usb-image-summary.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("sh scripts/base1-recovery-usb-image-validate.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("sh scripts/base1-recovery-usb-target-summary.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("sh scripts/base1-recovery-dry-run.sh --dry-run"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_surfaces_link_emergency_shell_design() {
+    let image = std::fs::read_to_string("base1/RECOVERY_USB_IMAGE_SUMMARY.md")
+        .expect("recovery usb image summary");
+    let command_index = std::fs::read_to_string("base1/RECOVERY_USB_COMMAND_INDEX.md")
+        .expect("recovery usb command index");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(image.contains("RECOVERY_USB_EMERGENCY_SHELL.md"), "{image}");
+    assert!(
+        command_index.contains("RECOVERY_USB_EMERGENCY_SHELL.md"),
+        "{command_index}"
+    );
+    assert!(
+        readme.contains("base1/RECOVERY_USB_EMERGENCY_SHELL.md"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds a read-only emergency shell behavior design for Base1 recovery USB planning.

Implements:
- Recovery USB emergency shell behavior design
- emergency shell checklist
- required shell-access behavior
- guardrails against hidden privilege and shell access removal
- README and recovery USB surface links
- docs tests for emergency shell coverage

Validation:
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_docs
- cargo test -p phase1 --test base1_recovery_usb_image_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_image_validation_bundle
- cargo test -p phase1 --test base1_recovery_usb_image_command_index_docs
- cargo test -p phase1 --test base1_foundation

Refs #135