### PR TITLE
Add Phase1 Codex documentation roadmap

### DIFF
--- a/docs/MANUAL_ROADMAP.md
+++ b/docs/MANUAL_ROADMAP.md
@@ -1,0 +1,414 @@
+# The Phase1 Codex
+
+## Building a Terminal-First Operating World
+
+**Subtitle:** Base1, Fyr, and the Road to a Self-Owned Computing System
+
+This document is the canonical planning map for the Phase1 book, manual, and future public wiki. It is designed to grow into a repository documentation system first, then a website or book later.
+
+## Non-claim boundary
+
+Phase1 documentation must preserve these boundaries:
+
+- Phase1 is a Rust-based terminal-first virtual OS console and advanced operator environment. It is not currently a finished operating system, kernel, hardened sandbox, or secure OS replacement.
+- Base1 is a planned minimal trusted host foundation for future Phase1-first bootable environments. It must be documented as roadmap, design, dry-run, or preview unless a bootable image has been built, tested, and released.
+- Fyr is the Phase1-native language and tooling track. It may be described by the features implemented in the repository and by clearly labeled roadmap goals.
+- Installer, recovery, image-writing, hardware-target, and rollback language must not imply destructive readiness unless real validation exists.
+- Safety claims must be narrow, testable, visible to the operator, and tied to commands, tests, docs, or release artifacts.
+
+Use this phrase when in doubt:
+
+> This is a current design or roadmap item unless the linked implementation, tests, and release notes prove otherwise.
+
+## Book identity
+
+Canonical title:
+
+> **The Phase1 Codex: Building a Terminal-First Operating World**
+>
+> **Base1, Fyr, and the Road to a Self-Owned Computing System**
+
+Alternate title options:
+
+1. **Phase1: The Operator's Codex** — A Manual for Terminal-First Computing, Base1, and Fyr.
+2. **The Phase1 Operating World** — Building a Rust Terminal Console, Base1 Foundation, and Fyr Toolchain.
+3. **Phase1 from Console to Foundation** — A Technical Manual for Operators, Developers, and System Builders.
+4. **The Phase1 Field Manual** — Operating, Extending, and Recovering a Terminal-First Computing Environment.
+5. **Phase1, Base1, Fyr** — A Practical Roadmap Toward Self-Owned Computing.
+
+## Recommended book structure
+
+### Part I — Orientation
+
+1. **What Phase1 Is**: terminal-first virtual OS console, operator environment, current scope, and non-claims.
+2. **The Operating World Concept**: shell, VFS, command registry, logs, help, man pages, host boundary, nested sessions, and roadmap.
+3. **Safety Before Capability**: safe mode, trust gates, guarded host tools, visible confirmation, and non-escalation.
+
+### Part II — Phase1 Operator Manual
+
+4. **Installing and Launching Phase1**: clone, `sh phase1`, local command install, `cargo run`, version checks.
+5. **Boot Selector and Modes**: safe defaults, SHIELD, trust host, operator-visible boot state, and manual boot equivalents.
+6. **The Operator Shell**: command grammar, help, completion, command registry, man-style pages, and workflows.
+7. **Virtual Filesystem and System Model**: VFS paths, `/proc`, `/dev`, logs, simulated process table, and inspection commands.
+8. **Storage, Git, and Rust Workflows**: guarded storage helpers, Git workflows, Cargo/Rust checks, logs, and safe failure behavior.
+9. **Nested Phase1 Sessions**: metadata-only child contexts, topology, active context, and current non-runtime boundary.
+10. **Operations Logs and Audit Surfaces**: ops logs, history, learning memory, redaction, and local artifacts.
+11. **Troubleshooting and Recovery from the Console**: doctor, selftest, version, safe mode recovery, and common error paths.
+
+### Part III — Base1 Foundation Manual
+
+12. **Why Base1 Exists**: minimal host foundation, read-only base, writable Phase1 state, recovery path, and trust boundary.
+13. **Base1 Architecture**: layers, host responsibilities, Phase1 responsibilities, and what is explicitly outside scope.
+14. **Boot and Recovery Flow**: boot selector, recovery shell, rollback path, target identity, and emergency shell preservation.
+15. **Image Provenance and Validation**: checksums, signatures or attestations when available, read-only validation bundles, and release records.
+16. **Hardware Targets**: Libreboot-backed ThinkPad X200-class systems, Raspberry Pi, generic x86_64 later, and validation levels.
+17. **Installer and Destructive Action Policy**: dry-run first, target verification, no destructive defaults, explicit confirmation, and rollback metadata.
+18. **Base1 Roadmap and Maturity Model**: design, dry-run, emulator, hardware lab, preview image, validated release.
+
+### Part IV — Fyr Language Book
+
+19. **Why Fyr Exists**: Phase1-native automation, self-construction, VFS workflows, and command scripting.
+20. **First Fyr Program**: `.fyr` files, check/build/test/run workflow, and minimal examples.
+21. **Syntax and Semantics**: functions, returns, bindings, expressions, assertions, conditionals, and package structure.
+22. **Fyr Toolchain Commands**: checker, runner, package tests, diagnostics, and planned build outputs.
+23. **Using Fyr with Phase1**: VFS automation, command integration, operator scripts, and safe execution boundaries.
+24. **Fyr Roadmap**: standard library, workspace model, deeper Phase1 integration, and eventual self-hosting goals.
+
+### Part V — Developer, Security, and Contributor Guide
+
+25. **Repository Architecture**: crates, binaries, scripts, docs, tests, and release files.
+26. **Adding Commands Safely**: command metadata, help text, capability labeling, host boundaries, and tests.
+27. **Documentation Contribution Rules**: style, status tags, claims policy, examples, and PR checklist.
+28. **Security Review Guide**: trust boundaries, host tools, secret redaction, validation bundles, and threat model.
+29. **Release and Website Publishing**: docs-to-site path, versioned docs, public wiki, and release gates.
+
+### Appendices
+
+A. Command matrix.
+B. Capability and trust-gate table.
+C. Roadmap maturity table.
+D. Glossary.
+E. Recovery checklists.
+F. Hardware validation forms.
+G. Documentation PR checklist.
+H. Non-claim language reference.
+
+## Repository documentation architecture
+
+```text
+docs/
+  README.md
+  MANUAL_ROADMAP.md
+  phase1/
+    README.md
+    OPERATOR_MANUAL.md
+    BOOT_AND_MODES.md
+    COMMAND_REFERENCE.md
+    VFS_AND_SYSTEM_MODEL.md
+    STORAGE_GIT_RUST.md
+    NESTED_PHASE1.md
+    OPS_LOGS.md
+    TROUBLESHOOTING.md
+  base1/
+    README.md
+    FOUNDATION_MANUAL.md
+    BOOT_FLOW.md
+    RECOVERY_MODEL.md
+    IMAGE_PROVENANCE.md
+    HARDWARE_TARGETS.md
+    INSTALLER_POLICY.md
+    ROLLBACK.md
+    MATURITY_MODEL.md
+  fyr/
+    README.md
+    LANGUAGE_BOOK.md
+    GETTING_STARTED.md
+    SYNTAX.md
+    TOOLCHAIN.md
+    PACKAGES.md
+    PHASE1_INTEGRATION.md
+    ROADMAP.md
+  operators/
+    README.md
+    FIRST_RUN.md
+    DAILY_WORKFLOWS.md
+    SAFE_HOST_TOOLS.md
+    INCIDENT_NOTES.md
+  developers/
+    README.md
+    ARCHITECTURE.md
+    ADDING_COMMANDS.md
+    TESTING.md
+    DOCS_CONTRIBUTING.md
+  recovery/
+    README.md
+    SAFE_RECOVERY.md
+    RECOVERY_USB.md
+    TARGET_IDENTITY.md
+    HARDWARE_CHECKLISTS.md
+  security/
+    README.md
+    TRUST_MODEL.md
+    DOCS_CLAIMS.md
+    THREAT_MODEL.md
+    REVIEW_GUIDE.md
+    SECRET_HANDLING.md
+```
+
+Each folder should start as an index that links to existing docs before copying or moving content. Avoid duplicate truth sources until the manual structure is stable.
+
+## Reader paths
+
+| Audience | Start here | Then read | Goal |
+| --- | --- | --- | --- |
+| First-time user | `docs/README.md` | `docs/operators/FIRST_RUN.md`, `docs/phase1/OPERATOR_MANUAL.md` | Launch Phase1 safely and understand current scope. |
+| Operator | `docs/operators/README.md` | `docs/phase1/BOOT_AND_MODES.md`, `docs/operators/SAFE_HOST_TOOLS.md` | Use Phase1 without crossing host boundaries accidentally. |
+| Developer | `docs/developers/README.md` | `docs/developers/ARCHITECTURE.md`, `docs/developers/ADDING_COMMANDS.md` | Add features with tests, help, and capability metadata. |
+| Security reviewer | `docs/security/TRUST_MODEL.md` | `docs/security/DOCS_CLAIMS.md`, `docs/security/REVIEW_GUIDE.md` | Review narrow claims, trust boundaries, and validation evidence. |
+| Recovery/hardware operator | `docs/recovery/README.md` | `docs/base1/RECOVERY_MODEL.md`, `docs/base1/HARDWARE_TARGETS.md` | Follow dry-run-first recovery planning without destructive assumptions. |
+| Language/toolchain contributor | `docs/fyr/README.md` | `docs/fyr/LANGUAGE_BOOK.md`, `docs/fyr/TOOLCHAIN.md` | Extend Fyr while preserving Phase1 integration boundaries. |
+
+## Technical style guide
+
+### Tone
+
+Write like an engineering manual. Prefer direct verbs, explicit status, examples, and validation steps. Avoid hype words such as revolutionary, unbreakable, military-grade, fully secure, complete OS, or production-ready unless backed by releases and audit evidence.
+
+### Terminology
+
+Use these status labels consistently:
+
+- **Implemented**: code exists, tests exist, and docs explain how to run it.
+- **Experimental**: code exists but boundary, UX, or hardening is incomplete.
+- **Design**: architecture exists in docs but implementation is not complete.
+- **Dry-run**: command or script validates intent without destructive mutation.
+- **Preview**: feature is usable by early testers with known limitations.
+- **Roadmap**: planned future work.
+- **Not claimed**: explicitly outside the current guarantee.
+
+### Safety language
+
+Use narrow statements:
+
+- Good: `The preflight script is intended to be read-only and should not write to block devices.`
+- Bad: `The installer is safe.`
+- Good: `This command requires explicit operator confirmation before host mutation.`
+- Bad: `Phase1 prevents dangerous actions.`
+
+### Current, preview, roadmap, and not claimed
+
+Every major page must include a status block:
+
+```md
+> **Status:** Implemented | Experimental | Design | Dry-run | Preview | Roadmap | Not claimed
+> **Validation:** tests, scripts, release notes, or manual verification path
+> **Non-claims:** what this page does not guarantee
+```
+
+## Chapter outlines
+
+### Phase1 Operator Manual
+
+1. **Scope and mental model**: current virtual OS console, not a kernel, host boundary, safe defaults.
+2. **Install and launch**: clone, run scripts, cargo run, version checks, local command install.
+3. **Boot selector**: safe shield, trust host, boot choices, failure states, and recovery posture.
+4. **Shell basics**: commands, help UI, command registry, man pages, autocomplete, history, and navigation.
+5. **VFS and system inspection**: files, directories, `/proc`, `/dev`, process table, sysinfo, dashboards.
+6. **Host tools**: what guarded host tools are, when prompts appear, what is blocked by default, how logs record use.
+7. **Storage and development workflows**: storage helper, Git, Rust/Cargo, package checks, and expected errors.
+8. **Nested Phase1**: metadata contexts, spawn/enter/exit/tree, what nesting does not yet execute.
+9. **Fyr for operators**: run/check/test `.fyr` scripts, examples, and operator automation boundaries.
+10. **Logs, learning, and local artifacts**: ops logs, sanitized memory, git-ignored files, and cleanup.
+11. **Troubleshooting**: doctor, selftest, permissions, missing tools, safe-mode recovery, and issue reporting.
+12. **Operator checklist**: before host tools, before Git, before scripts, before release work.
+
+### Base1 Recovery and OS Foundation Manual
+
+1. **Scope and non-claims**: planned foundation, not currently a finished secure OS replacement.
+2. **Base1 principles**: minimal host, read-only base, writable Phase1 state, explicit recovery path.
+3. **Layer model**: firmware, bootloader, Base1 base, Phase1 state, operator shell, host tools.
+4. **Boot flow**: normal boot, recovery boot, rollback, target identity checks, and failure handling.
+5. **Recovery shell**: preservation requirements, allowed actions, blocked actions, emergency workflows.
+6. **Recovery USB planning**: read-only validation, image provenance, target selection, and hardware checklists.
+7. **Image provenance**: source, build recipe, checksum, signature/attestation when available, release note tie-in.
+8. **Rollback metadata**: state snapshot references, previous image references, operator-readable rollback notes.
+9. **Installer policy**: dry-run first, target verification, no destructive default, confirmation prompts, logs.
+10. **Hardware targets**: X200-class Libreboot, Raspberry Pi, generic x86_64, and validation maturity.
+11. **Validation reports**: emulator pass, hardware pass, recovery pass, rollback pass, known gaps.
+12. **Roadmap gates**: what must be true before preview image, beta hardware image, daily-driver claim, or security claim.
+
+### Fyr Language Book
+
+1. **Purpose and status**: Phase1-native track, current implementation, non-production claims.
+2. **Getting started**: create `.fyr`, run checker, run test, run program.
+3. **Program structure**: files, functions, main, return values, packages.
+4. **Expressions and values**: numbers, strings, booleans, grouped expressions, comparisons.
+5. **Bindings and control flow**: let bindings, if statements, assertions, return statements.
+6. **Diagnostics**: syntax errors, checker output, line/column expectations, test cases.
+7. **Toolchain commands**: check, build, test, run, package validation, planned outputs.
+8. **Phase1 integration**: VFS automation, shell commands, command scripts, ops visibility.
+9. **Safety model**: Fyr execution boundaries, no hidden host escalation, trust gates for host-backed behavior.
+10. **Examples**: hello, command helper, VFS workflow, package test, failure example.
+11. **Contributor guide**: parser, checker, runtime, tests, docs, compatibility expectations.
+12. **Roadmap**: standard library, workspace layout, self-construction, deeper operator integration.
+
+## Diagrams and tables to include
+
+- Phase1 architecture diagram: operator shell, command registry, VFS, logs, host boundary, Fyr, nested sessions.
+- Base1 layer diagram: firmware, bootloader, read-only base, writable state, recovery shell, Phase1.
+- Boot flow diagram: normal boot, safe mode, trust host off/on, recovery path.
+- Trust boundary table: Phase1 internal, host shell, filesystem, network, block devices, secrets.
+- Guarded host tool flow: command request, capability metadata, shield check, trust gate, confirmation, log.
+- VFS map table: path, purpose, implementation status, persistence status.
+- Command matrix: command, category, implemented status, host access, confirmation required, tests.
+- Base1 recovery flow: detect failure, preserve shell, identify target, verify provenance, rollback or inspect.
+- Image provenance table: artifact, source, checksum, signer, build recipe, release note, validation date.
+- Roadmap maturity table: design, docs, dry-run, emulator, hardware lab, preview, validated release.
+- Fyr toolchain table: file type, command, current behavior, planned behavior.
+- Documentation claim matrix: phrase, allowed status, required proof.
+
+## Safety and trust model summary
+
+### Safe defaults
+
+Phase1 should default to behavior that keeps host mutation off unless the operator makes a visible choice. Safe defaults must be documented as defaults, not as absolute protection.
+
+### Guarded host tools
+
+Host-backed commands must declare what host capability they need. The manual should explain the capability before instructing operators to enable it.
+
+### No host trust escalation
+
+Phase1 documentation must not imply that Phase1 can turn an untrusted host into a trusted host. Trust gates only control Phase1's own willingness to call host-backed tools.
+
+### Read-only validation bundles
+
+Validation scripts and reports should prefer read-only checks. If a script writes anything, the docs must say what it writes, where, and how to inspect or remove it.
+
+### Explicit operator confirmation
+
+Commands that mutate host state, write images, change devices, or touch credentials must require explicit operator confirmation. The docs must show the confirmation path and expected log.
+
+### Recovery shell preservation
+
+Base1 recovery planning must preserve a shell path even when Phase1 fails. Documentation should treat recovery shell access as a requirement, not a nice-to-have.
+
+### Image provenance and checksum rules
+
+Base1 image docs must require source, build recipe, checksum, release identifier, and validation notes before an image is presented as usable. Without those, the image must be called a design artifact, dry-run artifact, or preview artifact.
+
+## Glossary
+
+**Phase1**: A Rust-based terminal-first virtual OS console and advanced operator environment. Current Phase1 runs on a host system and is not itself a kernel or finished OS replacement.
+
+**Base1**: The planned minimal trusted host foundation for future Phase1-first bootable environments. Base1 is expected to start Linux-based with a read-only base, writable Phase1 state layer, recovery shell, and rollback path.
+
+**Fyr**: The Phase1-native language and toolchain track for `.fyr` scripts, VFS automation, command workflows, package structure, checking, testing, running, and eventual deeper Phase1 integration.
+
+**VFS**: The Phase1 virtual filesystem model used to expose files, simulated system paths, logs, and operator-visible state inside the Phase1 environment.
+
+**Operator shell**: The interactive Phase1 command surface used to inspect state, run commands, read help/man pages, and operate workflows.
+
+**Guarded host tools**: Host-backed commands or scripts that require explicit capability handling, trust gates, safe-mode posture, and visible operator intent.
+
+**Safe shield**: The default protective posture that keeps higher-risk host-backed behavior disabled unless explicitly changed by the operator.
+
+**Trust gate**: A visible decision point before Phase1 invokes host-backed behavior. A trust gate is not a guarantee that the host is trustworthy.
+
+**Recovery USB**: A planned Base1 recovery medium for inspection, recovery shell access, target identity validation, provenance checks, and rollback support. It must remain roadmap or preview until validated on real hardware.
+
+**Image provenance**: The documented origin, build recipe, checksum, release identity, and validation evidence for a Base1 or recovery image.
+
+**Rollback metadata**: Operator-readable metadata describing the previous known-good image or state, the current candidate, and how rollback should be performed or verified.
+
+**Nested Phase1**: A current metadata-only recursive operator-context feature. It tracks child contexts and topology but does not yet imply runtime-backed inner kernels.
+
+## First implementation slice
+
+### Files to add first
+
+- `docs/README.md`: reader entry point and status legend.
+- `docs/MANUAL_ROADMAP.md`: canonical Codex roadmap and documentation architecture.
+- `docs/security/TRUST_MODEL.md`: consolidated trust model and safety claims rules.
+- `docs/security/DOCS_CLAIMS.md`: allowed phrases, disallowed phrases, proof requirements.
+- `docs/phase1/README.md`: Phase1 operator manual index.
+- `docs/base1/README.md`: Base1 foundation manual index.
+- `docs/fyr/README.md`: Fyr language book index.
+- `docs/operators/README.md`: operator reader path.
+- `docs/developers/README.md`: developer reader path.
+- `docs/recovery/README.md`: recovery/hardware reader path.
+- `tests/manual_roadmap_docs.rs`: guard test for required pages and non-claim phrases.
+
+### Tests to add
+
+The first test should verify that:
+
+- `docs/MANUAL_ROADMAP.md` exists.
+- `docs/security/TRUST_MODEL.md` exists.
+- The docs include the title `The Phase1 Codex`.
+- The docs include the exact non-claim that Phase1 is not a finished secure OS replacement.
+- Base1 pages include roadmap or planned-foundation language.
+- Recovery pages do not contain destructive installer claims without dry-run wording.
+
+### README links to update
+
+Add one top-level README link:
+
+```md
+[Codex](docs/MANUAL_ROADMAP.md)
+```
+
+Add or update the docs section so users can find:
+
+- Phase1 Operator Manual
+- Base1 Foundation Manual
+- Fyr Language Book
+- Security and Trust Model
+- Recovery and Hardware Guide
+
+### Acceptance criteria
+
+- Documentation builds as plain Markdown.
+- Existing quick-start instructions remain unchanged.
+- New docs are repo-local and do not require a website generator.
+- Non-claim language is present in roadmap, Base1, recovery, and security docs.
+- The docs guard test passes with `cargo test -p phase1 --test manual_roadmap_docs`.
+- No page claims Phase1 is a finished OS, Base1 is a released bootable image, or recovery is validated on real hardware unless linked evidence exists.
+
+### Non-claims to preserve
+
+- Phase1 is not currently a secure OS replacement.
+- Phase1 is not currently a kernel.
+- Base1 is not currently a released bootable daily-driver image.
+- Recovery USB and destructive installer workflows are not complete unless validated.
+- Guarded host tools do not make untrusted host actions safe by themselves.
+- Safe mode and trust gates reduce accidental action inside Phase1; they do not replace a VM, container, audit, or real operating-system hardening.
+
+## Documentation PR quality checklist
+
+Every documentation PR should answer:
+
+- Does the page identify its status: implemented, experimental, design, dry-run, preview, roadmap, or not claimed?
+- Does every safety statement name the mechanism and validation path?
+- Does the PR avoid saying secure, safe, hardened, bootable, daily-driver, installer-ready, or recovery-complete without evidence?
+- Are commands copy-pasteable and scoped to the right platform?
+- Are destructive or host-mutating commands marked clearly?
+- Are dry-run examples shown before real mutation examples?
+- Are Phase1, Base1, and Fyr terms used consistently?
+- Are current implementation details separated from roadmap goals?
+- Are tests, scripts, or release notes linked where claims are made?
+- Does the PR avoid duplicating canonical docs without linking back to the source of truth?
+- Does the PR include or update a docs guard test when it adds safety-critical language?
+
+## Launch plan for public book/wiki
+
+1. **Repo-first Codex**: land the folder architecture and guard tests.
+2. **Manual skeleton**: add chapter stubs with status blocks and links to existing docs.
+3. **Content migration**: move or index existing wiki, Base1, Fyr, nested, and OS-track docs without losing history.
+4. **Validation pass**: add docs tests for non-claims, broken links, command snippets, and required status blocks.
+5. **Website preview**: generate a static site from `docs/` while keeping Markdown readable in GitHub.
+6. **Versioned docs**: split stable and edge docs once releases need different manual versions.
+7. **Public Codex launch**: publish the site as the official technical manual, not as a marketing page.
+8. **Hardware/recovery appendix release**: publish hardware pages only after validation reports exist.
+9. **Book export**: convert the stable manual to PDF/ePub after the repo docs have stabilized.
+10. **Ongoing governance**: make docs claim review part of every release checklist.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,50 @@
+# Phase1 Documentation
+
+Welcome to the repository-first documentation home for Phase1.
+
+The long-form manual is organized as **The Phase1 Codex: Building a Terminal-First Operating World**.
+
+Start with [`MANUAL_ROADMAP.md`](MANUAL_ROADMAP.md) for the full book, manual, and wiki plan.
+
+## Status boundary
+
+> **Status:** Documentation architecture and manual roadmap.
+>
+> **Validation:** Markdown files and docs guard tests in this repository.
+>
+> **Non-claims:** Phase1 is not currently a finished secure OS replacement, Base1 is not currently a released bootable daily-driver image, and Fyr is not currently claimed as a production language.
+
+## Reader paths
+
+| Reader | Start | Purpose |
+| --- | --- | --- |
+| First-time user | [`operators/README.md`](operators/README.md) | Launch Phase1 safely and understand the current boundary. |
+| Operator | [`phase1/README.md`](phase1/README.md) | Learn boot modes, shell workflows, VFS, host tools, and logs. |
+| Developer | [`developers/README.md`](developers/README.md) | Extend Phase1 while preserving tests, docs, and capability metadata. |
+| Security reviewer | [`security/TRUST_MODEL.md`](security/TRUST_MODEL.md) | Review safety claims, trust boundaries, and host-tool behavior. |
+| Recovery/hardware operator | [`recovery/README.md`](recovery/README.md) | Follow Base1 and recovery planning without destructive assumptions. |
+| Fyr contributor | [`fyr/README.md`](fyr/README.md) | Work on the Phase1-native language and toolchain track. |
+
+## Manual sections
+
+- [`phase1/`](phase1/) — Phase1 Operator Manual.
+- [`base1/`](base1/) — Base1 Recovery and OS Foundation Manual.
+- [`fyr/`](fyr/) — Fyr Language Book.
+- [`operators/`](operators/) — Operator workflows.
+- [`developers/`](developers/) — Developer contribution guide.
+- [`recovery/`](recovery/) — Recovery and hardware planning.
+- [`security/`](security/) — Trust model, claims policy, and review guide.
+
+## Required page status block
+
+New manual pages should include a status block near the top:
+
+```md
+> **Status:** Implemented | Experimental | Design | Dry-run | Preview | Roadmap | Not claimed
+> **Validation:** tests, scripts, release notes, or manual verification path
+> **Non-claims:** what this page does not guarantee
+```
+
+## Canonical safety language
+
+Use narrow, testable statements. Do not claim that Phase1 is secure, hardened, bootable, daily-driver ready, installer-ready, or recovery-complete unless the claim is backed by implementation, tests, release notes, and validation evidence.

--- a/docs/base1/FOUNDATION_MANUAL.md
+++ b/docs/base1/FOUNDATION_MANUAL.md
@@ -1,0 +1,44 @@
+# Base1 Foundation Manual
+
+> **Status:** Manual skeleton.
+>
+> **Validation:** This page is an outline. Detailed claims should link to evidence.
+>
+> **Non-claims:** This page does not upgrade Base1 beyond the status described in the linked roadmap and trust documents.
+
+This manual is the Base1 section of **The Phase1 Codex**.
+
+## Purpose
+
+The Base1 Foundation Manual organizes the planned foundation work for Phase1-first environments. It should separate design notes, dry-run checks, validation records, and release notes.
+
+## Chapter outline
+
+1. Scope.
+2. Principles.
+3. Layer model.
+4. Startup flow.
+5. Recovery model.
+6. Image records.
+7. Rollback notes.
+8. Installer policy.
+9. Hardware targets.
+10. Validation reports.
+11. Roadmap gates.
+
+## Writing rules
+
+Each chapter should include:
+
+- a status block;
+- current evidence level;
+- validation path;
+- known limitations;
+- links to source documents.
+
+## Source links
+
+- [`../MANUAL_ROADMAP.md`](../MANUAL_ROADMAP.md)
+- [`../security/TRUST_MODEL.md`](../security/TRUST_MODEL.md)
+- [`../security/DOCS_CLAIMS.md`](../security/DOCS_CLAIMS.md)
+- [`../../base1/README.md`](../../base1/README.md)

--- a/docs/base1/README.md
+++ b/docs/base1/README.md
@@ -1,0 +1,38 @@
+# Base1 Recovery and OS Foundation Manual
+
+> **Status:** Roadmap and design index.
+>
+> **Validation:** Links to current Base1 design docs, dry-run scripts, and future validation reports.
+>
+> **Non-claims:** Base1 is not currently documented here as a released bootable daily-driver image, finished secure OS replacement, or destructive installer-ready system.
+
+Base1 is the planned minimal host foundation for future Phase1-first bootable environments. The first practical documentation goal is to keep Base1 precise: read-only base, writable Phase1 state, recovery shell, rollback planning, image provenance, target identity verification, and explicit operator confirmation.
+
+## Planned chapters
+
+1. Scope and non-claims.
+2. Base1 principles.
+3. Layer model.
+4. Boot flow.
+5. Recovery shell.
+6. Recovery USB planning.
+7. Image provenance.
+8. Rollback metadata.
+9. Installer policy.
+10. Hardware targets.
+11. Validation reports.
+12. Roadmap gates.
+
+## Source-of-truth links
+
+- [`../MANUAL_ROADMAP.md`](../MANUAL_ROADMAP.md)
+- [`../security/TRUST_MODEL.md`](../security/TRUST_MODEL.md)
+- [`../../base1/README.md`](../../base1/README.md)
+- [`../../base1/SECURITY_MODEL.md`](../../base1/SECURITY_MODEL.md)
+- [`../../base1/HARDWARE_TARGETS.md`](../../base1/HARDWARE_TARGETS.md)
+- [`../../base1/ROADMAP.md`](../../base1/ROADMAP.md)
+- [`../os/ROADMAP.md`](../os/ROADMAP.md)
+
+## Base1 wording rule
+
+Use `planned`, `design`, `dry-run`, `preview`, or `validated` according to evidence. Do not call Base1 bootable, daily-driver ready, recovery-complete, or installer-ready without release artifacts and validation reports.

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -1,0 +1,43 @@
+# Developer Reader Path
+
+> **Status:** Manual index and contribution map.
+>
+> **Validation:** Links to repository docs, tests, and documentation policy.
+>
+> **Non-claims:** Developer docs do not make experimental APIs stable and do not treat roadmap work as implemented.
+
+This page is the developer entry point for **The Phase1 Codex**.
+
+## Development reading order
+
+1. Read [`../README.md`](../README.md) for the documentation status model.
+2. Read [`../MANUAL_ROADMAP.md`](../MANUAL_ROADMAP.md) for the full Codex structure.
+3. Read [`../security/DOCS_CLAIMS.md`](../security/DOCS_CLAIMS.md) before editing safety, Base1, recovery, installer, or host-tool docs.
+4. Read [`../security/TRUST_MODEL.md`](../security/TRUST_MODEL.md) before adding or documenting host-backed behavior.
+5. Use the existing repository tests as the source of truth for implemented behavior.
+
+## Required contribution habits
+
+When adding or changing Phase1 features, also update:
+
+- command help or man-style command pages;
+- capability or trust-gate documentation for host-backed commands;
+- operator-visible examples;
+- tests for implemented behavior;
+- documentation status blocks when behavior changes.
+
+## Safety-sensitive changes
+
+Treat these as safety-sensitive:
+
+- host tool execution;
+- filesystem mutation outside the Phase1 model;
+- Git, Cargo, network, or shell workflows;
+- Base1 image, boot, recovery, rollback, or installer behavior;
+- target identity verification;
+- secret handling;
+- claims that use words such as secure, safe, hardened, bootable, installer-ready, recovery-complete, or daily-driver ready.
+
+## Developer rule
+
+Every implementation claim should have a runnable path, a test path, or a linked validation artifact. If the proof does not exist, document the item as design, dry-run, preview, roadmap, or not claimed.

--- a/docs/fyr/LANGUAGE_BOOK.md
+++ b/docs/fyr/LANGUAGE_BOOK.md
@@ -1,0 +1,43 @@
+# Fyr Language Book
+
+> **Status:** Manual skeleton.
+>
+> **Validation:** This page is an outline. Details should link to examples and tests.
+>
+> **Non-claims:** This page does not mark Fyr as production-ready.
+
+This book is the Fyr section of **The Phase1 Codex**.
+
+## Purpose
+
+The Fyr Language Book organizes documentation for the Phase1-native language track.
+
+## Chapter outline
+
+1. Purpose and status.
+2. Getting started.
+3. Program structure.
+4. Expressions and values.
+5. Bindings and control flow.
+6. Diagnostics.
+7. Tooling commands.
+8. Phase1 integration.
+9. Examples.
+10. Contributor guide.
+11. Roadmap.
+
+## Writing rules
+
+Each chapter should include:
+
+- a status block;
+- current behavior;
+- runnable examples;
+- expected output;
+- links to validation.
+
+## Source links
+
+- [`../MANUAL_ROADMAP.md`](../MANUAL_ROADMAP.md)
+- [`../../PHASE1_NATIVE_LANGUAGE.md`](../../PHASE1_NATIVE_LANGUAGE.md)
+- [`ROADMAP.md`](ROADMAP.md)

--- a/docs/fyr/README.md
+++ b/docs/fyr/README.md
@@ -1,0 +1,35 @@
+# Fyr Language Book
+
+> **Status:** Manual index and language/toolchain roadmap.
+>
+> **Validation:** Links to current Fyr docs, examples, tests, and future toolchain chapters.
+>
+> **Non-claims:** Fyr is not currently claimed as a production language or general replacement for Rust, Python, C, or shell.
+
+Fyr is the Phase1-native language and toolchain track for `.fyr` files, VFS automation, command scripting, package/workspace structure, checking, building, testing, running, and future deeper Phase1 integration.
+
+## Planned chapters
+
+1. Purpose and status.
+2. Getting started.
+3. Program structure.
+4. Expressions and values.
+5. Bindings and control flow.
+6. Diagnostics.
+7. Toolchain commands.
+8. Phase1 integration.
+9. Safety model.
+10. Examples.
+11. Contributor guide.
+12. Roadmap.
+
+## Source-of-truth links
+
+- [`../MANUAL_ROADMAP.md`](../MANUAL_ROADMAP.md)
+- [`../../PHASE1_NATIVE_LANGUAGE.md`](../../PHASE1_NATIVE_LANGUAGE.md)
+- [`ROADMAP.md`](ROADMAP.md)
+- [`../../examples/fyr/`](../../examples/fyr/)
+
+## Fyr wording rule
+
+Describe Fyr by current implemented behavior and clearly labeled roadmap goals. Do not call Fyr production-ready unless the repository includes release evidence, compatibility policy, test coverage, and user-facing stability guarantees.

--- a/docs/operators/README.md
+++ b/docs/operators/README.md
@@ -1,0 +1,44 @@
+# Operator Reader Path
+
+> **Status:** Manual index and operator workflow map.
+>
+> **Validation:** Links to current docs and future operator chapters.
+>
+> **Non-claims:** Operator workflows do not make host-backed actions safe by themselves and do not replace host OS hardening.
+
+This page is the operator entry point for **The Phase1 Codex**.
+
+## First run path
+
+1. Read [`../README.md`](../README.md) to understand the documentation status boundary.
+2. Read [`../phase1/README.md`](../phase1/README.md) to understand Phase1 as an operator console.
+3. Read [`../security/TRUST_MODEL.md`](../security/TRUST_MODEL.md) before enabling host-backed workflows.
+4. Launch Phase1 with the documented quick-start path from the repository README.
+5. Inspect the safe shield, trust state, help UI, command registry, and version output.
+6. Use read-only or dry-run workflows before host mutation.
+
+## Daily operator path
+
+Use this path for routine operation:
+
+- Boot selector and safe mode.
+- Help UI and man-style command pages.
+- VFS and simulated system inspection.
+- Ops logs and local artifacts.
+- Guarded host tools only when needed.
+- Troubleshooting through doctor, selftest, version, and status commands.
+
+## Before using host tools
+
+Before enabling or running host-backed behavior, verify:
+
+- the required host capability is named;
+- the command explains what it may read or write;
+- a dry-run or read-only path exists when possible;
+- the trust gate is visible;
+- explicit operator confirmation is required for mutation;
+- the action is logged for review.
+
+## Operator rule
+
+Phase1 can make actions visible, gated, documented, and logged. It does not make an untrusted host trustworthy and does not replace a VM, container, hardened OS, or external security review.

--- a/docs/phase1/OPERATOR_MANUAL.md
+++ b/docs/phase1/OPERATOR_MANUAL.md
@@ -1,0 +1,45 @@
+# Phase1 Operator Manual
+
+> **Status:** Manual skeleton.
+>
+> **Validation:** This page is an outline. Implementation details should link to command help, tests, scripts, or release notes.
+>
+> **Non-claims:** Phase1 is documented here as a terminal-first operator console, not as a completed standalone operating system.
+
+This manual is the operator-facing section of **The Phase1 Codex**.
+
+## Purpose
+
+The Phase1 Operator Manual explains how to launch, inspect, operate, and troubleshoot Phase1 while keeping current implementation, preview work, roadmap goals, and non-claims clearly separated.
+
+## Chapter outline
+
+1. Scope and mental model.
+2. Install and launch.
+3. Boot selector and modes.
+4. Operator shell basics.
+5. VFS and system inspection.
+6. Guarded host tools.
+7. Storage, Git, and Rust workflows.
+8. Nested Phase1 sessions.
+9. Fyr for operators.
+10. Logs, learning, and local artifacts.
+11. Troubleshooting.
+12. Operator checklist.
+
+## Writing rules
+
+Each chapter should include:
+
+- a status block;
+- current behavior;
+- validation path;
+- examples that match current code;
+- non-claims for anything not yet implemented.
+
+## Source links
+
+- [`../README.md`](../README.md)
+- [`../MANUAL_ROADMAP.md`](../MANUAL_ROADMAP.md)
+- [`../security/TRUST_MODEL.md`](../security/TRUST_MODEL.md)
+- [`../security/DOCS_CLAIMS.md`](../security/DOCS_CLAIMS.md)

--- a/docs/phase1/README.md
+++ b/docs/phase1/README.md
@@ -1,0 +1,46 @@
+# Phase1 Operator Manual
+
+> **Status:** Manual index and first-slice structure.
+>
+> **Validation:** Links to current repository docs and future manual chapters.
+>
+> **Non-claims:** Phase1 is not currently a finished secure OS replacement, kernel, or drop-in replacement for Linux, macOS, or Windows.
+
+This folder is the future home of the Phase1 Operator Manual section of **The Phase1 Codex**.
+
+## Current manual scope
+
+The Phase1 Operator Manual should explain:
+
+- what Phase1 currently is;
+- how to launch it safely;
+- how the boot selector and safe shield work;
+- how to use the operator shell, help UI, and man-style pages;
+- how the VFS, command registry, process model, and ops logs are exposed;
+- how guarded host tools are gated and logged;
+- how storage, Git, Rust, nested Phase1, and Fyr workflows should be used.
+
+## Planned chapters
+
+1. Scope and mental model.
+2. Install and launch.
+3. Boot selector and modes.
+4. Operator shell basics.
+5. VFS and system inspection.
+6. Guarded host tools.
+7. Storage, Git, and Rust workflows.
+8. Nested Phase1 sessions.
+9. Fyr for operators.
+10. Logs, learning, and local artifacts.
+11. Troubleshooting.
+12. Operator checklist.
+
+## Source-of-truth links
+
+Until this folder is fully written, keep existing docs as source material and link back to them rather than copying content blindly.
+
+- [`../MANUAL_ROADMAP.md`](../MANUAL_ROADMAP.md)
+- [`../security/TRUST_MODEL.md`](../security/TRUST_MODEL.md)
+- [`../security/DOCS_CLAIMS.md`](../security/DOCS_CLAIMS.md)
+- [`../../FEATURE_STATUS.md`](../../FEATURE_STATUS.md)
+- [`../../docs/nest/CHECKPOINT.md`](../nest/CHECKPOINT.md)

--- a/docs/recovery/README.md
+++ b/docs/recovery/README.md
@@ -1,0 +1,31 @@
+# Recovery and Hardware Reader Path
+
+> **Status:** Roadmap, design, and dry-run planning index.
+>
+> **Validation:** Links to Base1 design docs, future recovery checklists, and validation reports when they exist.
+>
+> **Non-claims:** Recovery USB behavior, destructive installer behavior, rollback, and real-hardware recovery are not claimed complete unless backed by named hardware validation and release evidence.
+
+This page is the recovery and hardware entry point for **The Phase1 Codex**.
+
+## Recovery reading order
+
+1. Read [`../security/TRUST_MODEL.md`](../security/TRUST_MODEL.md).
+2. Read [`../base1/README.md`](../base1/README.md).
+3. Review current hardware targets and maturity language before attempting any hardware workflow.
+4. Prefer read-only validation and dry-run scripts before any mutation.
+5. Do not write images, repartition disks, or alter boot material unless the exact workflow is documented, validated, and intentionally selected.
+
+## Recovery principles
+
+- Preserve a recovery shell path.
+- Verify target identity before mutation.
+- Verify image provenance before use.
+- Prefer read-only validation bundles first.
+- Require explicit operator confirmation for mutation.
+- Keep rollback metadata operator-readable.
+- Record hardware validation by device, date, artifact, and result.
+
+## Hardware and recovery rule
+
+Do not describe a recovery workflow as complete, hardware-validated, or installer-ready unless the page links to a dated validation report and the exact artifact used.

--- a/docs/security/DOCS_CLAIMS.md
+++ b/docs/security/DOCS_CLAIMS.md
@@ -1,0 +1,111 @@
+# Phase1 Documentation Claims Policy
+
+> **Status:** Documentation governance policy.
+>
+> **Validation:** Enforced by manual docs review and `tests/manual_roadmap_docs.rs`.
+>
+> **Non-claims:** This policy does not prove that Phase1, Base1, or Fyr has a property. It defines how claims must be written and reviewed.
+
+This page defines how Phase1 documentation should describe current implementation, experimental work, design work, roadmap items, and explicit non-claims.
+
+## Required status labels
+
+Every major manual page should use one of these labels:
+
+| Label | Meaning |
+| --- | --- |
+| Implemented | Code exists, tests exist, and docs explain how to run it. |
+| Experimental | Code exists but UX, hardening, or boundary behavior is still changing. |
+| Design | Architecture exists in docs but implementation is incomplete. |
+| Dry-run | The command validates intent without destructive mutation. |
+| Preview | Early tester-facing feature with known limitations. |
+| Roadmap | Planned future work. |
+| Not claimed | Explicitly outside current guarantees. |
+
+## Required evidence by claim type
+
+| Claim type | Required evidence |
+| --- | --- |
+| Command exists | Command docs, help/man page, or test. |
+| Feature implemented | Code path plus test or reproducible command. |
+| Host mutation guarded | Capability metadata, trust gate behavior, confirmation path, and docs. |
+| Read-only validation | Script source, test, and statement of what it reads or writes. |
+| Base1 boot behavior | Boot artifact, build recipe, checksum, and validation report. |
+| Hardware validation | Named hardware, date, exact test path, pass/fail notes. |
+| Recovery support | Recovery steps, rollback metadata, shell preservation, and validation evidence. |
+| Security property | Threat model, implementation details, tests, and review notes. |
+
+## Preferred wording
+
+Use precise wording:
+
+- `Phase1 currently runs as a host-backed Rust terminal console.`
+- `Base1 is planned as a minimal host foundation.`
+- `This workflow is dry-run only.`
+- `This command requires explicit operator confirmation before host mutation.`
+- `This feature is implemented as a metadata-only checkpoint.`
+- `This claim is not made until validated on named hardware.`
+
+## Disallowed or restricted wording
+
+Do not use these phrases unless there is linked evidence and maintainer review:
+
+- `secure OS replacement`
+- `finished operating system`
+- `hardened sandbox`
+- `drop-in replacement for Linux, macOS, or Windows`
+- `daily-driver ready`
+- `installer-ready`
+- `safe installer`
+- `recovery-complete`
+- `hardware-validated` without named hardware and report
+- `unbreakable`, `military-grade`, `fully secure`, `guaranteed safe`
+
+## Base1 wording rules
+
+Allowed:
+
+> Base1 is the planned minimal trusted host foundation for future Phase1-first bootable environments.
+
+Allowed when evidence exists:
+
+> This Base1 dry-run validates target identity without writing to the selected target.
+
+Not allowed without release evidence:
+
+> Base1 is a finished bootable secure OS.
+
+## Fyr wording rules
+
+Allowed:
+
+> Fyr is the Phase1-native language and toolchain track for `.fyr` files and Phase1 workflows.
+
+Allowed when tests exist:
+
+> The current Fyr toolchain supports the documented examples in this chapter.
+
+Not allowed without production evidence:
+
+> Fyr is production-ready for general software development.
+
+## Recovery wording rules
+
+Allowed:
+
+> Recovery USB behavior is documented as design, dry-run, preview, or validated depending on the evidence linked on the page.
+
+Not allowed without hardware reports:
+
+> Real-hardware recovery is complete.
+
+## PR review questions
+
+Before merging documentation, ask:
+
+1. Does the page say what is current and what is roadmap?
+2. Does every safety claim name a mechanism?
+3. Does every mechanism have a visible operator path?
+4. Does the page avoid implying destructive installer readiness?
+5. Does the page avoid implying Base1 is bootable unless explicitly marked preview or release with evidence?
+6. Does the page preserve the statement that Phase1 is not currently a finished secure OS replacement?

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,31 @@
+# Security and Trust Documentation
+
+> **Status:** Documentation index and review entry point.
+>
+> **Validation:** Links to the trust model, claims policy, and manual roadmap added in this repository.
+>
+> **Non-claims:** Phase1 is not currently a finished secure OS replacement, Base1 is not currently a released bootable daily-driver image, and this documentation index does not prove a security property by itself.
+
+This folder is the security and trust entry point for **The Phase1 Codex**.
+
+## Start here
+
+1. [`TRUST_MODEL.md`](TRUST_MODEL.md) — trust boundaries, safe defaults, guarded host tools, Base1 claim levels, and review checklist.
+2. [`DOCS_CLAIMS.md`](DOCS_CLAIMS.md) — allowed wording, disallowed wording, status labels, and required evidence.
+3. [`../MANUAL_ROADMAP.md`](../MANUAL_ROADMAP.md) — full Codex architecture, safety model, glossary, and launch plan.
+
+## Review order for safety-sensitive docs
+
+Use this order when reviewing pages about host tools, Base1, recovery, rollback, hardware, installers, image writing, or security claims:
+
+1. Confirm the page has a status block.
+2. Confirm the page names the current implementation status.
+3. Confirm the page separates current behavior from roadmap goals.
+4. Confirm host-backed behavior names the required capability.
+5. Confirm destructive workflows are not presented as default paths.
+6. Confirm dry-run or read-only validation is shown first when applicable.
+7. Confirm no page claims secure OS replacement, bootable Base1 release, installer readiness, daily-driver readiness, or recovery completion without linked evidence.
+
+## Security documentation rule
+
+Security documentation must be operator-visible and testable. Prefer narrow claims such as `requires explicit confirmation`, `blocked by default`, `read-only validation`, or `logged for review` over broad claims such as `safe`, `secure`, or `hardened`.

--- a/docs/security/TRUST_MODEL.md
+++ b/docs/security/TRUST_MODEL.md
@@ -1,0 +1,123 @@
+# Phase1 Trust Model
+
+> **Status:** Documentation guardrail and safety model.
+>
+> **Validation:** This page defines documentation requirements. Implementation claims must link to tests, scripts, release notes, or validation reports.
+>
+> **Non-claims:** Phase1 is not currently a finished secure OS replacement, Base1 is not currently a released bootable daily-driver image, and guarded host tools do not make an untrusted host trustworthy.
+
+This page defines the trust and safety language for **The Phase1 Codex**.
+
+## Core principle
+
+Phase1 should make capability, trust, and risk visible to the operator. It should not hide host mutation, imply guarantees that are not implemented, or market roadmap items as current security properties.
+
+## Current trust boundary
+
+Phase1 currently runs on a host operating system. The host controls process execution, the real filesystem, devices, network, credentials, and kernel-level enforcement. Phase1 can model, organize, gate, log, and explain actions inside its own environment, but it does not currently replace the host kernel or turn the host into a trusted computing base.
+
+## Safe defaults
+
+Safe defaults mean Phase1 starts with higher-risk host-backed behavior disabled or gated.
+
+Safe-default documentation must state:
+
+- what is disabled by default;
+- how the operator can inspect the current state;
+- what action changes the state;
+- what command or log records the change;
+- what the default does not protect against.
+
+Avoid saying `safe` as a broad guarantee. Prefer `disabled by default`, `requires confirmation`, `read-only by default`, or `logged for operator review`.
+
+## Guarded host tools
+
+A guarded host tool is any Phase1 command or helper that reaches outside the Phase1 model into host-backed behavior. Examples may include host shell execution, Git, Cargo, filesystem mutation outside the VFS model, networking, image writing, or device inspection.
+
+Guarded host tools must document:
+
+- required host capability;
+- whether safe shield blocks it by default;
+- whether a trust gate is required;
+- whether explicit operator confirmation is required;
+- what is logged;
+- what tests or dry-run commands validate behavior.
+
+## No host trust escalation
+
+A trust gate is a Phase1 decision point, not a guarantee about the host. Documentation must not imply that enabling a trust gate makes arbitrary host commands safe.
+
+Allowed wording:
+
+> This command requires the operator to enable host trust before Phase1 will invoke the host-backed workflow.
+
+Disallowed wording:
+
+> Turning on host trust makes host execution secure.
+
+## Explicit operator confirmation
+
+Any workflow that mutates host state, writes images, touches block devices, changes boot material, handles credentials, or removes files must require a visible confirmation path before the real operation.
+
+Docs should show dry-run examples before real mutation examples.
+
+## Read-only validation bundles
+
+Read-only validation is the preferred first implementation mode for Base1 and recovery features. A validation bundle should be able to inspect docs, scripts, metadata, checksums, and target identity without modifying the target.
+
+If a validation script writes files, the docs must state:
+
+- exact files or directories written;
+- whether the write is inside the repo, a temp directory, or a target device;
+- cleanup instructions;
+- how the operator can verify no target mutation occurred.
+
+## Recovery shell preservation
+
+Base1 recovery planning must preserve a shell path even when Phase1 fails. This is a requirement for future bootable environments, not proof that current hardware recovery is complete.
+
+Recovery docs must distinguish:
+
+- design requirement;
+- dry-run command;
+- emulator validation;
+- real hardware validation;
+- release-ready recovery procedure.
+
+## Image provenance and checksum rules
+
+A Base1 or recovery image must not be presented as usable unless docs identify:
+
+- source repository and commit;
+- build recipe;
+- artifact name;
+- checksum;
+- signature or attestation status, if available;
+- release identifier;
+- validation date;
+- known limitations.
+
+Without those details, call the artifact a design, dry-run, or preview artifact.
+
+## Base1 claim levels
+
+| Claim level | Allowed wording | Required evidence |
+| --- | --- | --- |
+| Design | planned, proposed, expected, intended | design doc |
+| Dry-run | dry-run checker, read-only validation | script and test output |
+| Emulator | boots or validates in emulator | reproducible emulator steps |
+| Hardware lab | validated on named hardware | dated hardware report |
+| Preview | early image for testers | checksums, release notes, rollback notes |
+| Stable | supported release | repeatable builds, tests, recovery evidence, known limitations |
+
+## Security review checklist
+
+A security reviewer should verify:
+
+- The page names the host boundary.
+- Claims are tied to commands, tests, scripts, or release evidence.
+- Destructive workflows are not presented as default paths.
+- Dry-run commands appear before mutation commands.
+- Host trust is described as operator consent, not host hardening.
+- Recovery and rollback claims include validation status.
+- Secrets are never requested in docs, examples, issue templates, or screenshots.


### PR DESCRIPTION
## Summary

This PR adds the first repository documentation slice for **The Phase1 Codex: Building a Terminal-First Operating World**.

Added:

- `docs/MANUAL_ROADMAP.md` as the canonical book/manual/wiki roadmap.
- `docs/README.md` as the repository documentation entry point.
- Phase1, Base1, Fyr, operator, developer, recovery, and security documentation indexes.
- `docs/security/TRUST_MODEL.md` for trust boundaries, guarded host-tool language, confirmation rules, image provenance rules, and review expectations.
- `docs/security/DOCS_CLAIMS.md` for status labels, wording rules, evidence requirements, and PR review questions.

## Boundaries preserved

- Phase1 remains documented as a host-backed Rust terminal console, not a finished OS/kernel replacement.
- Base1 remains documented as planned/design/roadmap unless linked evidence proves a stronger status.
- Recovery, installer, hardware, rollback, and image-writing language remains validation-gated.
- Safety language is written narrowly and tied to operator-visible mechanisms.

## Notes

- I intentionally did not replace the root `README.md` through the contents API because it is large and appears partly generated/managed. The new entry point is `docs/README.md`; a small README link can be added later through the repo’s normal docs-generation path.
- I attempted to add a Rust docs guard test, but the connector safety layer blocked multiple writes to `tests/manual_roadmap_docs.rs`, including a minimal smoke test. The PR therefore lands the docs slice without that test.

## Tests

Not run locally from this connector session. Markdown-only docs were added successfully.