### PR TITLE
Relax help dispatch docs test

### DIFF
--- a/tests/help_command_palette_ui_docs.rs
+++ b/tests/help_command_palette_ui_docs.rs
@@ -63,5 +63,5 @@ fn runtime_main_help_dispatch_passes_arguments_to_registry_help() {
         main.contains(r#"\"help\" => print!(\"{}\", registry::help(args))"#),
         "{main}"
     );
-    assert!(!main.contains(r#"\"help\" => ui::print_help()"#), "{main}");
+    assert!(!main.contains("ui::print_help()"), "{main}");
 }


### PR DESCRIPTION
Relaxes the help palette dispatch docs test so it verifies the runtime behavior hook instead of one exact formatting string.

Validation:
- cargo test -p phase1 --test help_command_palette_ui_docs --quiet
- cargo test -p phase1 --test help_command_overhaul_docs --quiet
- cargo test -p phase1 --test v6_crimson_theme_command --quiet
- cargo test -p phase1 --test v6_crimson_default_theme --quiet
- cargo test -p phase1 --test base1_foundation --quiet

Refs #135