### PR TITLE
Add Base1 recovery USB emergency shell validation bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ sh scripts/base1-recovery-usb-hardware-validate.sh
 sh scripts/base1-recovery-usb-hardware-checklist.sh
 sh scripts/base1-recovery-usb-index.sh
 sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-recovery-usb-emergency-shell-validate.sh
 sh scripts/base1-recovery-usb-emergency-shell-report.sh
 sh scripts/base1-recovery-usb-image-summary.sh
 sh scripts/base1-recovery-usb-image-validate.sh

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -18,6 +18,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 - `base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md` — Recovery USB image provenance command index.
 - `base1/RECOVERY_USB_EMERGENCY_SHELL.md` — Recovery USB emergency shell behavior design.
 - `scripts/base1-recovery-usb-emergency-shell-report.sh` — Recovery USB emergency shell report command.
+- `scripts/base1-recovery-usb-emergency-shell-validate.sh` — Recovery USB emergency shell validation bundle.
 - `scripts/base1-recovery-usb-image-report.sh` — Recovery USB image provenance report command.
 - `scripts/base1-recovery-usb-image-validate.sh` — Recovery USB image provenance validation bundle.
 - `scripts/base1-recovery-usb-image-summary.sh` — Recovery USB image provenance summary command.

--- a/base1/RECOVERY_USB_EMERGENCY_SHELL.md
+++ b/base1/RECOVERY_USB_EMERGENCY_SHELL.md
@@ -53,6 +53,7 @@ This design does not launch a shell, grant privileges, edit boot settings, or ch
 
 Run first:
 
+    sh scripts/base1-recovery-usb-emergency-shell-validate.sh
     sh scripts/base1-recovery-usb-emergency-shell-report.sh
     sh scripts/base1-recovery-usb-image-summary.sh
     sh scripts/base1-recovery-usb-image-validate.sh

--- a/base1/RECOVERY_USB_IMAGE_SUMMARY.md
+++ b/base1/RECOVERY_USB_IMAGE_SUMMARY.md
@@ -29,6 +29,7 @@ This document is advisory and read-only. It does not download images, write USB 
 
 Run the read-only commands first:
 
+    sh scripts/base1-recovery-usb-emergency-shell-validate.sh
     sh scripts/base1-recovery-usb-emergency-shell-report.sh
     sh scripts/base1-recovery-usb-image-summary.sh
     sh scripts/base1-recovery-usb-image-validate.sh

--- a/scripts/base1-recovery-usb-emergency-shell-validate.sh
+++ b/scripts/base1-recovery-usb-emergency-shell-validate.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 recovery USB emergency shell validation bundle
+
+usage:
+  sh scripts/base1-recovery-usb-emergency-shell-validate.sh
+
+This command is read-only. It runs emergency shell behavior preview commands
+without writing USB media, changing boot settings, writing to /boot, modifying
+disks, changing firmware state, launching privileged shells, or changing host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+run_cmd() {
+  echo
+  echo "$ $*"
+  "$@"
+}
+
+cat <<'EOF'
+base1 recovery USB emergency shell validation bundle
+mode                  : read-only
+writes                : no
+shell_launch          : no
+firmware              : Libreboot expected
+hardware              : X200-class expected
+bootloader            : GRUB first
+media                 : external USB planned
+target_identity       : required before writing
+image_provenance      : required before writing
+root_boundary         : operator-visible
+emergency_access      : must remain available
+trust                 : no host trust escalation
+EOF
+
+run_cmd sh scripts/base1-recovery-usb-emergency-shell-report.sh
+run_cmd sh scripts/base1-recovery-usb-image-summary.sh
+run_cmd sh scripts/base1-recovery-usb-image-validate.sh
+run_cmd sh scripts/base1-recovery-usb-target-summary.sh
+run_cmd sh scripts/base1-recovery-dry-run.sh --dry-run
+
+echo
+echo "base1 recovery USB emergency shell validation bundle complete"

--- a/tests/base1_recovery_usb_emergency_shell_validation_bundle.rs
+++ b/tests/base1_recovery_usb_emergency_shell_validation_bundle.rs
@@ -1,0 +1,105 @@
+use std::process::Command;
+
+#[test]
+fn recovery_usb_emergency_shell_validation_bundle_runs_read_only_previews() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-emergency-shell-validate.sh")
+        .output()
+        .expect("run recovery USB emergency shell validation bundle");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("base1 recovery USB emergency shell validation bundle"),
+        "{text}"
+    );
+    assert!(text.contains("mode                  : read-only"), "{text}");
+    assert!(text.contains("writes                : no"), "{text}");
+    assert!(text.contains("shell_launch          : no"), "{text}");
+    assert!(
+        text.contains("firmware              : Libreboot expected"),
+        "{text}"
+    );
+    assert!(
+        text.contains("hardware              : X200-class expected"),
+        "{text}"
+    );
+    assert!(
+        text.contains("bootloader            : GRUB first"),
+        "{text}"
+    );
+    assert!(
+        text.contains("root_boundary         : operator-visible"),
+        "{text}"
+    );
+    assert!(
+        text.contains("emergency_access      : must remain available"),
+        "{text}"
+    );
+    assert!(
+        text.contains("base1 recovery USB emergency shell report"),
+        "{text}"
+    );
+    assert!(
+        text.contains("base1 recovery USB image provenance summary"),
+        "{text}"
+    );
+    assert!(
+        text.contains("base1 recovery USB emergency shell validation bundle complete"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_emergency_shell_validation_bundle_help_is_read_only() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-emergency-shell-validate.sh")
+        .arg("--help")
+        .output()
+        .expect("run recovery USB emergency shell validation help");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("read-only"), "{text}");
+    assert!(text.contains("without writing USB media"), "{text}");
+    assert!(text.contains("privileged shells"), "{text}");
+    assert!(text.contains("host trust"), "{text}");
+}
+
+#[test]
+fn recovery_usb_emergency_shell_validation_bundle_avoids_mutating_tools_and_sensitive_terms() {
+    let script = std::fs::read_to_string("scripts/base1-recovery-usb-emergency-shell-validate.sh")
+        .expect("recovery USB emergency shell validation bundle");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only emergency shell behavior validation bundle for Base1 recovery USB planning.

Implements:
- scripts/base1-recovery-usb-emergency-shell-validate.sh
- grouped emergency shell report, image summary, image validation, target summary, and recovery dry-run runner
- emergency shell access and root/admin boundary summary
- README, emergency shell design, command index, and image summary updates
- mutating-tool and sensitive-term guard test

Validation:
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_validation_bundle
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_report_script
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_docs
- cargo test -p phase1 --test base1_recovery_usb_image_summary_docs
- cargo test -p phase1 --test base1_foundation

Refs #135