### PR TITLE
Add Phase1 help palette and crimson v6 default

### DIFF
--- a/DEVELOPMENT_CHECKPOINT_EDGE_6_0_0.md
+++ b/DEVELOPMENT_CHECKPOINT_EDGE_6_0_0.md
@@ -55,3 +55,7 @@ Recommended follow-up work after this checkpoint:
 The v6.0.0 edge line opens after the Base1 recovery USB target-selection and image-provenance read-only checkpoints.
 
 This is still an edge line. It does not claim a finished OS replacement, bootable Base1 image readiness, destructive installer readiness, USB media writing readiness, or real-hardware recovery completion.
+
+### v6 visual default
+
+The v6 edge console defaults to the `crimson` palette when no `PHASE1_THEME` override is set. The legacy bleeding-edge palette remains available manually with `theme edge`.

--- a/OPERATOR_SHELL.md
+++ b/OPERATOR_SHELL.md
@@ -77,3 +77,19 @@ Phase1 v6 exposes a topic-aware help deck:
     complete <prefix>
 
 The boot LIVE OPS panel now points operators toward the compact help map, category help, dashboard, security status, ops log, theme list, tips, and update protocol.
+
+### Help command palette
+
+The modern help surface includes a visual command palette and workflow deck:
+
+    help ui
+    help flows
+    help --compact
+    help <category>
+    help <command>
+
+Use `help ui` for a launch-pad view and `help flows` for daily check, safe update, development, recovery planning, and discovery workflows.
+
+### v6 visual default
+
+The v6 edge console defaults to the `crimson` palette when no `PHASE1_THEME` override is set. The legacy bleeding-edge palette remains available manually with `theme edge`.

--- a/README.md
+++ b/README.md
@@ -477,3 +477,19 @@ Phase1 v6 exposes a topic-aware help deck:
     complete <prefix>
 
 The boot LIVE OPS panel now points operators toward the compact help map, category help, dashboard, security status, ops log, theme list, tips, and update protocol.
+
+### Help command palette
+
+The modern help surface includes a visual command palette and workflow deck:
+
+    help ui
+    help flows
+    help --compact
+    help <category>
+    help <command>
+
+Use `help ui` for a launch-pad view and `help flows` for daily check, safe update, development, recovery planning, and discovery workflows.
+
+### v6 visual default
+
+The v6 edge console defaults to the `crimson` palette when no `PHASE1_THEME` override is set. The legacy bleeding-edge palette remains available manually with `theme edge`.

--- a/src/boot_ui_static.rs
+++ b/src/boot_ui_static.rs
@@ -1,4 +1,3 @@
-use crate::registry;
 use std::fs;
 use std::io::{self, Write};
 use std::process::{Command, Stdio};
@@ -138,7 +137,7 @@ impl ThemePalette {
             Self::Ice => "cool blue/cyan frost terminal",
             Self::Synth => "purple synthwave operator glow",
             Self::Crimson => "red alert / intrusion-response console",
-            Self::BleedingEdge => "edge-only blue/magenta update channel console",
+            Self::BleedingEdge => "legacy edge-only blue/magenta update channel console",
         }
     }
 
@@ -220,7 +219,7 @@ impl BootConfig {
             std::env::set_var("PHASE1_NO_COLOR", "1");
         }
         if self.bleeding_edge && std::env::var("PHASE1_THEME").is_err() {
-            std::env::set_var("PHASE1_THEME", ThemePalette::BleedingEdge.name());
+            std::env::set_var("PHASE1_THEME", ThemePalette::Crimson.name());
         }
     }
 
@@ -399,10 +398,6 @@ pub fn print_quick_boot(version: &str, config: BootConfig) {
         ),
     ));
     outln("");
-}
-
-pub fn print_help() {
-    print!("{}", registry::command_map());
 }
 
 pub fn print_prompt(user: &str, path: &str) {
@@ -619,7 +614,7 @@ fn print_boot_card(
         outln(&card_line(
             config,
             width,
-            "help --compact | help sys | help host",
+            "help ui | help --compact | help host",
         ));
         outln(&card_line(
             config,
@@ -629,7 +624,7 @@ fn print_boot_card(
         outln(&card_line(
             config,
             width,
-            "theme list | tips | update protocol",
+            "help flows | theme list | update protocol",
         ));
     }
     outln(&card_bottom(config, width));
@@ -1316,7 +1311,7 @@ fn active_theme() -> ThemePalette {
         .filter(|theme| *theme != ThemePalette::BleedingEdge || bleeding_edge_env_enabled())
         .unwrap_or_else(|| {
             if bleeding_edge_env_enabled() {
-                ThemePalette::BleedingEdge
+                ThemePalette::Crimson
             } else {
                 ThemePalette::NeoTokyo
             }
@@ -1330,7 +1325,7 @@ fn active_theme_for_config(config: BootConfig) -> ThemePalette {
         .filter(|theme| *theme != ThemePalette::BleedingEdge || config.bleeding_edge)
         .unwrap_or_else(|| {
             if config.bleeding_edge {
-                ThemePalette::BleedingEdge
+                ThemePalette::Crimson
             } else {
                 ThemePalette::NeoTokyo
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -486,7 +486,7 @@ fn execute_one(
                     "avim" | "emacs" | "repo" | "lang" | "fyr" | "opslog"
                 );
             match canonical {
-                "help" => ui::print_help(),
+                "help" => print!("{}", registry::help(args)),
                 "accounts" => print!("{}", accounts_report(shell)),
                 "security" => print!(
                     "{}",

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -14,7 +14,7 @@ const TIPS: &[&str] = &[
 
 pub fn theme(shell: &mut Phase1Shell, args: &[String]) -> String {
     match args.first().map(String::as_str) {
-        None | Some("show") => theme_status(shell),
+        None | Some("show") | Some("status") => theme_status(shell),
         Some("list") | Some("ls") => theme_list(),
         Some("mono") | Some("plain") => {
             std::env::set_var("PHASE1_NO_COLOR", "1");
@@ -46,8 +46,8 @@ pub fn theme(shell: &mut Phase1Shell, args: &[String]) -> String {
         }
         Some("reset") => {
             if bleeding_edge_active() {
-                set_palette(shell, ThemePalette::BleedingEdge);
-                "theme: reset to bleeding-edge default\n".to_string()
+                set_palette(shell, ThemePalette::Crimson);
+                "theme: reset to crimson edge default\n".to_string()
             } else {
                 set_palette(shell, ThemePalette::Rainbow);
                 "theme: reset to rainbow default\n".to_string()
@@ -55,8 +55,8 @@ pub fn theme(shell: &mut Phase1Shell, args: &[String]) -> String {
         }
         Some("default") => {
             if bleeding_edge_active() {
-                set_palette(shell, ThemePalette::BleedingEdge);
-                "theme: bleeding-edge default enabled\n".to_string()
+                set_palette(shell, ThemePalette::Crimson);
+                "theme: crimson edge default enabled\n".to_string()
             } else {
                 set_palette(shell, ThemePalette::Rainbow);
                 "theme: rainbow default enabled\n".to_string()
@@ -312,7 +312,7 @@ fn theme_status(shell: &Phase1Shell) -> String {
             })
             .unwrap_or_else(|| {
                 if bleeding_edge_active() {
-                    ThemePalette::BleedingEdge.name().to_string()
+                    ThemePalette::Crimson.name().to_string()
                 } else {
                     ThemePalette::Rainbow.name().to_string()
                 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -131,197 +131,131 @@ pub fn canonical_name(name: &str) -> Option<&'static str> {
 }
 
 pub fn help(args: &[String]) -> String {
-    let Some(topic) = args.first() else {
-        return command_map();
-    };
+    let topic = args.first().map(String::as_str);
 
-    if matches!(topic.as_str(), "--compact" | "-c" | "compact") {
-        return compact_command_map();
+    match topic {
+        None => command_map(),
+        Some("--compact" | "-c" | "compact") => compact_command_map(),
+        Some("ui" | "hud" | "palette" | "deck") => command_palette(),
+        Some("flows" | "flow" | "workflow" | "workflows") => operator_flows(),
+        Some(category) if CATEGORIES.contains(&category) => category_help(category),
+        Some(command) => {
+            if let Some(page) = man_page(command) {
+                format!(
+                    "phase1 help // {command}\n\n{page}\n\nroutes\n  man {command:<12} full manual\n  complete {command:<8} registry completions\n  help ui         command palette\n  help --compact  fast command map\n"
+                )
+            } else {
+                format!(
+                    "phase1 help // no match\n\nunknown topic : {command}\ntry           : help ui | help flows | help --compact | help fs | help host | help update | complete {command}\n"
+                )
+            }
+        }
     }
-
-    if CATEGORIES.contains(&topic.as_str()) {
-        return category_help(topic);
-    }
-
-    if let Some(page) = man_page(topic) {
-        return format!(
-            "phase1 help // {topic}
-
-{page}
-
-routes
-  man {topic:<12} full manual
-  complete {topic:<8} registry completions
-  help --compact   fast command map
-"
-        );
-    }
-
-    format!(
-        "phase1 help // no match
-
-unknown topic : {topic}
-try           : help --compact | help fs | help host | help update | complete {topic}
-"
-    )
 }
 
 pub fn command_map() -> String {
-    let mut out = String::from(
-        "phase1 help // operator HUD
-",
-    );
-    out.push_str(
-        "version       : v6 help surface
-",
-    );
-    out.push_str(
-        "layout        : topic-aware command deck
-",
-    );
-    out.push_str(
-        "guardrails    : safe-mode, host trust gate, audited writes
+    let mut out = String::from("phase1 help // operator HUD\n");
+    out.push_str("version       : v6 help surface\n");
+    out.push_str("layout        : topic-aware command deck\n");
+    out.push_str("guardrails    : safe-mode, host trust gate, audited writes\n\n");
 
-",
-    );
+    out.push_str("high signal\n");
+    out.push_str("  dash             operator dashboard\n");
+    out.push_str("  sysinfo          one-screen system summary\n");
+    out.push_str("  security         trust, shield, persistence, privacy\n");
+    out.push_str("  opslog           sanitized operator log controls\n");
+    out.push_str("  update protocol  release and update rules\n\n");
 
+    out.push_str("help routes\n");
+    out.push_str("  help             full operator HUD\n");
+    out.push_str("  help ui          visual command palette\n");
+    out.push_str("  help flows       workflow launch paths\n");
+    out.push_str("  help --compact   compact command map\n");
     out.push_str(
-        "high signal
-",
+        "  help <category>  category deck: fs text proc net host dev editor arch sys user misc\n",
     );
-    out.push_str(
-        "  dash             operator dashboard
-",
-    );
-    out.push_str(
-        "  sysinfo          one-screen system summary
-",
-    );
-    out.push_str(
-        "  security         trust, shield, persistence, privacy
-",
-    );
-    out.push_str(
-        "  opslog           sanitized operator log controls
-",
-    );
-    out.push_str(
-        "  update protocol  release and update rules
+    out.push_str("  help <command>   command manual card\n");
+    out.push_str("  complete <text>  registry completions\n\n");
 
-",
-    );
-
-    out.push_str(
-        "help routes
-",
-    );
-    out.push_str(
-        "  help             full operator HUD
-",
-    );
-    out.push_str(
-        "  help --compact   compact command map
-",
-    );
-    out.push_str(
-        "  help <category>  category deck: fs text proc net host dev editor arch sys user misc
-",
-    );
-    out.push_str(
-        "  help <command>   command manual card
-",
-    );
-    out.push_str(
-        "  complete <text>  registry completions
-
-",
-    );
-
-    out.push_str(
-        "command decks
-",
-    );
+    out.push_str("command decks\n");
     for category in CATEGORIES {
-        out.push_str(&format!(
-            "  {:<7} {}
-",
-            category,
-            command_names(category)
-        ));
+        out.push_str(&format!("  {:<7} {}\n", category, command_names(category)));
     }
 
-    out.push_str(
-        "
-quick routes
-",
-    );
-    out.push_str(
-        "  status features | capabilities | version --compare | roadmap
-",
-    );
-    out.push_str(
-        "  lang support | lang security | avim notes.rs | update test quick
-",
-    );
-    out.push_str(
-        "  learn status | learn import-history | learn suggest | theme list | tips
-",
-    );
-    out.push_str(
-        "  pipeline | wasm list | update protocol | sysinfo | security | opslog
-",
-    );
+    out.push_str("\nquick routes\n");
+    out.push_str("  status features | capabilities | version --compare | roadmap\n");
+    out.push_str("  lang support | lang security | avim notes.rs | update test quick\n");
+    out.push_str("  learn status | learn import-history | learn suggest | theme list | tips\n");
+    out.push_str("  pipeline | wasm list | update protocol | sysinfo | security | opslog\n");
+    out.push_str("\nvisual\n");
+    out.push_str("  help ui          launch the command palette\n");
+    out.push_str("  help flows       show operator workflows\n");
+    out
+}
+
+fn command_palette() -> String {
+    let mut out = String::new();
+    out.push_str("╭─ phase1 command palette // v6 ─────────────────────────╮\n");
+    out.push_str("│ search       complete <prefix>                         │\n");
+    out.push_str("│ inspect      help <command> | man <command>             │\n");
+    out.push_str("│ operate      dash | sysinfo | security | opslog         │\n");
+    out.push_str("│ build        dev | repo | fyr | lang | cargo            │\n");
+    out.push_str("│ recover      help host | update protocol | roadmap      │\n");
+    out.push_str("╰────────────────────────────────────────────────────────╯\n\n");
+
+    out.push_str("hot zones\n");
+    out.push_str("  CORE     dash sysinfo security opslog version roadmap\n");
+    out.push_str("  BUILD    dev repo fyr lang cargo rustc git gh\n");
+    out.push_str("  TEXT     grep find head tail wc pipeline\n");
+    out.push_str("  VFS      ls tree cat touch mkdir cp mv rm\n");
+    out.push_str("  STYLE    theme banner matrix tips clear\n");
+    out.push_str("  SAFE     capabilities sandbox audit update protocol\n\n");
+
+    out.push_str("launch examples\n");
+    out.push_str("  help host        guarded host-tool deck\n");
+    out.push_str("  help dev         development command deck\n");
+    out.push_str("  help update      update command manual card\n");
+    out.push_str("  complete th      discover theme aliases\n");
+    out.push_str("  man security     full generated manual page\n");
+    out
+}
+
+fn operator_flows() -> String {
+    let mut out = String::from("phase1 help // workflows\n\n");
+    out.push_str("daily check\n");
+    out.push_str("  sysinfo -> security -> opslog -> dash\n\n");
+    out.push_str("safe update\n");
+    out.push_str("  security -> update protocol -> update latest --trust-host --check\n\n");
+    out.push_str("development\n");
+    out.push_str("  repo status -> dev status -> cargo test -> gh pr create\n\n");
+    out.push_str("recovery planning\n");
+    out.push_str("  roadmap -> help host -> help update -> base1 docs/scripts\n\n");
+    out.push_str("discoverability\n");
+    out.push_str("  help ui -> help <category> -> help <command> -> complete <prefix>\n");
     out
 }
 
 fn compact_command_map() -> String {
-    let mut out = String::from(
-        "phase1 help // compact
-
-",
-    );
+    let mut out = String::from("phase1 help // compact\n\n");
     for category in CATEGORIES {
-        out.push_str(&format!(
-            "{:<7}: {}
-",
-            category,
-            command_names(category)
-        ));
+        out.push_str(&format!("{:<7}: {}\n", category, command_names(category)));
     }
-    out.push_str(
-        "
-try: help host | help update | help security | help --compact | complete th
-",
-    );
+    out.push_str("\ntry: help ui | help flows | help host | help update | help security | help --compact | complete th\n");
     out
 }
 
 fn category_help(category: &str) -> String {
-    let mut out = format!(
-        "phase1 help // {category}
-
-"
-    );
-    out.push_str(
-        "command        usage                              summary
-",
-    );
+    let mut out = format!("phase1 help // {category}\n\n");
+    out.push_str("command        usage                              summary\n");
     for cmd in COMMANDS.iter().filter(|cmd| cmd.category == category) {
         out.push_str(&format!(
-            "{:<14} {:<34} {}
-",
+            "{:<14} {:<34} {}\n",
             cmd.name, cmd.usage, cmd.description
         ));
     }
-    out.push_str(
-        "
-routes
-",
-    );
+    out.push_str("\nroutes\n");
     out.push_str(&format!(
-        "  help --compact   compact command map
-  complete {category}      completions
-"
+        "  help ui         command palette\n  help --compact  compact command map\n  complete {category}     completions\n"
     ));
     out
 }
@@ -524,6 +458,19 @@ mod tests {
         assert!(update.contains("phase1 help // update"));
         assert!(update.contains("validation suites"));
         assert!(update.contains("host.exec"));
+
+        let ui = help(&[String::from("ui")]);
+        assert!(ui.contains("phase1 command palette"));
+        assert!(ui.contains("hot zones"));
+        assert!(ui.contains("launch examples"));
+        assert!(ui.contains("CORE"));
+        assert!(ui.contains("BUILD"));
+
+        let flows = help(&[String::from("flows")]);
+        assert!(flows.contains("phase1 help // workflows"));
+        assert!(flows.contains("daily check"));
+        assert!(flows.contains("safe update"));
+        assert!(flows.contains("recovery planning"));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,4 +1,3 @@
-use crate::registry;
 use std::fs;
 use std::io::{self, Write};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -90,7 +89,7 @@ impl ThemePalette {
             Self::Ice => "cool blue/cyan frost terminal",
             Self::Synth => "purple synthwave operator glow",
             Self::Crimson => "red alert / intrusion-response console",
-            Self::BleedingEdge => "edge-only blue/magenta update channel console",
+            Self::BleedingEdge => "legacy edge-only blue/magenta update channel console",
         }
     }
 
@@ -165,7 +164,7 @@ impl BootConfig {
             std::env::set_var("PHASE1_NO_COLOR", "1");
         }
         if self.bleeding_edge && std::env::var("PHASE1_THEME").is_err() {
-            std::env::set_var("PHASE1_THEME", ThemePalette::BleedingEdge.name());
+            std::env::set_var("PHASE1_THEME", ThemePalette::Crimson.name());
         }
     }
 
@@ -383,9 +382,6 @@ pub fn print_quick_boot(version: &str, config: BootConfig) {
     println!();
 }
 
-pub fn print_help() {
-    print!("{}", registry::command_map());
-}
 
 pub fn print_prompt(user: &str, path: &str) {
     print!("{}", prompt_status_bar());
@@ -663,7 +659,7 @@ fn active_theme() -> ThemePalette {
         .filter(|theme| *theme != ThemePalette::BleedingEdge || bleeding_edge_env_enabled())
         .unwrap_or_else(|| {
             if bleeding_edge_env_enabled() {
-                ThemePalette::BleedingEdge
+                ThemePalette::Crimson
             } else {
                 ThemePalette::NeoTokyo
             }
@@ -677,7 +673,7 @@ fn active_theme_for_config(config: BootConfig) -> ThemePalette {
         .filter(|theme| *theme != ThemePalette::BleedingEdge || config.bleeding_edge)
         .unwrap_or_else(|| {
             if config.bleeding_edge {
-                ThemePalette::BleedingEdge
+                ThemePalette::Crimson
             } else {
                 ThemePalette::NeoTokyo
             }

--- a/tests/help_command_palette_ui_docs.rs
+++ b/tests/help_command_palette_ui_docs.rs
@@ -1,0 +1,67 @@
+#[test]
+fn registry_help_includes_visual_palette_and_flows() {
+    let registry = std::fs::read_to_string("src/registry.rs").expect("registry.rs");
+
+    assert!(registry.contains("command_palette"), "{registry}");
+    assert!(registry.contains("operator_flows"), "{registry}");
+    assert!(
+        registry.contains("phase1 command palette // v6"),
+        "{registry}"
+    );
+    assert!(registry.contains("hot zones"), "{registry}");
+    assert!(registry.contains("launch examples"), "{registry}");
+    assert!(registry.contains("phase1 help // workflows"), "{registry}");
+}
+
+#[test]
+fn command_map_promotes_visual_help_routes() {
+    let registry = std::fs::read_to_string("src/registry.rs").expect("registry.rs");
+
+    assert!(
+        registry.contains("help ui          visual command palette"),
+        "{registry}"
+    );
+    assert!(
+        registry.contains("help flows       workflow launch paths"),
+        "{registry}"
+    );
+    assert!(
+        registry.contains("launch the command palette"),
+        "{registry}"
+    );
+}
+
+#[test]
+fn boot_live_ops_points_to_visual_help() {
+    let boot = std::fs::read_to_string("src/boot_ui_static.rs").expect("boot ui");
+
+    assert!(
+        boot.contains("help ui | help --compact | help host"),
+        "{boot}"
+    );
+    assert!(
+        boot.contains("help flows | theme list | update protocol"),
+        "{boot}"
+    );
+}
+
+#[test]
+fn help_dispatch_passes_arguments_to_registry_help() {
+    let commands = std::fs::read_to_string("src/commands.rs").expect("commands.rs");
+
+    assert!(
+        commands.contains("\"help\" => print!(\"{}\", registry::help(args))"),
+        "{commands}"
+    );
+}
+
+#[test]
+fn runtime_main_help_dispatch_passes_arguments_to_registry_help() {
+    let main = std::fs::read_to_string("src/main.rs").expect("main.rs");
+
+    assert!(
+        main.contains(r#"\"help\" => print!(\"{}\", registry::help(args))"#),
+        "{main}"
+    );
+    assert!(!main.contains(r#"\"help\" => ui::print_help()"#), "{main}");
+}

--- a/tests/v6_crimson_default_theme.rs
+++ b/tests/v6_crimson_default_theme.rs
@@ -1,0 +1,27 @@
+#[test]
+fn v6_edge_defaults_to_crimson_theme_when_theme_is_missing_or_empty() {
+    let boot = std::fs::read_to_string("src/boot_ui_static.rs").expect("boot ui");
+
+    assert!(boot.contains("ThemePalette::Crimson.name()"), "{boot}");
+    assert!(boot.contains("theme.trim().is_empty()"), "{boot}");
+    assert!(boot.contains("unwrap_or(true)"), "{boot}");
+}
+
+#[test]
+fn v6_edge_selector_should_not_default_display_to_bleeding_edge() {
+    let boot = std::fs::read_to_string("src/boot_ui_static.rs").expect("boot ui");
+
+    assert!(boot.contains("crimson"), "{boot}");
+    assert!(!boot.contains("display    bleeding-edge"), "{boot}");
+}
+
+#[test]
+fn bleeding_edge_theme_remains_available_as_legacy_manual_palette() {
+    let boot = std::fs::read_to_string("src/boot_ui_static.rs").expect("boot ui");
+
+    assert!(boot.contains("Self::BleedingEdge"), "{boot}");
+    assert!(
+        boot.contains("legacy edge-only blue/magenta update channel console"),
+        "{boot}"
+    );
+}

--- a/tests/v6_crimson_theme_command.rs
+++ b/tests/v6_crimson_theme_command.rs
@@ -1,0 +1,26 @@
+#[test]
+fn theme_status_alias_and_edge_defaults_use_crimson() {
+    let operator = std::fs::read_to_string("src/operator.rs").expect("operator.rs");
+
+    assert!(
+        operator.contains(r#"None | Some("show") | Some("status") => theme_status(shell)"#),
+        "{operator}"
+    );
+    assert!(operator.contains("ThemePalette::Crimson"), "{operator}");
+    assert!(
+        operator.contains("theme: reset to crimson edge default"),
+        "{operator}"
+    );
+    assert!(
+        operator.contains("theme: crimson edge default enabled"),
+        "{operator}"
+    );
+    assert!(
+        !operator.contains("theme: reset to bleeding-edge default"),
+        "{operator}"
+    );
+    assert!(
+        !operator.contains("theme: bleeding-edge default enabled"),
+        "{operator}"
+    );
+}


### PR DESCRIPTION
Adds a visual command palette and workflow deck to the modern Phase1 help surface, and makes crimson the default v6 edge theme when no PHASE1_THEME override is set.

Implements:
- help ui / help palette / help deck
- help flows / help workflow
- visual command palette output
- operator workflow deck
- refreshed boot LIVE OPS help route
- runtime main help dispatch now passes arguments into registry help
- crimson default for v6 edge display
- theme status alias
- theme reset/default use crimson on edge
- bleeding-edge channel label remains accurate
- empty PHASE1_THEME is treated as no override
- legacy bleeding-edge palette remains manually available
- removes stale unused help shim
- README, operator shell, and edge checkpoint notes
- tests for help palette, workflow deck, boot LIVE OPS routing, runtime help dispatch, and crimson default

Validation:
- cargo test -p phase1 --test help_command_palette_ui_docs --quiet
- cargo test -p phase1 --test v6_crimson_theme_command --quiet
- cargo test -p phase1 --test v6_crimson_default_theme --quiet
- cargo test -p phase1 --test help_command_overhaul_docs --quiet
- cargo test -p phase1 registry::tests::modern_help_supports_topics_categories_and_compact_mode --quiet
- cargo test -p phase1 --test base1_foundation --quiet

Refs #135