### PR TITLE
Add Phase1 Codex docs guard test

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,3 +493,9 @@ Use `help ui` for a launch-pad view and `help flows` for daily check, safe updat
 ### v6 visual default
 
 The v6 edge console defaults to the `crimson` palette when no `PHASE1_THEME` override is set. The legacy bleeding-edge palette remains available manually with `theme edge`.
+
+## Documentation
+
+- [The Phase1 Codex](docs/MANUAL_ROADMAP.md)
+- [Documentation index](docs/README.md)
+

--- a/tests/manual_roadmap_docs.rs
+++ b/tests/manual_roadmap_docs.rs
@@ -1,0 +1,29 @@
+use std::fs;
+
+#[test]
+fn phase1_codex_docs_exist() {
+    for path in [
+        "docs/README.md",
+        "docs/MANUAL_ROADMAP.md",
+        "docs/phase1/README.md",
+        "docs/phase1/OPERATOR_MANUAL.md",
+        "docs/base1/README.md",
+        "docs/base1/FOUNDATION_MANUAL.md",
+        "docs/fyr/README.md",
+        "docs/fyr/LANGUAGE_BOOK.md",
+        "docs/security/README.md",
+        "docs/security/TRUST_MODEL.md",
+        "docs/security/DOCS_CLAIMS.md",
+    ] {
+        assert!(fs::metadata(path).is_ok(), "missing documentation file: {path}");
+    }
+}
+
+#[test]
+fn phase1_codex_title_is_present() {
+    let roadmap = fs::read_to_string("docs/MANUAL_ROADMAP.md")
+        .expect("manual roadmap should be readable");
+
+    assert!(roadmap.contains("The Phase1 Codex"));
+    assert!(roadmap.contains("Building a Terminal-First Operating World"));
+}


### PR DESCRIPTION
## Summary

Follow-up to PR #215.

This PR adds:

- A root README link to the Phase1 Codex documentation.
- `tests/manual_roadmap_docs.rs` to guard that the Codex roadmap and core docs remain present.

## Validation

Run locally:

```bash
cargo test -p phase1 --test manual_roadmap_docs
```

Result: 2 passed, 0 failed.

## Notes

PR #215 already landed the Codex documentation structure. This PR adds the missing discoverability/test guard piece tracked by issue #216.