### PR TITLE
Document Base1 recovery USB emergency shell checkpoint release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Start here:
 - [`base1/RECOVERY_USB_EMERGENCY_SHELL.md`](base1/RECOVERY_USB_EMERGENCY_SHELL.md) — Recovery USB emergency shell behavior design
 - [`base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md`](base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md) — Recovery USB emergency shell summary
 - [`base1/RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md`](base1/RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md) — Recovery USB emergency shell command index
+- [`RELEASE_BASE1_RECOVERY_USB_EMERGENCY_SHELL_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_EMERGENCY_SHELL_READONLY_V1.md) — Recovery USB emergency shell read-only checkpoint release notes
 - [`RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md) — Recovery USB image provenance read-only checkpoint release notes
 - [`RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_TARGET_READONLY_V1.md) — Recovery USB target selection read-only checkpoint release notes
 - [`RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md`](RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md) — Recovery USB hardware read-only checkpoint release notes

--- a/RELEASE_BASE1_RECOVERY_USB_EMERGENCY_SHELL_READONLY_V1.md
+++ b/RELEASE_BASE1_RECOVERY_USB_EMERGENCY_SHELL_READONLY_V1.md
@@ -1,0 +1,82 @@
+# Base1 recovery USB emergency shell read-only checkpoint v1
+
+This checkpoint captures the read-only emergency shell behavior path for Base1 recovery USB planning.
+
+## Status
+
+- Checkpoint branch: checkpoint/base1-recovery-usb-emergency-shell-readonly-v1
+- Checkpoint tag: base1-recovery-usb-emergency-shell-readonly-v1
+- Firmware profile: Libreboot expected
+- Hardware profile: ThinkPad X200-class expected
+- Bootloader expectation: GRUB first
+- Recovery media: external USB planned
+- Target identity: required before future writing
+- Image provenance: required before future writing
+- Emergency shell access: must remain available
+- Root/admin boundary: operator-visible
+- Secure Boot: not assumed
+- TPM: not assumed
+- Current maturity: emergency shell reports, validation bundle, summaries, command index, and read-only documentation
+
+## Included documents
+
+- base1/RECOVERY_USB_EMERGENCY_SHELL.md
+- base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md
+- base1/RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md
+- base1/RECOVERY_USB_IMAGE_SUMMARY.md
+- base1/RECOVERY_USB_IMAGE_COMMAND_INDEX.md
+- base1/RECOVERY_USB_COMMAND_INDEX.md
+
+## Included commands
+
+- scripts/base1-recovery-usb-emergency-shell-summary.sh
+- scripts/base1-recovery-usb-emergency-shell-validate.sh
+- scripts/base1-recovery-usb-emergency-shell-report.sh
+- scripts/base1-recovery-usb-image-summary.sh
+- scripts/base1-recovery-usb-image-validate.sh
+- scripts/base1-recovery-dry-run.sh --dry-run
+
+## Validation
+
+Run:
+
+    cargo test -p phase1 --test base1_recovery_usb_emergency_shell_command_index_docs
+    cargo test -p phase1 --test base1_recovery_usb_emergency_shell_summary_script
+    cargo test -p phase1 --test base1_recovery_usb_emergency_shell_summary_docs
+    cargo test -p phase1 --test base1_recovery_usb_emergency_shell_validation_bundle
+    cargo test -p phase1 --test base1_recovery_usb_emergency_shell_report_script
+    cargo test -p phase1 --test base1_recovery_usb_emergency_shell_docs
+    cargo test -p phase1 --test base1_foundation
+
+## Guardrails
+
+- Do not launch privileged shells automatically.
+- Do not remove emergency shell access.
+- Do not hide root/admin boundaries.
+- Do not write USB media.
+- Do not run dd automatically.
+- Do not partition disks.
+- Do not format disks.
+- Do not install GRUB automatically.
+- Do not edit grub.cfg automatically.
+- Do not write to /boot.
+- Do not change boot order.
+- Do not flash firmware.
+- Do not store passwords, tokens, private keys, recovery phrases, or personal secrets.
+
+## Non-claims
+
+This checkpoint does not claim:
+
+- Emergency shell execution readiness.
+- Privileged shell launch support.
+- USB media writing readiness.
+- Bootable Base1 image readiness.
+- Destructive installer readiness.
+- Automatic recovery readiness.
+- Real-hardware recovery completion.
+- Real-hardware rollback completion.
+
+## Next milestone
+
+The next milestone should remain read-only unless shell entry, exit, state access, rollback metadata, log collection, storage layout, and actual Libreboot/X200-class boot behavior are verified.

--- a/base1/RECOVERY_USB_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_COMMAND_INDEX.md
@@ -83,3 +83,6 @@ See also: [`RELEASE_BASE1_RECOVERY_USB_HARDWARE_READONLY_V1.md`](../RELEASE_BASE
 
 
 See also: [`RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md`](../RELEASE_BASE1_RECOVERY_USB_IMAGE_READONLY_V1.md) — recovery USB image provenance read-only checkpoint release notes.
+
+
+See also: [`RELEASE_BASE1_RECOVERY_USB_EMERGENCY_SHELL_READONLY_V1.md`](../RELEASE_BASE1_RECOVERY_USB_EMERGENCY_SHELL_READONLY_V1.md) — recovery USB emergency shell read-only checkpoint release notes.

--- a/base1/RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md
+++ b/base1/RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md
@@ -63,3 +63,6 @@ Every emergency-shell document or command must preserve these rules:
 ## Promotion rule
 
 A future recovery USB environment can only promote emergency shell behavior after shell entry, exit, state access, rollback metadata, log collection, storage layout, and actual Libreboot/X200-class boot behavior are verified.
+
+
+See also: [`RELEASE_BASE1_RECOVERY_USB_EMERGENCY_SHELL_READONLY_V1.md`](../RELEASE_BASE1_RECOVERY_USB_EMERGENCY_SHELL_READONLY_V1.md) — recovery USB emergency shell read-only checkpoint release notes.

--- a/base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md
+++ b/base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md
@@ -81,3 +81,6 @@ Recovery USB emergency shell behavior must remain read-only until shell entry, e
 
 
 See also: [Recovery USB emergency shell command index](RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md).
+
+
+See also: [RELEASE_BASE1_RECOVERY_USB_EMERGENCY_SHELL_READONLY_V1.md](../RELEASE_BASE1_RECOVERY_USB_EMERGENCY_SHELL_READONLY_V1.md).

--- a/tests/base1_recovery_usb_emergency_shell_release_notes_docs.rs
+++ b/tests/base1_recovery_usb_emergency_shell_release_notes_docs.rs
@@ -1,0 +1,82 @@
+#[test]
+fn recovery_usb_emergency_shell_release_notes_record_checkpoint_status() {
+    let doc = std::fs::read_to_string("RELEASE_BASE1_RECOVERY_USB_EMERGENCY_SHELL_READONLY_V1.md")
+        .expect("recovery usb emergency shell release notes");
+
+    assert!(
+        doc.contains("Base1 recovery USB emergency shell read-only checkpoint v1"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("checkpoint/base1-recovery-usb-emergency-shell-readonly-v1"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("base1-recovery-usb-emergency-shell-readonly-v1"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Firmware profile: Libreboot expected"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("Hardware profile: ThinkPad X200-class expected"),
+        "{doc}"
+    );
+    assert!(doc.contains("Bootloader expectation: GRUB first"), "{doc}");
+    assert!(
+        doc.contains("Emergency shell access: must remain available"),
+        "{doc}"
+    );
+}
+
+#[test]
+fn recovery_usb_emergency_shell_release_notes_list_surfaces_and_non_claims() {
+    let doc = std::fs::read_to_string("RELEASE_BASE1_RECOVERY_USB_EMERGENCY_SHELL_READONLY_V1.md")
+        .expect("recovery usb emergency shell release notes");
+
+    assert!(
+        doc.contains("base1/RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-recovery-usb-emergency-shell-summary.sh"),
+        "{doc}"
+    );
+    assert!(
+        doc.contains("scripts/base1-recovery-usb-emergency-shell-validate.sh"),
+        "{doc}"
+    );
+    assert!(doc.contains("Emergency shell execution readiness"), "{doc}");
+    assert!(doc.contains("Privileged shell launch support"), "{doc}");
+    assert!(doc.contains("Automatic recovery readiness"), "{doc}");
+    assert!(doc.contains("Real-hardware rollback completion"), "{doc}");
+}
+
+#[test]
+fn recovery_usb_emergency_shell_surfaces_link_release_notes() {
+    let summary = std::fs::read_to_string("base1/RECOVERY_USB_EMERGENCY_SHELL_SUMMARY.md")
+        .expect("recovery usb emergency shell summary");
+    let index = std::fs::read_to_string("base1/RECOVERY_USB_EMERGENCY_SHELL_COMMAND_INDEX.md")
+        .expect("recovery usb emergency shell command index");
+    let command_index = std::fs::read_to_string("base1/RECOVERY_USB_COMMAND_INDEX.md")
+        .expect("recovery usb command index");
+    let readme = std::fs::read_to_string("README.md").expect("README.md");
+
+    assert!(
+        summary.contains("RELEASE_BASE1_RECOVERY_USB_EMERGENCY_SHELL_READONLY_V1.md"),
+        "{summary}"
+    );
+    assert!(
+        index.contains("RELEASE_BASE1_RECOVERY_USB_EMERGENCY_SHELL_READONLY_V1.md"),
+        "{index}"
+    );
+    assert!(
+        command_index.contains("RELEASE_BASE1_RECOVERY_USB_EMERGENCY_SHELL_READONLY_V1.md"),
+        "{command_index}"
+    );
+    assert!(
+        readme.contains("RELEASE_BASE1_RECOVERY_USB_EMERGENCY_SHELL_READONLY_V1.md"),
+        "{readme}"
+    );
+}


### PR DESCRIPTION
Adds release notes for the Base1 recovery USB emergency shell read-only checkpoint.

Implements:
- RELEASE_BASE1_RECOVERY_USB_EMERGENCY_SHELL_READONLY_V1.md
- emergency shell docs and commands inventory
- validation command set
- explicit guardrails and non-claims
- README, recovery USB command index, emergency shell summary, and emergency shell command index links
- docs tests for release notes coverage

Validation:
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_release_notes_docs
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_command_index_docs
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_summary_script
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_summary_docs
- cargo test -p phase1 --test base1_recovery_usb_emergency_shell_validation_bundle
- cargo test -p phase1 --test base1_foundation

Refs #135