### PR TITLE
Document Base1 preview stack runbook

### DIFF
--- a/docs/base1/PREVIEW_STACK_RUNBOOK.md
+++ b/docs/base1/PREVIEW_STACK_RUNBOOK.md
@@ -1,0 +1,143 @@
+# Base1 Preview Stack Runbook
+
+This runbook describes the current safe Base1 emulator-preview workflow.
+
+It is intentionally preview-only. It does not describe a released Base1 image, a finished installer, a completed recovery process, a hardware validation result, or a daily-driver-ready operating system.
+
+## Purpose
+
+The preview stack gives operators one guarded path for checking Base1 preview inputs, generating an emulator-preview bundle, inspecting that bundle, recording provenance, and verifying checksums.
+
+The stack is useful for preparing evidence before any future bootable-image promotion work. It is not itself a boot validation.
+
+## Current safe stack
+
+The one-command stack is:
+
+```sh
+sh scripts/base1-preview-stack.sh \
+  --bundle build/base1-preview-stack-demo \
+  --kernel build/base1-test-vmlinuz \
+  --initrd build/base1-test-initrd.img \
+  --image-mb 1 \
+  --no-qemu-check
+```
+
+The stack runs these steps in order:
+
+1. `scripts/base1-preview-inputs.sh`
+2. `scripts/base1-emulator-preview.sh`
+3. `scripts/base1-emulator-doctor.sh`
+4. `scripts/base1-preview-gate.sh --dry-run`
+5. `scripts/base1-preview-provenance.sh`
+6. `scripts/base1-preview-verify.sh`
+
+## Inputs
+
+Required inputs:
+
+| Input | Meaning | Boundary |
+| --- | --- | --- |
+| `--kernel <path>` | Candidate kernel file for emulator preview packaging | Must be an existing file; not validated as a release kernel |
+| `--initrd <path>` | Candidate initrd file for emulator preview packaging | Must be an existing file; not validated as a release initrd |
+| `--bundle <dir>` | Output bundle directory under `build/` | Must remain under `build/` |
+| `--image-mb <n>` | Placeholder raw sandbox size | Preview artifact only |
+| `--no-qemu-check` | Skip QEMU presence check | Does not launch QEMU |
+
+## Outputs
+
+A successful stack run produces a preview bundle under `build/`.
+
+Expected outputs include:
+
+| Path | Purpose |
+| --- | --- |
+| `manifest.env` | Bundle-level preview metadata |
+| `README.txt` | Bundle-local summary |
+| `base1-sandbox.raw` | Sandbox placeholder artifact |
+| `base1-rootfs-preview.tar` | Root filesystem preview archive when available |
+| `run-qemu-bundle.sh` | Emulator scaffold script |
+| `staging/manifest.env` | Staging metadata |
+| `staging/boot/grub/grub.cfg` | Preview GRUB config |
+| `staging/boot/vmlinuz` | Copied candidate kernel |
+| `staging/boot/initrd.img` | Copied candidate initrd |
+| `reports/provenance.env` | Preview provenance record |
+| `reports/SHA256SUMS` | Recorded SHA-256 checksums |
+
+## Verification behavior
+
+The final verification step reads `reports/SHA256SUMS` and checks that each listed file still exists and still matches the recorded SHA-256.
+
+A mismatch is treated as bundle drift. The verifier fails instead of silently accepting changed artifacts.
+
+## Safe local smoke flow
+
+```sh
+mkdir -p build
+printf 'kernel placeholder\n' > build/base1-test-vmlinuz
+printf 'initrd placeholder\n' > build/base1-test-initrd.img
+
+sh scripts/base1-preview-stack.sh \
+  --bundle build/base1-preview-stack-demo \
+  --kernel build/base1-test-vmlinuz \
+  --initrd build/base1-test-initrd.img \
+  --image-mb 1 \
+  --no-qemu-check
+
+sh scripts/base1-preview-verify.sh \
+  --bundle build/base1-preview-stack-demo
+```
+
+This smoke flow uses placeholder inputs. Passing it proves the preview stack mechanics work; it does not prove Base1 boots.
+
+## Promotion rule
+
+Do not promote any preview bundle to a stronger status unless all of the following are recorded:
+
+1. Exact source commit.
+2. Exact kernel and initrd source.
+3. Generated `reports/provenance.env`.
+4. Generated `reports/SHA256SUMS`.
+5. Passing `scripts/base1-preview-verify.sh` output.
+6. A human-readable validation report under `docs/base1/validation/`.
+7. A clear statement of what was not validated.
+
+## Non-claims
+
+This runbook does not claim that Base1 is bootable.
+
+It also does not claim:
+
+- Base1 is a released OS image.
+- Base1 is a secure OS replacement.
+- Base1 is daily-driver ready.
+- The preview bundle is safe to install on hardware.
+- Recovery USB behavior is complete.
+- Real hardware has been validated.
+- The emulator was launched by the safe preview stack.
+
+## Related scripts
+
+| Script | Role |
+| --- | --- |
+| `scripts/base1-preview-inputs.sh` | Read-only input checker |
+| `scripts/base1-emulator-preview.sh` | Preview bundle generator under `build/` |
+| `scripts/base1-emulator-doctor.sh` | Read-only bundle doctor |
+| `scripts/base1-preview-gate.sh` | Dry-run guarded handoff gate |
+| `scripts/base1-preview-provenance.sh` | Preview provenance and checksum writer |
+| `scripts/base1-preview-verify.sh` | Read-only checksum verifier |
+| `scripts/base1-preview-stack.sh` | End-to-end safe stack wrapper |
+
+## Test targets
+
+Relevant tests:
+
+```sh
+cargo test -p phase1 --test base1_preview_inputs_script
+cargo test -p phase1 --test base1_emulator_preview_script
+cargo test -p phase1 --test base1_emulator_doctor_script
+cargo test -p phase1 --test base1_preview_gate_script
+cargo test -p phase1 --test base1_preview_provenance_script
+cargo test -p phase1 --test base1_preview_verify_script
+cargo test -p phase1 --test base1_preview_stack_script
+```

--- a/docs/base1/README.md
+++ b/docs/base1/README.md
@@ -2,7 +2,7 @@
 
 > **Status:** Roadmap and design index.
 >
-> **Validation:** Links to current Base1 design docs, dry-run scripts, readiness matrix, validation runbook, validation report template, validation reports archive, and future validation reports.
+> **Validation:** Links to current Base1 design docs, dry-run scripts, readiness matrix, validation runbook, validation report template, validation reports archive, preview stack runbook, and future validation reports.
 >
 > **Non-claims:** Base1 is not currently documented here as a released bootable daily-driver image, finished secure OS replacement, or destructive installer-ready system.
 
@@ -28,6 +28,7 @@ Base1 is the planned minimal host foundation for future Phase1-first bootable en
 - [`READINESS_MATRIX.md`](READINESS_MATRIX.md)
 - [`VALIDATION_RUNBOOK.md`](VALIDATION_RUNBOOK.md)
 - [`VALIDATION_REPORT_TEMPLATE.md`](VALIDATION_REPORT_TEMPLATE.md)
+- [`PREVIEW_STACK_RUNBOOK.md`](PREVIEW_STACK_RUNBOOK.md)
 - [`validation/README.md`](validation/README.md)
 - [`../MANUAL_ROADMAP.md`](../MANUAL_ROADMAP.md)
 - [`../security/TRUST_MODEL.md`](../security/TRUST_MODEL.md)
@@ -48,6 +49,8 @@ Use [`READINESS_MATRIX.md`](READINESS_MATRIX.md) before strengthening Base1 word
 ## Runbook rule
 
 Use [`VALIDATION_RUNBOOK.md`](VALIDATION_RUNBOOK.md) for documentation-only Base1 checks. The runbook verifies docs structure and guardrails only; it does not validate boot, hardware, recovery, rollback, image, installer, persistence, or daily-driver behavior.
+
+Use [`PREVIEW_STACK_RUNBOOK.md`](PREVIEW_STACK_RUNBOOK.md) for the current safe emulator-preview stack. The preview stack runbook covers input checks, bundle generation, doctor checks, dry-run gating, provenance, and checksum verification; it does not validate boot, hardware, recovery, installer behavior, or daily-driver readiness.
 
 ## Report rule
 

--- a/tests/base1_preview_stack_runbook_docs.rs
+++ b/tests/base1_preview_stack_runbook_docs.rs
@@ -1,0 +1,79 @@
+use std::fs;
+
+const RUNBOOK: &str = "docs/base1/PREVIEW_STACK_RUNBOOK.md";
+const INDEX: &str = "docs/base1/README.md";
+
+#[test]
+fn base1_preview_stack_runbook_exists() {
+    assert!(fs::metadata(RUNBOOK).is_ok(), "missing Base1 preview stack runbook");
+}
+
+#[test]
+fn base1_index_links_preview_stack_runbook() {
+    let index = fs::read_to_string(INDEX).expect("Base1 docs index should be readable");
+
+    assert!(
+        index.contains("PREVIEW_STACK_RUNBOOK.md"),
+        "Base1 index should link the preview stack runbook"
+    );
+    assert!(
+        index.contains("safe emulator-preview stack"),
+        "Base1 index should explain the preview stack boundary"
+    );
+}
+
+#[test]
+fn base1_preview_stack_runbook_lists_safe_stack_order() {
+    let runbook = fs::read_to_string(RUNBOOK).expect("Base1 preview stack runbook should be readable");
+
+    for expected in [
+        "scripts/base1-preview-inputs.sh",
+        "scripts/base1-emulator-preview.sh",
+        "scripts/base1-emulator-doctor.sh",
+        "scripts/base1-preview-gate.sh --dry-run",
+        "scripts/base1-preview-provenance.sh",
+        "scripts/base1-preview-verify.sh",
+        "scripts/base1-preview-stack.sh",
+        "reports/provenance.env",
+        "reports/SHA256SUMS",
+    ] {
+        assert!(runbook.contains(expected), "runbook missing stack item: {expected}");
+    }
+}
+
+#[test]
+fn base1_preview_stack_runbook_preserves_non_claims() {
+    let runbook = fs::read_to_string(RUNBOOK).expect("Base1 preview stack runbook should be readable");
+
+    for expected in [
+        "does not claim that Base1 is bootable",
+        "not prove Base1 boots",
+        "not claim",
+        "released OS image",
+        "secure OS replacement",
+        "daily-driver ready",
+        "safe to install on hardware",
+        "Recovery USB behavior is complete",
+        "Real hardware has been validated",
+        "emulator was launched",
+    ] {
+        assert!(runbook.contains(expected), "runbook missing non-claim: {expected}");
+    }
+}
+
+#[test]
+fn base1_preview_stack_runbook_preserves_promotion_rule() {
+    let runbook = fs::read_to_string(RUNBOOK).expect("Base1 preview stack runbook should be readable");
+
+    for expected in [
+        "Exact source commit",
+        "Exact kernel and initrd source",
+        "Generated `reports/provenance.env`",
+        "Generated `reports/SHA256SUMS`",
+        "Passing `scripts/base1-preview-verify.sh` output",
+        "validation report under `docs/base1/validation/`",
+        "what was not validated",
+    ] {
+        assert!(runbook.contains(expected), "runbook missing promotion rule: {expected}");
+    }
+}


### PR DESCRIPTION
Adds the Base1 preview stack operator runbook, links it from the Base1 docs index, and adds a docs guard test.