### PR TITLE
Add Base1 recovery USB emergency shell summary command

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ sh scripts/base1-recovery-usb-hardware-validate.sh
 sh scripts/base1-recovery-usb-hardware-checklist.sh
 sh scripts/base1-recovery-usb-index.sh
 sh scripts/base1-recovery-usb-target-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-recovery-usb-emergency-shell-summary.sh
 sh scripts/base1-recovery-usb-emergency-shell-validate.sh
 sh scripts/base1-recovery-usb-emergency-shell-report.sh
 sh scripts/base1-recovery-usb-image-summary.sh

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -20,6 +20,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 - `base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md` — Recovery USB emergency shell summary.
 - `scripts/base1-recovery-usb-emergency-shell-report.sh` — Recovery USB emergency shell report command.
 - `scripts/base1-recovery-usb-emergency-shell-validate.sh` — Recovery USB emergency shell validation bundle.
+- `scripts/base1-recovery-usb-emergency-shell-summary.sh` — Recovery USB emergency shell summary command.
 - `scripts/base1-recovery-usb-image-report.sh` — Recovery USB image provenance report command.
 - `scripts/base1-recovery-usb-image-validate.sh` — Recovery USB image provenance validation bundle.
 - `scripts/base1-recovery-usb-image-summary.sh` — Recovery USB image provenance summary command.

--- a/base1/RECOVERY_USB_EMERGENCY_SHELL.md
+++ b/base1/RECOVERY_USB_EMERGENCY_SHELL.md
@@ -53,6 +53,7 @@ This design does not launch a shell, grant privileges, edit boot settings, or ch
 
 Run first:
 
+    sh scripts/base1-recovery-usb-emergency-shell-summary.sh
     sh scripts/base1-recovery-usb-emergency-shell-validate.sh
     sh scripts/base1-recovery-usb-emergency-shell-report.sh
     sh scripts/base1-recovery-usb-image-summary.sh

--- a/base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md
+++ b/base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md
@@ -30,6 +30,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 
 Run the read-only commands first:
 
+    sh scripts/base1-recovery-usb-emergency-shell-summary.sh
     sh scripts/base1-recovery-usb-emergency-shell-validate.sh
     sh scripts/base1-recovery-usb-emergency-shell-report.sh
     sh scripts/base1-recovery-usb-image-summary.sh

--- a/scripts/base1-recovery-usb-emergency-shell-summary.sh
+++ b/scripts/base1-recovery-usb-emergency-shell-summary.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Base1 recovery USB emergency shell summary
+
+usage:
+  sh scripts/base1-recovery-usb-emergency-shell-summary.sh
+
+This command is read-only. It prints the recovery USB emergency shell behavior
+summary without writing USB media, changing boot settings, writing to /boot,
+modifying disks, changing firmware state, launching privileged shells, or
+changing host trust.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "error: unknown argument: $1" >&2
+    show_help >&2
+    exit 2
+    ;;
+esac
+
+cat <<'EOF'
+base1 recovery USB emergency shell summary
+mode                  : read-only
+writes                : no
+shell_launch          : no
+firmware              : Libreboot expected
+hardware              : X200-class expected
+bootloader            : GRUB first
+media                 : external USB planned
+target_identity       : required before writing
+image_provenance      : required before writing
+root_boundary         : operator-visible
+emergency_access      : must remain available
+trust                 : no host trust escalation
+maturity              : emergency shell reports, validation bundle, design, and documentation
+
+read first:
+1. base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md
+2. base1/RECOVERY_USB_EMERGENCY_SHELL.md
+3. base1/RECOVERY_USB_IMAGE_SUMMARY.md
+4. base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md
+5. base1/RECOVERY_USB_COMMAND_INDEX.md
+
+first commands:
+- sh scripts/base1-recovery-usb-emergency-shell-summary.sh
+- sh scripts/base1-recovery-usb-emergency-shell-validate.sh
+- sh scripts/base1-recovery-usb-emergency-shell-report.sh
+- sh scripts/base1-recovery-usb-image-summary.sh
+- sh scripts/base1-recovery-dry-run.sh --dry-run
+
+not claimed:
+- emergency shell execution readiness
+- privileged shell launch support
+- USB media writing readiness
+- bootable Base1 image readiness
+- automatic recovery readiness
+- real-hardware recovery completion
+- real-hardware rollback completion
+EOF

--- a/tests/base1_recovery_usb_emergency_shell_summary_script.rs
+++ b/tests/base1_recovery_usb_emergency_shell_summary_script.rs
@@ -1,0 +1,110 @@
+use std::process::Command;
+
+#[test]
+fn recovery_usb_emergency_shell_summary_script_prints_summary() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-emergency-shell-summary.sh")
+        .output()
+        .expect("run recovery USB emergency shell summary script");
+
+    let mut text = String::new();
+    text.push_str(&String::from_utf8_lossy(&output.stdout));
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("base1 recovery USB emergency shell summary"),
+        "{text}"
+    );
+    assert!(text.contains("mode                  : read-only"), "{text}");
+    assert!(text.contains("writes                : no"), "{text}");
+    assert!(text.contains("shell_launch          : no"), "{text}");
+    assert!(
+        text.contains("firmware              : Libreboot expected"),
+        "{text}"
+    );
+    assert!(
+        text.contains("hardware              : X200-class expected"),
+        "{text}"
+    );
+    assert!(
+        text.contains("bootloader            : GRUB first"),
+        "{text}"
+    );
+    assert!(
+        text.contains("emergency_access      : must remain available"),
+        "{text}"
+    );
+}
+
+#[test]
+fn recovery_usb_emergency_shell_summary_script_lists_docs_commands_and_non_claims() {
+    let output = Command::new("sh")
+        .arg("scripts/base1-recovery-usb-emergency-shell-summary.sh")
+        .output()
+        .expect("run recovery USB emergency shell summary script");
+
+    let text = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        text.contains("base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md"),
+        "{text}"
+    );
+    assert!(
+        text.contains("base1/RECOVERY_USB_EMERGENCY_SHELL.md"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-recovery-usb-emergency-shell-summary.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-recovery-usb-emergency-shell-validate.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("sh scripts/base1-recovery-usb-emergency-shell-report.sh"),
+        "{text}"
+    );
+    assert!(
+        text.contains("emergency shell execution readiness"),
+        "{text}"
+    );
+    assert!(text.contains("privileged shell launch support"), "{text}");
+    assert!(text.contains("automatic recovery readiness"), "{text}");
+    assert!(text.contains("real-hardware rollback completion"), "{text}");
+}
+
+#[test]
+fn recovery_usb_emergency_shell_summary_script_avoids_mutating_tools_and_sensitive_terms() {
+    let script = std::fs::read_to_string("scripts/base1-recovery-usb-emergency-shell-summary.sh")
+        .expect("recovery USB emergency shell summary script");
+
+    let forbidden = [
+        "flashrom",
+        "grub-install",
+        "grub-mkconfig",
+        "update-grub",
+        "bootctl install",
+        "efibootmgr",
+        "mkfs",
+        "fdisk",
+        "parted",
+        "sfdisk",
+        "diskutil erase",
+        "dd if=",
+        "mount ",
+        "umount ",
+        "rm -rf",
+        "password",
+        "token",
+        "private key",
+    ];
+
+    for token in forbidden {
+        assert!(
+            !script.contains(token),
+            "forbidden token {token:?} found in script"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only emergency shell behavior summary command for Base1 recovery USB planning.

Implements:
- scripts/base1-recovery-usb-emergency-shell-summary.sh
- emergency shell behavior summary output
- docs and first command list
- explicit non-claims for shell execution, privilege launch, media writing, recovery, and rollback
- README, emergency shell design, emergency shell summary, and command index updates
- mutating-tool and sensitive-term guard test

Validation:
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_summary_script
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_validation_bundle
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_report_script
- cargo test -p phase1 --test base1_foundation

Refs #135