### PR TITLE
Add Base1 recovery USB emergency shell report

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ sh scripts/base1-recovery-usb-hardware-validate.sh
 sh scripts/base1-recovery-usb-hardware-checklist.sh
 sh scripts/base1-recovery-usb-index.sh
 sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-recovery-usb-emergency-shell-report.sh
 sh scripts/base1-recovery-usb-image-summary.sh
 sh scripts/base1-recovery-usb-image-validate.sh
 sh scripts/base1-recovery-usb-image-report.sh

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -17,6 +17,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 - `base1/RECOVERY_USB_IMAGE_SUMMARY.md` — Recovery USB image provenance summary.
 - `base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md` — Recovery USB image provenance command index.
 - `base1/RECOVERY_USB_EMERGENCY_SHELL.md` — Recovery USB emergency shell behavior design.
+- `scripts/base1-recovery-usb-emergency-shell-report.sh` — Recovery USB emergency shell report command.
 - `scripts/base1-recovery-usb-image-report.sh` — Recovery USB image provenance report command.
 - `scripts/base1-recovery-usb-image-validate.sh` — Recovery USB image provenance validation bundle.
 - `scripts/base1-recovery-usb-image-summary.sh` — Recovery USB image provenance summary command.

--- a/base1/RECOVERY_USB_EMERGENCY_SHELL.md
+++ b/base1/RECOVERY_USB_EMERGENCY_SHELL.md
@@ -53,6 +53,7 @@ This design does not launch a shell, grant privileges, edit boot settings, or ch
 
 Run first:
 
+    sh scripts/base1-recovery-usb-emergency-shell-report.sh
     sh scripts/base1-recovery-usb-image-summary.sh
     sh scripts/base1-recovery-usb-image-validate.sh
     sh scripts/base1-recovery-usb-target-summary.sh

--- a/base1/RECOVERY_USB_IMAGE_SUMMARY.md
+++ b/base1/RECOVERY_USB_IMAGE_SUMMARY.md
@@ -29,6 +29,7 @@ This document is advisory and read-only. It does not download images, write USB 
 
 Run the read-only commands first:
 
+    sh scripts/base1-recovery-usb-emergency-shell-report.sh
     sh scripts/base1-recovery-usb-image-summary.sh
     sh scripts/base1-recovery-usb-image-validate.sh
     sh scripts/base1-recovery-usb-image-report.sh

--- a/scripts/base1-recovery-usb-emergency-shell-report.sh
+++ b/scripts/base1-recovery-usb-emergency-shell-report.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 recovery USB emergency shell report
+
+usage:
+  sh scripts/base1-recovery-usb-emergency-shell-report.sh
+
+This command is read-only. It prints an emergency shell behavior report
+template without writing USB media, changing boot settings, writing to /boot,
+modifying disks, changing firmware state, launching privileged shells, or
+changing host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+cat <<'EOF'
+base1 recovery USB emergency shell report
+mode                  : read-only
+writes                : no
+firmware              : Libreboot expected
+hardware              : X200-class expected
+bootloader            : GRUB first
+media                 : external USB planned
+target_identity       : required before writing
+image_provenance      : required before writing
+trust                 : no host trust escalation
+
+emergency shell behavior:
+- emergency shell entry path: unknown
+- keyboard availability: unknown
+- display readability: unknown
+- root/admin boundary: operator-visible
+- Phase1 auto-launch status: unknown
+- Phase1 state path: /state/phase1 preview
+- rollback metadata path: /recovery preview
+- recovery media boot path: unknown
+- network availability: unknown
+- offline recovery capability: unknown
+- log collection path: unknown
+- exit/reboot path: unknown
+
+required behavior:
+- emergency shell access must remain available
+- root/admin boundary must remain visible
+- automatic recovery must not hide emergency access
+
+validation commands:
+- sh scripts/base1-recovery-usb-emergency-shell-report.sh
+- sh scripts/base1-recovery-usb-image-summary.sh
+- sh scripts/base1-recovery-usb-image-validate.sh
+- sh scripts/base1-recovery-dry-run.sh --dry-run
+
+status: emergency shell behavior not verified
+EOF

--- a/tests/base1_recovery_usb_emergency_shell_report_script.rs
+++ b/tests/base1_recovery_usb_emergency_shell_report_script.rs
@@ -1,0 +1,112 @@
+use std::process::Command;
+
+#[test]
+fn recovery_usb_emergency_shell_report_script_prints_report_template() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-emergency-shell-report.sh")
+        .output()
+        .expect("run recovery USB emergency shell report script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("base1 recovery USB emergency shell report"),
+        "{text}"
+    );
+    assert!(text.contains("mode                  : read-only"), "{text}");
+    assert!(text.contains("writes                : no"), "{text}");
+    assert!(
+        text.contains("firmware              : Libreboot expected"),
+        "{text}"
+    );
+    assert!(
+        text.contains("hardware              : X200-class expected"),
+        "{text}"
+    );
+    assert!(
+        text.contains("bootloader            : GRUB first"),
+        "{text}"
+    );
+    assert!(
+        text.contains("trust                 : no host trust escalation"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_emergency_shell_report_script_lists_behavior_and_commands() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-emergency-shell-report.sh")
+        .output()
+        .expect("run recovery USB emergency shell report script");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        text.contains("emergency shell entry path: unknown"),
+        "{text}"
+    );
+    assert!(text.contains("keyboard availability: unknown"), "{text}");
+    assert!(text.contains("display readability: unknown"), "{text}");
+    assert!(
+        text.contains("root/admin boundary: operator-visible"),
+        "{text}"
+    );
+    assert!(
+        text.contains("Phase1 state path: /state/phase1 preview"),
+        "{text}"
+    );
+    assert!(
+        text.contains("rollback metadata path: /recovery preview"),
+        "{text}"
+    );
+    assert!(
+        text.contains("emergency shell access must remain available"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-recovery-usb-image-validate.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("emergency shell behavior not verified"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_emergency_shell_report_script_avoids_mutating_tools_and_sensitive_terms() {
+    let script = std::fs::read_to_string("scripts/base1-recovery-usb-emergency-shell-report.sh")
+        .expect("recovery USB emergency shell report script");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only emergency shell behavior report command for Base1 recovery USB planning.

Implements:
- scripts/base1-recovery-usb-emergency-shell-report.sh
- emergency shell behavior report template
- root/admin boundary and shell-access visibility
- README, emergency shell design, command index, and image summary updates
- mutating-tool and sensitive-term guard test

Validation:
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_report_script
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_docs
- cargo test -p phase1 --test base1_recovery_usb_image_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_image_validation_bundle
- cargo test -p phase1 --test base1_foundation

Refs #135