### PR TITLE
Document Base1 recovery USB emergency shell summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ Start here:
 - [`base1/RECOVERY_USB_IMAGE_SUMMARY.md`](base1/RECOVERY_USB_IMAGE_SUMMARY.md) — Recovery USB image provenance summary
 - [`base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md`](base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md) — Recovery USB image provenance command index
 - [`base1/RECOVERY_USB_EMERGENCY_SHELL.md`](base1/RECOVERY_USB_EMERGENCY_SHELL.md) — Recovery USB emergency shell behavior design
+- [`base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md`](base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md) — Recovery USB emergency shell summary
 - [`RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md) — Recovery USB image provenance read-only checkpoint release notes
 - [`RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md) — Recovery USB target selection read-only checkpoint release notes
 - [`RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md) — Recovery USB hardware read-only checkpoint release notes

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -17,6 +17,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 - `base1/RECOVERY_USB_IMAGE_SUMMARY.md` — Recovery USB image provenance summary.
 - `base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md` — Recovery USB image provenance command index.
 - `base1/RECOVERY_USB_EMERGENCY_SHELL.md` — Recovery USB emergency shell behavior design.
+- `base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md` — Recovery USB emergency shell summary.
 - `scripts/base1-recovery-usb-emergency-shell-report.sh` — Recovery USB emergency shell report command.
 - `scripts/base1-recovery-usb-emergency-shell-validate.sh` — Recovery USB emergency shell validation bundle.
 - `scripts/base1-recovery-usb-image-report.sh` — Recovery USB image provenance report command.

--- a/base1/RECOVERY_USB_EMERGENCY_SHELL.md
+++ b/base1/RECOVERY_USB_EMERGENCY_SHELL.md
@@ -80,3 +80,6 @@ Run first:
 ## Promotion rule
 
 A future recovery USB environment can only promote emergency shell behavior after shell entry, exit, state access, rollback metadata, log collection, storage layout, and actual Libreboot/X200-class boot behavior are verified.
+
+
+See also: [Recovery USB emergency shell summary](RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md).

--- a/base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md
+++ b/base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md
@@ -1,0 +1,79 @@
+# Base1 recovery USB emergency shell summary
+
+This summary ties together the read-only emergency shell behavior path for Base1 recovery USB planning.
+
+This document is advisory and read-only. It does not write USB media, partition disks, format disks, install GRUB, edit grub.cfg, write to /boot, flash firmware, change boot order, launch privileged shells, or modify host trust.
+
+## Target scope
+
+- Firmware profile: Libreboot expected.
+- Hardware profile: ThinkPad X200-class expected.
+- Bootloader expectation: GRUB first.
+- Recovery media: external USB planned.
+- Target identity: required before writing.
+- Image provenance: required before writing.
+- Emergency shell access: must remain available.
+- Root/admin boundary: operator-visible.
+- Secure Boot: not assumed.
+- TPM: not assumed.
+- Current maturity: emergency shell reports, validation bundle, design, and read-only documentation.
+
+## Read first
+
+1. `base1/RECOVERY_USB_EMERGENCY_SHELL.md`
+2. `base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md`
+3. `base1/RECOVERY_USB_IMAGE_SUMMARY.md`
+4. `base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md`
+5. `base1/RECOVERY_USB_COMMAND_INDEX.md`
+
+## First commands
+
+Run the read-only commands first:
+
+    sh scripts/base1-recovery-usb-emergency-shell-validate.sh
+    sh scripts/base1-recovery-usb-emergency-shell-report.sh
+    sh scripts/base1-recovery-usb-image-summary.sh
+    sh scripts/base1-recovery-usb-image-validate.sh
+    sh scripts/base1-recovery-dry-run.sh --dry-run
+
+## Emergency shell behavior fields
+
+The current emergency shell path records:
+
+- Emergency shell entry path.
+- Keyboard availability.
+- Display readability.
+- Root/admin boundary.
+- Phase1 auto-launch status.
+- Phase1 state path.
+- Rollback metadata path.
+- Recovery media boot path.
+- Network availability.
+- Offline recovery capability.
+- Log collection path.
+- Exit/reboot path.
+
+## Required behavior
+
+Emergency shell access must remain available.
+
+Root/admin boundaries must remain visible.
+
+Automatic recovery must not hide emergency access.
+
+## Still not claimed
+
+This summary does not claim:
+
+- Emergency shell execution readiness.
+- Privileged shell launch support.
+- USB media writing readiness.
+- Bootable Base1 image readiness.
+- Destructive installer readiness.
+- Automatic recovery readiness.
+- Real-hardware recovery completion.
+- Real-hardware rollback completion.
+
+## Promotion rule
+
+Recovery USB emergency shell behavior must remain read-only until shell entry, exit, state access, rollback metadata, log collection, storage layout, and actual Libreboot/X200-class boot behavior are verified.

--- a/base1/RECOVERY_USB_IMAGE_SUMMARY.md
+++ b/base1/RECOVERY_USB_IMAGE_SUMMARY.md
@@ -86,3 +86,6 @@ See also: [RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md](../RELEASE_BASE1_REC
 
 
 See also: [Recovery USB emergency shell behavior design](RECOVERY_USB_EMERGENCY_SHELL.md).
+
+
+See also: [Recovery USB emergency shell summary](RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md).

--- a/tests/base1_recovery_usb_emergency_shell_summary_docs.rs
+++ b/tests/base1_recovery_usb_emergency_shell_summary_docs.rs
@@ -1,0 +1,87 @@
+#[test]
+fn recovery_usb_emergency_shell_summary_lists_core_docs_and_commands() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md")
+        .expect("recovery usb emergency shell summary");
+
+    assert!(
+        doc.contains("Base1 recovery USB emergency shell summary"),
+        "{doc}"
+    );
+    assert!(doc.contains("RECOVERY_USB_EMERGENCY_SHELL.md"), "{doc}");
+    assert!(
+        doc.contains("RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md"),
+        "{doc}"
+    );
+    assert!(doc.contains("RECOVERY_USB_IMAGE_SUMMARY.md"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_IMAGE_COMMAND_INDEX.md"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_COMMAND_INDEX.md"), "{doc}");
+    assert!(
+        doc.contains("sh scripts/base1-recovery-usb-emergency-shell-validate.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("sh scripts/base1-recovery-usb-emergency-shell-report.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("sh scripts/base1-recovery-dry-run.sh --dry-run"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_emergency_shell_summary_records_behavior_fields() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md")
+        .expect("recovery usb emergency shell summary");
+
+    assert!(doc.contains("Emergency shell entry path"), "{doc}");
+    assert!(doc.contains("Keyboard availability"), "{doc}");
+    assert!(doc.contains("Display readability"), "{doc}");
+    assert!(doc.contains("Root/admin boundary"), "{doc}");
+    assert!(doc.contains("Phase1 auto-launch status"), "{doc}");
+    assert!(doc.contains("Rollback metadata path"), "{doc}");
+    assert!(doc.contains("Log collection path"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_emergency_shell_summary_preserves_non_claims_and_promotion_rule() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md")
+        .expect("recovery usb emergency shell summary");
+
+    assert!(doc.contains("Emergency shell execution readiness"), "{doc}");
+    assert!(doc.contains("Privileged shell launch support"), "{doc}");
+    assert!(doc.contains("USB media writing readiness"), "{doc}");
+    assert!(doc.contains("Bootable Base1 image readiness"), "{doc}");
+    assert!(doc.contains("Automatic recovery readiness"), "{doc}");
+    assert!(doc.contains("Real-hardware recovery completion"), "{doc}");
+    assert!(doc.contains("Real-hardware rollback completion"), "{doc}");
+    assert!(doc.contains("must remain read-only"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_emergency_shell_surfaces_link_summary() {
+    let emergency = std::fs::read_to_string("base1/RECOVERY_USB_EMERGENCY_SHELL.md")
+        .expect("recovery usb emergency shell");
+    let image = std::fs::read_to_string("base1/RECOVERY_USB_IMAGE_SUMMARY.md")
+        .expect("recovery usb image summary");
+    let command_index = std::fs::read_to_string("base1/RECOVERY_USB_COMMAND_INDEX.md")
+        .expect("recovery usb command index");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        emergency.contains("RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md"),
+        "{emergency}"
+    );
+    assert!(
+        image.contains("RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md"),
+        "{image}"
+    );
+    assert!(
+        command_index.contains("RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md"),
+        "{command_index}"
+    );
+    assert!(
+        readme.contains("base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds a read-only emergency shell behavior summary for Base1 recovery USB planning.

Implements:
- Recovery USB emergency shell summary
- emergency shell doc and command path
- emergency behavior field summary
- required shell-access behavior
- explicit non-claims and promotion rule
- README and recovery USB surface links
- docs tests for emergency shell summary coverage

Validation:
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_validation_bundle
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_report_script
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_docs
- cargo test -p phase1 --test base1_foundation

Refs #135