### PR TITLE
Add Base1 preview stack validation report

### DIFF
--- a/docs/base1/validation/2026-05-10-preview-stack.md
+++ b/docs/base1/validation/2026-05-10-preview-stack.md
@@ -1,0 +1,161 @@
+# Base1 Validation Report: Safe Preview Stack
+
+Date: 2026-05-10
+
+Status: preview evidence record
+
+Result: PASS for preview-stack mechanics when the listed tests pass locally or in CI.
+
+Promotion recommendation: keep Base1 at preview-only for this path. Do not promote this evidence to bootable, installer-ready, hardware-validated, recovery-complete, secure OS replacement, or daily-driver-ready status.
+
+## Scope
+
+This report records the current safe Base1 emulator-preview stack evidence.
+
+The stack covered by this report is:
+
+1. `scripts/base1-preview-inputs.sh`
+2. `scripts/base1-emulator-preview.sh`
+3. `scripts/base1-emulator-doctor.sh`
+4. `scripts/base1-preview-gate.sh --dry-run`
+5. `scripts/base1-preview-provenance.sh`
+6. `scripts/base1-preview-verify.sh`
+7. `scripts/base1-preview-stack.sh`
+
+This report is about mechanics and guardrails only. It records that the preview stack can check inputs, generate a preview bundle under `build/`, run read-only checks, refuse unsafe handoff by default, write provenance/checksums, and verify the recorded checksums.
+
+## Evidence files
+
+Primary docs:
+
+- `docs/base1/PREVIEW_STACK_RUNBOOK.md`
+- `docs/base1/README.md`
+- `docs/base1/READINESS_MATRIX.md`
+- `docs/base1/VALIDATION_REPORT_TEMPLATE.md`
+- `docs/base1/validation/README.md`
+
+Primary scripts:
+
+- `scripts/base1-preview-inputs.sh`
+- `scripts/base1-emulator-preview.sh`
+- `scripts/base1-emulator-doctor.sh`
+- `scripts/base1-preview-gate.sh`
+- `scripts/base1-preview-provenance.sh`
+- `scripts/base1-preview-verify.sh`
+- `scripts/base1-preview-stack.sh`
+
+Primary tests:
+
+- `tests/base1_preview_inputs_script.rs`
+- `tests/base1_emulator_preview_script.rs`
+- `tests/base1_emulator_doctor_script.rs`
+- `tests/base1_preview_gate_script.rs`
+- `tests/base1_preview_provenance_script.rs`
+- `tests/base1_preview_verify_script.rs`
+- `tests/base1_preview_stack_script.rs`
+- `tests/base1_preview_stack_runbook_docs.rs`
+
+## Validation commands
+
+Recommended test commands:
+
+```sh
+cargo test -p phase1 --test base1_preview_inputs_script
+cargo test -p phase1 --test base1_emulator_preview_script
+cargo test -p phase1 --test base1_emulator_doctor_script
+cargo test -p phase1 --test base1_preview_gate_script
+cargo test -p phase1 --test base1_preview_provenance_script
+cargo test -p phase1 --test base1_preview_verify_script
+cargo test -p phase1 --test base1_preview_stack_script
+cargo test -p phase1 --test base1_preview_stack_runbook_docs
+```
+
+Recommended safe manual smoke command:
+
+```sh
+mkdir -p build
+printf 'kernel placeholder\n' > build/base1-test-vmlinuz
+printf 'initrd placeholder\n' > build/base1-test-initrd.img
+
+sh scripts/base1-preview-stack.sh \
+  --bundle build/base1-preview-stack-demo \
+  --kernel build/base1-test-vmlinuz \
+  --initrd build/base1-test-initrd.img \
+  --image-mb 1 \
+  --no-qemu-check
+
+sh scripts/base1-preview-verify.sh \
+  --bundle build/base1-preview-stack-demo
+```
+
+## Expected outputs
+
+A successful preview-stack run creates a bundle under `build/` with preview-only artifacts including:
+
+- `manifest.env`
+- `README.txt`
+- `base1-sandbox.raw`
+- `base1-rootfs-preview.tar` when present
+- `run-qemu-bundle.sh`
+- `staging/manifest.env`
+- `staging/boot/grub/grub.cfg`
+- `staging/boot/vmlinuz`
+- `staging/boot/initrd.img`
+- `reports/provenance.env`
+- `reports/SHA256SUMS`
+
+A successful verification run reports SHA-256 matches for each listed file in `reports/SHA256SUMS`.
+
+## Guardrails observed
+
+The current stack is designed to preserve these guardrails:
+
+- Output bundle path remains under `build/`.
+- QEMU is not launched by the stack.
+- The gate path defaults to dry-run.
+- The execution path requires a separate explicit confirmation phrase in `scripts/base1-preview-gate.sh`.
+- Provenance is recorded inside the preview bundle.
+- Checksum verification fails on drift.
+- Real-device write tools are excluded from the preview scripts and tests.
+- The runbook states the preview-only boundary.
+
+## What this validates
+
+This evidence validates the following narrow claims only:
+
+- The safe preview stack exists.
+- The preview stack is wired in a predictable order.
+- Placeholder kernel/initrd inputs can be packaged into a preview bundle.
+- The bundle doctor can inspect the generated preview bundle.
+- The preview gate can perform a dry-run without launching QEMU.
+- Provenance and SHA-256 checksum files can be generated.
+- The verifier can detect checksum drift.
+- The documentation names the safe path and non-claims.
+
+## What this does not validate
+
+This report does not claim that Base1 is bootable.
+
+This report also does not validate or claim:
+
+- A released Base1 image.
+- A secure OS replacement.
+- A daily-driver-ready system.
+- A hardware installation path.
+- A destructive installer path.
+- Recovery USB completion.
+- Rollback completion.
+- Real hardware behavior.
+- Emulator launch success.
+- Kernel correctness.
+- Initrd correctness.
+- GRUB runtime behavior.
+- Any chain of trust beyond preview-bundle checksums.
+
+## Promotion boundary
+
+This report supports the `preview` evidence level for the safe preview stack mechanics only.
+
+Do not use this report to mark Base1 as bootable, validated on hardware, installer-ready, recovery-complete, secure OS replacement, or daily-driver ready.
+
+Before promotion to any stronger status, require a separate report with real target identity, exact kernel/initrd provenance, emulator launch evidence, boot logs, failure logs, rollback/recovery notes, and explicit non-claims for what remains untested.

--- a/docs/base1/validation/README.md
+++ b/docs/base1/validation/README.md
@@ -52,5 +52,6 @@ Roadmap -> Design -> Dry-run -> Preview -> Validated
 ## Current reports
 
 - [`2026-05-10-docs-evidence-chain.md`](2026-05-10-docs-evidence-chain.md) — documentation-only Base1 evidence-chain report.
+- [`2026-05-10-preview-stack.md`](2026-05-10-preview-stack.md) — safe Base1 preview-stack mechanics evidence report.
 
 Add reports only when there is evidence to preserve.

--- a/tests/base1_preview_stack_validation_report_docs.rs
+++ b/tests/base1_preview_stack_validation_report_docs.rs
@@ -1,0 +1,90 @@
+use std::fs;
+
+const REPORT: &str = "docs/base1/validation/2026-05-10-preview-stack.md";
+const INDEX: &str = "docs/base1/validation/README.md";
+
+#[test]
+fn base1_preview_stack_validation_report_exists() {
+    assert!(fs::metadata(REPORT).is_ok(), "missing Base1 preview stack validation report");
+}
+
+#[test]
+fn validation_index_links_preview_stack_report() {
+    let index = fs::read_to_string(INDEX).expect("Base1 validation index should be readable");
+
+    assert!(
+        index.contains("2026-05-10-preview-stack.md"),
+        "validation index should link the preview stack report"
+    );
+    assert!(
+        index.contains("safe Base1 preview-stack mechanics evidence report"),
+        "validation index should explain the preview stack report scope"
+    );
+}
+
+#[test]
+fn preview_stack_report_records_scope_and_evidence() {
+    let report = fs::read_to_string(REPORT).expect("Base1 preview stack report should be readable");
+
+    for expected in [
+        "Base1 Validation Report: Safe Preview Stack",
+        "Date: 2026-05-10",
+        "Status: preview evidence record",
+        "Result: PASS for preview-stack mechanics",
+        "scripts/base1-preview-inputs.sh",
+        "scripts/base1-emulator-preview.sh",
+        "scripts/base1-emulator-doctor.sh",
+        "scripts/base1-preview-gate.sh --dry-run",
+        "scripts/base1-preview-provenance.sh",
+        "scripts/base1-preview-verify.sh",
+        "scripts/base1-preview-stack.sh",
+        "docs/base1/PREVIEW_STACK_RUNBOOK.md",
+        "reports/provenance.env",
+        "reports/SHA256SUMS",
+    ] {
+        assert!(report.contains(expected), "report missing expected evidence: {expected}");
+    }
+}
+
+#[test]
+fn preview_stack_report_preserves_non_claims() {
+    let report = fs::read_to_string(REPORT).expect("Base1 preview stack report should be readable");
+
+    for expected in [
+        "does not claim that Base1 is bootable",
+        "released Base1 image",
+        "secure OS replacement",
+        "daily-driver-ready system",
+        "hardware installation path",
+        "destructive installer path",
+        "Recovery USB completion",
+        "Rollback completion",
+        "Real hardware behavior",
+        "Emulator launch success",
+        "Kernel correctness",
+        "Initrd correctness",
+        "GRUB runtime behavior",
+        "Do not use this report to mark Base1 as bootable",
+    ] {
+        assert!(report.contains(expected), "report missing non-claim: {expected}");
+    }
+}
+
+#[test]
+fn preview_stack_report_preserves_promotion_boundary() {
+    let report = fs::read_to_string(REPORT).expect("Base1 preview stack report should be readable");
+
+    for expected in [
+        "preview evidence level",
+        "safe preview stack mechanics only",
+        "real target identity",
+        "exact kernel/initrd provenance",
+        "emulator launch evidence",
+        "boot logs",
+        "failure logs",
+        "rollback/recovery notes",
+        "explicit non-claims",
+    ] {
+        assert!(report.contains(expected), "report missing promotion boundary: {expected}");
+    }
+}


### PR DESCRIPTION
Adds a dated validation report for the safe Base1 preview stack, links it from the validation archive, and adds a docs guard test.