### PR TITLE
Document Base1 recovery USB emergency shell command index

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Start here:
 - [`base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md`](base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md) — Recovery USB image provenance command index
 - [`base1/RECOVERY_USB_EMERGENCY_SHELL.md`](base1/RECOVERY_USB_EMERGENCY_SHELL.md) — Recovery USB emergency shell behavior design
 - [`base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md`](base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md) — Recovery USB emergency shell summary
+- [`base1/RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md`](base1/RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md) — Recovery USB emergency shell command index
 - [`RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md) — Recovery USB image provenance read-only checkpoint release notes
 - [`RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md) — Recovery USB target selection read-only checkpoint release notes
 - [`RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md) — Recovery USB hardware read-only checkpoint release notes

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -18,6 +18,7 @@ This document is advisory and read-only. It does not write USB media, partition 
 - `base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md` — Recovery USB image provenance command index.
 - `base1/RECOVERY_USB_EMERGENCY_SHELL.md` — Recovery USB emergency shell behavior design.
 - `base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md` — Recovery USB emergency shell summary.
+- `base1/RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md` — Recovery USB emergency shell command index.
 - `scripts/base1-recovery-usb-emergency-shell-report.sh` — Recovery USB emergency shell report command.
 - `scripts/base1-recovery-usb-emergency-shell-validate.sh` — Recovery USB emergency shell validation bundle.
 - `scripts/base1-recovery-usb-emergency-shell-summary.sh` — Recovery USB emergency shell summary command.

--- a/base1/RECOVERY_USB_EMERGENCY_SHELL.md
+++ b/base1/RECOVERY_USB_EMERGENCY_SHELL.md
@@ -84,3 +84,6 @@ A future recovery USB environment can only promote emergency shell behavior afte
 
 
 See also: [Recovery USB emergency shell summary](RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md).
+
+
+See also: [Recovery USB emergency shell command index](RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md).

--- a/base1/RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md
@@ -1,0 +1,65 @@
+# Base1 recovery USB emergency shell command index
+
+This index collects the read-only emergency shell behavior documents and commands for Base1 recovery USB planning.
+
+This document is advisory and read-only. It does not write USB media, partition disks, format disks, install GRUB, edit grub.cfg, write to /boot, flash firmware, change boot order, launch privileged shells, or modify host trust.
+
+## Emergency shell documents
+
+- `base1/RECOVERY_USB_EMERGENCY_SHELL.md` — emergency shell behavior design.
+- `base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md` — emergency shell behavior summary.
+- `base1/RECOVERY_USB_IMAGE_SUMMARY.md` — image provenance summary.
+- `base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md` — image provenance command index.
+- `base1/RECOVERY_USB_COMMAND_INDEX.md` — broader recovery USB command index.
+
+## Emergency shell commands
+
+- `scripts/base1-recovery-usb-emergency-shell-summary.sh`
+- `scripts/base1-recovery-usb-emergency-shell-validate.sh`
+- `scripts/base1-recovery-usb-emergency-shell-report.sh`
+- `scripts/base1-recovery-usb-image-summary.sh`
+- `scripts/base1-recovery-usb-image-validate.sh`
+- `scripts/base1-recovery-dry-run.sh --dry-run`
+
+## Emergency shell fields
+
+An emergency shell preview must keep these fields operator-visible:
+
+- Emergency shell entry path.
+- Keyboard availability.
+- Display readability.
+- Root/admin boundary.
+- Phase1 auto-launch status.
+- Phase1 state path.
+- Rollback metadata path.
+- Recovery media boot path.
+- Network availability.
+- Offline recovery capability.
+- Log collection path.
+- Exit/reboot path.
+
+## Shared guardrails
+
+Every emergency-shell document or command must preserve these rules:
+
+- Report shell launch: no.
+- Report writes: no.
+- Keep emergency shell access available.
+- Keep root/admin boundaries operator-visible.
+- Do not launch privileged shells automatically.
+- Do not remove emergency shell access.
+- Do not hide root/admin boundaries.
+- Do not write USB media.
+- Do not run dd automatically.
+- Do not partition disks.
+- Do not format disks.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not flash firmware.
+- Do not change boot order.
+- Do not store passwords, tokens, private keys, recovery phrases, or personal secrets.
+
+## Promotion rule
+
+A future recovery USB environment can only promote emergency shell behavior after shell entry, exit, state access, rollback metadata, log collection, storage layout, and actual Libreboot/X200-class boot behavior are verified.

--- a/base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md
+++ b/base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md
@@ -78,3 +78,6 @@ This summary does not claim:
 ## Promotion rule
 
 Recovery USB emergency shell behavior must remain read-only until shell entry, exit, state access, rollback metadata, log collection, storage layout, and actual Libreboot/X200-class boot behavior are verified.
+
+
+See also: [Recovery USB emergency shell command index](RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md).

--- a/tests/base1_recovery_usb_emergency_shell_command_index_docs.rs
+++ b/tests/base1_recovery_usb_emergency_shell_command_index_docs.rs
@@ -1,0 +1,102 @@
+#[test]
+fn recovery_usb_emergency_shell_command_index_lists_docs_and_commands() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md")
+        .expect("recovery usb emergency shell command index");
+
+    assert!(
+        doc.contains("Base1 recovery USB emergency shell command index"),
+        "{doc}"
+    );
+    assert!(doc.contains("RECOVERY_USB_EMERGENCY_SHELL.md"), "{doc}");
+    assert!(
+        doc.contains("RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md"),
+        "{doc}"
+    );
+    assert!(doc.contains("RECOVERY_USB_IMAGE_SUMMARY.md"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_IMAGE_COMMAND_INDEX.md"), "{doc}");
+    assert!(doc.contains("RECOVERY_USB_COMMAND_INDEX.md"), "{doc}");
+    assert!(
+        doc.contains("scripts/base1-recovery-usb-emergency-shell-summary.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-recovery-usb-emergency-shell-validate.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-recovery-usb-emergency-shell-report.sh"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_emergency_shell_command_index_preserves_behavior_fields() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md")
+        .expect("recovery usb emergency shell command index");
+
+    assert!(doc.contains("Emergency shell entry path"), "{doc}");
+    assert!(doc.contains("Keyboard availability"), "{doc}");
+    assert!(doc.contains("Display readability"), "{doc}");
+    assert!(doc.contains("Root/admin boundary"), "{doc}");
+    assert!(doc.contains("Phase1 auto-launch status"), "{doc}");
+    assert!(doc.contains("Rollback metadata path"), "{doc}");
+    assert!(doc.contains("Log collection path"), "{doc}");
+    assert!(doc.contains("Exit/reboot path"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_emergency_shell_command_index_preserves_guardrails() {
+    let doc = std::fs::read_to_string("base1/RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md")
+        .expect("recovery usb emergency shell command index");
+
+    assert!(doc.contains("Report shell launch: no"), "{doc}");
+    assert!(doc.contains("Report writes: no"), "{doc}");
+    assert!(
+        doc.contains("Keep emergency shell access available"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Keep root/admin boundaries operator-visible"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Do not launch privileged shells automatically"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Do not remove emergency shell access"),
+        "{doc}"
+    );
+    assert!(doc.contains("Do not hide root/admin boundaries"), "{doc}");
+    assert!(doc.contains("Do not write USB media"), "{doc}");
+    assert!(doc.contains("Do not write to /boot"), "{doc}");
+    assert!(doc.contains("Do not store passwords"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_emergency_shell_surfaces_link_command_index() {
+    let emergency = std::fs::read_to_string("base1/RECOVERY_USB_EMERGENCY_SHELL.md")
+        .expect("recovery usb emergency shell");
+    let summary = std::fs::read_to_string("base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md")
+        .expect("recovery usb emergency shell summary");
+    let command_index = std::fs::read_to_string("base1/RECOVERY_USB_COMMAND_INDEX.md")
+        .expect("recovery usb command index");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        emergency.contains("RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md"),
+        "{emergency}"
+    );
+    assert!(
+        summary.contains("RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md"),
+        "{summary}"
+    );
+    assert!(
+        command_index.contains("RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md"),
+        "{command_index}"
+    );
+    assert!(
+        readme.contains("base1/RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds a command index for Base1 recovery USB emergency shell behavior planning.

Implements:
- Recovery USB emergency shell command index
- emergency shell docs and command list
- emergency shell behavior field summary
- shared emergency shell guardrails
- README and recovery USB surface links
- docs tests for command index coverage

Validation:
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_command_index_docs
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_summary_script
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_validation_bundle
- cargo test -p phase1 --test base1_foundation

Refs #135