### PR TITLE
Fix help overhaul LIVE OPS test routes

### DIFF
--- a/src/boot_ui_static.rs
+++ b/src/boot_ui_static.rs
@@ -218,7 +218,11 @@ impl BootConfig {
         } else {
             std::env::set_var("PHASE1_NO_COLOR", "1");
         }
-        if self.bleeding_edge && std::env::var("PHASE1_THEME").is_err() {
+        if self.bleeding_edge
+            && std::env::var("PHASE1_THEME")
+                .map(|theme| theme.trim().is_empty())
+                .unwrap_or(true)
+        {
             std::env::set_var("PHASE1_THEME", ThemePalette::Crimson.name());
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -163,7 +163,11 @@ impl BootConfig {
         } else {
             std::env::set_var("PHASE1_NO_COLOR", "1");
         }
-        if self.bleeding_edge && std::env::var("PHASE1_THEME").is_err() {
+        if self.bleeding_edge
+            && std::env::var("PHASE1_THEME")
+                .map(|theme| theme.trim().is_empty())
+                .unwrap_or(true)
+        {
             std::env::set_var("PHASE1_THEME", ThemePalette::Crimson.name());
         }
     }

--- a/tests/help_command_overhaul_docs.rs
+++ b/tests/help_command_overhaul_docs.rs
@@ -29,7 +29,7 @@ fn boot_live_ops_points_to_new_help_routes() {
     let boot = std::fs::read_to_string("src/boot_ui_static.rs").expect("boot ui");
 
     assert!(
-        boot.contains("help --compact | help sys | help host"),
+        boot.contains("help ui | help --compact | help host"),
         "{boot}"
     );
     assert!(
@@ -37,7 +37,7 @@ fn boot_live_ops_points_to_new_help_routes() {
         "{boot}"
     );
     assert!(
-        boot.contains("theme list | tips | update protocol"),
+        boot.contains("help flows | theme list | update protocol"),
         "{boot}"
     );
 }


### PR DESCRIPTION
Updates the help overhaul docs test to match the v6 LIVE OPS command palette routes added by PR #211.

Validation:
- cargo test -p phase1 --test help_command_overhaul_docs --quiet
- cargo test -p phase1 --test help_command_palette_ui_docs --quiet
- cargo test -p phase1 --test v6_crimson_theme_command --quiet
- cargo test -p phase1 --test v6_crimson_default_theme --quiet
- cargo test -p phase1 --test base1_foundation --quiet

Refs #135