### PR TITLE
Add Codex contribution and review guides

### DIFF
--- a/docs/developers/DOCS_CONTRIBUTING.md
+++ b/docs/developers/DOCS_CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Phase1 Codex Documentation Contribution Guide
+
+> **Status:** Documentation governance guide.
+>
+> **Validation:** Use with `docs/security/DOCS_CLAIMS.md`, `docs/security/TRUST_MODEL.md`, and repository docs tests.
+>
+> **Non-claims:** This guide does not certify a feature, release, recovery workflow, or security property. It defines how documentation changes should be prepared and reviewed.
+
+This guide turns **The Phase1 Codex** rules into a practical checklist for contributors.
+
+## Required page shape
+
+Every major Codex page should include:
+
+```md
+> **Status:** Implemented | Experimental | Design | Dry-run | Preview | Roadmap | Not claimed
+> **Validation:** tests, scripts, release notes, or manual verification path
+> **Non-claims:** what this page does not guarantee
+```
+
+Use the strongest status only when the repository evidence supports it.
+
+## Contributor workflow
+
+1. Identify whether the change documents current behavior, experimental behavior, design, dry-run work, preview work, roadmap work, or an explicit non-claim.
+2. Link to the source of truth instead of duplicating long sections from another page.
+3. Add runnable examples only when they match current behavior.
+4. Put dry-run or read-only examples before mutation examples.
+5. Add or update docs tests when changing important navigation, claims, or safety wording.
+6. Keep examples free of secrets, real tokens, personal data, and host-specific private paths.
+
+## Safety-sensitive documentation
+
+Treat these topics as safety-sensitive:
+
+- host-backed tools;
+- filesystem mutation outside the Phase1 model;
+- Git, Cargo, shell, or network workflows;
+- Base1 boot, image, installer, rollback, or recovery material;
+- hardware validation;
+- target identity checks;
+- security claims;
+- secret handling.
+
+Safety-sensitive pages must be reviewed against [`../security/REVIEW_GUIDE.md`](../security/REVIEW_GUIDE.md).
+
+## Allowed claim pattern
+
+Prefer this structure:
+
+```md
+Current behavior: what exists now.
+Validation: how to verify it.
+Limitations: what it does not prove.
+Roadmap: what may come later.
+```
+
+## Disallowed shortcuts
+
+Do not make broad claims such as secure, safe, hardened, production-ready, installer-ready, recovery-complete, daily-driver ready, or bootable without linked evidence and review.
+
+## PR checklist
+
+Before opening a docs PR:
+
+- The page has a status block.
+- The page separates current behavior from roadmap work.
+- Every safety claim names the mechanism.
+- Every strong claim has evidence.
+- Destructive examples are not the first example.
+- Host-backed behavior names the host boundary.
+- Base1 and recovery language stays validation-gated.
+- Fyr language claims stay tied to current examples, tests, or roadmap labels.
+- Links to Codex index pages still work.
+- Relevant docs tests pass.

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -12,9 +12,10 @@ This page is the developer entry point for **The Phase1 Codex**.
 
 1. Read [`../README.md`](../README.md) for the documentation status model.
 2. Read [`../MANUAL_ROADMAP.md`](../MANUAL_ROADMAP.md) for the full Codex structure.
-3. Read [`../security/DOCS_CLAIMS.md`](../security/DOCS_CLAIMS.md) before editing safety, Base1, recovery, installer, or host-tool docs.
-4. Read [`../security/TRUST_MODEL.md`](../security/TRUST_MODEL.md) before adding or documenting host-backed behavior.
-5. Use the existing repository tests as the source of truth for implemented behavior.
+3. Read [`DOCS_CONTRIBUTING.md`](DOCS_CONTRIBUTING.md) before preparing documentation PRs.
+4. Read [`../security/DOCS_CLAIMS.md`](../security/DOCS_CLAIMS.md) before editing safety, Base1, recovery, installer, or host-tool docs.
+5. Read [`../security/TRUST_MODEL.md`](../security/TRUST_MODEL.md) before adding or documenting host-backed behavior.
+6. Use the existing repository tests as the source of truth for implemented behavior.
 
 ## Required contribution habits
 
@@ -37,6 +38,8 @@ Treat these as safety-sensitive:
 - target identity verification;
 - secret handling;
 - claims that use words such as secure, safe, hardened, bootable, installer-ready, recovery-complete, or daily-driver ready.
+
+Review safety-sensitive documentation with [`../security/REVIEW_GUIDE.md`](../security/REVIEW_GUIDE.md).
 
 ## Developer rule
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -2,7 +2,7 @@
 
 > **Status:** Documentation index and review entry point.
 >
-> **Validation:** Links to the trust model, claims policy, and manual roadmap added in this repository.
+> **Validation:** Links to the trust model, claims policy, review guide, and manual roadmap added in this repository.
 >
 > **Non-claims:** Phase1 is not currently a finished secure OS replacement, Base1 is not currently a released bootable daily-driver image, and this documentation index does not prove a security property by itself.
 
@@ -12,7 +12,8 @@ This folder is the security and trust entry point for **The Phase1 Codex**.
 
 1. [`TRUST_MODEL.md`](TRUST_MODEL.md) — trust boundaries, safe defaults, guarded host tools, Base1 claim levels, and review checklist.
 2. [`DOCS_CLAIMS.md`](DOCS_CLAIMS.md) — allowed wording, disallowed wording, status labels, and required evidence.
-3. [`../MANUAL_ROADMAP.md`](../MANUAL_ROADMAP.md) — full Codex architecture, safety model, glossary, and launch plan.
+3. [`REVIEW_GUIDE.md`](REVIEW_GUIDE.md) — practical reviewer checklist for safety-sensitive documentation.
+4. [`../MANUAL_ROADMAP.md`](../MANUAL_ROADMAP.md) — full Codex architecture, safety model, glossary, and launch plan.
 
 ## Review order for safety-sensitive docs
 
@@ -25,6 +26,7 @@ Use this order when reviewing pages about host tools, Base1, recovery, rollback,
 5. Confirm destructive workflows are not presented as default paths.
 6. Confirm dry-run or read-only validation is shown first when applicable.
 7. Confirm no page claims secure OS replacement, bootable Base1 release, installer readiness, daily-driver readiness, or recovery completion without linked evidence.
+8. Use [`REVIEW_GUIDE.md`](REVIEW_GUIDE.md) before approving safety-sensitive documentation.
 
 ## Security documentation rule
 

--- a/docs/security/REVIEW_GUIDE.md
+++ b/docs/security/REVIEW_GUIDE.md
@@ -1,0 +1,84 @@
+# Phase1 Codex Security Review Guide
+
+> **Status:** Documentation review guide.
+>
+> **Validation:** Use during documentation and safety-sensitive PR review with `DOCS_CLAIMS.md`, `TRUST_MODEL.md`, and repository tests.
+>
+> **Non-claims:** This guide does not certify Phase1 as a secure OS replacement, Base1 as a released bootable system, or any recovery path as hardware-complete.
+
+This guide defines how reviewers should evaluate safety-sensitive Codex changes.
+
+## Review goals
+
+A reviewer should confirm that documentation makes risk, capability, trust, and validation visible to the operator. The goal is not to make every page longer. The goal is to make every claim narrow, testable, and tied to evidence.
+
+## First-pass review
+
+Check every safety-sensitive page for:
+
+- a status block;
+- a clear current/roadmap split;
+- a validation path;
+- a non-claims section;
+- no broad security wording without evidence;
+- no destructive workflow presented as the default path;
+- no claim that Phase1 upgrades host trust;
+- no claim that Base1 is bootable, installer-ready, or recovery-complete unless evidence exists.
+
+## Host boundary review
+
+For host-backed workflows, verify that the page states:
+
+- which command or workflow crosses into host-backed behavior;
+- what capability is required;
+- whether safe shield or trust gates apply;
+- whether explicit confirmation is required;
+- what is logged;
+- what the workflow does not protect against.
+
+## Base1 and recovery review
+
+For Base1, recovery, rollback, image, hardware, or installer pages, verify that claims are labeled as one of:
+
+- design;
+- dry-run;
+- emulator validation;
+- hardware validation;
+- preview release;
+- stable release.
+
+A page may only use stronger language when it links to artifacts, checksums, build notes, validation reports, or named hardware results.
+
+## Fyr review
+
+For Fyr pages, verify that examples and language features match current tests or are clearly labeled roadmap.
+
+Do not allow production-language claims unless the repository includes explicit release, compatibility, and stability evidence.
+
+## Secret and privacy review
+
+Reject or request changes if examples include:
+
+- real tokens;
+- real passwords;
+- real email inbox content;
+- private host usernames when unnecessary;
+- API keys;
+- secret-looking placeholders that may encourage unsafe copying.
+
+Use placeholders such as `<token>`, `<device>`, `<path>`, or `<target>` only when the surrounding text explains that the operator must provide their own value.
+
+## Approval checklist
+
+Before approving a safety-sensitive documentation PR, answer:
+
+- Does the page describe what exists now?
+- Does the page describe what is only planned?
+- Does the page avoid overclaiming?
+- Does the page show dry-run or read-only paths first?
+- Does the page explain host-backed behavior clearly?
+- Does the page preserve recovery-shell and rollback caution?
+- Does the page name evidence for strong claims?
+- Do relevant docs tests pass?
+
+If any answer is no, request changes.


### PR DESCRIPTION
## Summary

Adds the next Phase1 Codex governance slice:

- `docs/developers/DOCS_CONTRIBUTING.md`
- `docs/security/REVIEW_GUIDE.md`
- links from the developer and security documentation indexes

## Why

Turns the Codex trust and claims model into practical contributor and reviewer workflows for future documentation PRs.

## Boundaries

- Does not certify any security property.
- Does not claim Phase1 is a finished secure OS replacement.
- Does not upgrade Base1 beyond roadmap, design, or validation-gated language.
- Keeps safety-sensitive documentation review tied to narrow, evidence-backed claims.

## Tests

Docs-only change. Not run locally from this connector session.