### PR TITLE
Add Base1 preview checks doc

### DIFF
--- a/docs/base1/PREVIEW_CHECKS.md
+++ b/docs/base1/PREVIEW_CHECKS.md
@@ -1,0 +1,75 @@
+# Base1 Preview Checks
+
+This page records the current command set for validating the Base1 safe preview stack after syncing `edge/stable`.
+
+It is a command checklist only. It does not launch the emulator, install Base1, validate hardware, complete recovery, create a released image, or prove that Base1 is bootable.
+
+## Sync
+
+~~~sh
+cd ~/phase1_library/phase1
+git checkout edge/stable
+git pull --ff-only origin edge/stable
+~~~
+
+## Preview-stack test set
+
+Run the full preview-stack guard set:
+
+~~~sh
+cargo test -p phase1 --test base1_preview_inputs_script
+cargo test -p phase1 --test base1_emulator_preview_script
+cargo test -p phase1 --test base1_emulator_doctor_script
+cargo test -p phase1 --test base1_preview_gate_script
+cargo test -p phase1 --test base1_preview_provenance_script
+cargo test -p phase1 --test base1_preview_verify_script
+cargo test -p phase1 --test base1_preview_stack_script
+cargo test -p phase1 --test base1_preview_stack_runbook_docs
+cargo test -p phase1 --test base1_preview_stack_validation_report_docs
+~~~
+
+## Safe manual smoke
+
+~~~sh
+mkdir -p build
+printf 'kernel placeholder\n' > build/base1-test-vmlinuz
+printf 'initrd placeholder\n' > build/base1-test-initrd.img
+
+sh scripts/base1-preview-stack.sh \
+  --bundle build/base1-preview-stack-demo \
+  --kernel build/base1-test-vmlinuz \
+  --initrd build/base1-test-initrd.img \
+  --image-mb 1 \
+  --no-qemu-check
+~~~
+
+The safe stack should end with:
+
+~~~text
+result: pass
+base1 preview stack: complete: safe preview stack passed with provenance verification
+~~~
+
+## Evidence produced
+
+A successful safe stack run should produce:
+
+- `build/base1-preview-stack-demo/reports/provenance.env`
+- `build/base1-preview-stack-demo/reports/SHA256SUMS`
+
+The final verification step reads `reports/SHA256SUMS` and checks that each listed file still matches the recorded SHA-256.
+
+## Non-claims
+
+This page does not claim that Base1 is bootable.
+
+It also does not claim:
+
+- Base1 is installer-ready.
+- Base1 is hardware-validated.
+- Base1 is recovery-complete.
+- Base1 is daily-driver ready.
+- The preview stack launches QEMU.
+- The placeholder kernel or initrd is a validated Base1 kernel/initrd.
+
+Use `docs/base1/validation/2026-05-10-preview-stack.md` as the current dated evidence record for this preview-only path.

--- a/docs/base1/README.md
+++ b/docs/base1/README.md
@@ -2,7 +2,7 @@
 
 > **Status:** Roadmap and design index.
 >
-> **Validation:** Links to current Base1 design docs, dry-run scripts, readiness matrix, validation runbook, validation report template, validation reports archive, preview stack runbook, and future validation reports.
+> **Validation:** Links to current Base1 design docs, dry-run scripts, readiness matrix, validation runbook, validation report template, validation reports archive, preview stack runbook, preview checks, and future validation reports.
 >
 > **Non-claims:** Base1 is not currently documented here as a released bootable daily-driver image, finished secure OS replacement, or destructive installer-ready system.
 
@@ -29,6 +29,7 @@ Base1 is the planned minimal host foundation for future Phase1-first bootable en
 - [`VALIDATION_RUNBOOK.md`](VALIDATION_RUNBOOK.md)
 - [`VALIDATION_REPORT_TEMPLATE.md`](VALIDATION_REPORT_TEMPLATE.md)
 - [`PREVIEW_STACK_RUNBOOK.md`](PREVIEW_STACK_RUNBOOK.md)
+- [`PREVIEW_CHECKS.md`](PREVIEW_CHECKS.md)
 - [`validation/README.md`](validation/README.md)
 - [`../MANUAL_ROADMAP.md`](../MANUAL_ROADMAP.md)
 - [`../security/TRUST_MODEL.md`](../security/TRUST_MODEL.md)
@@ -51,6 +52,8 @@ Use [`READINESS_MATRIX.md`](READINESS_MATRIX.md) before strengthening Base1 word
 Use [`VALIDATION_RUNBOOK.md`](VALIDATION_RUNBOOK.md) for documentation-only Base1 checks. The runbook verifies docs structure and guardrails only; it does not validate boot, hardware, recovery, rollback, image, installer, persistence, or daily-driver behavior.
 
 Use [`PREVIEW_STACK_RUNBOOK.md`](PREVIEW_STACK_RUNBOOK.md) for the current safe emulator-preview stack. The preview stack runbook covers input checks, bundle generation, doctor checks, dry-run gating, provenance, and checksum verification; it does not validate boot, hardware, recovery, installer behavior, or daily-driver readiness.
+
+Use [`PREVIEW_CHECKS.md`](PREVIEW_CHECKS.md) after syncing `edge/stable` to run the current preview-stack test set and safe manual smoke checklist. The checks page does not validate boot, hardware, recovery, installer behavior, or daily-driver readiness.
 
 ## Report rule
 

--- a/tests/base1_preview_checks_docs.rs
+++ b/tests/base1_preview_checks_docs.rs
@@ -1,0 +1,73 @@
+use std::fs;
+
+const CHECKS: &str = "docs/base1/PREVIEW_CHECKS.md";
+const INDEX: &str = "docs/base1/README.md";
+
+#[test]
+fn base1_preview_checks_doc_exists() {
+    assert!(fs::metadata(CHECKS).is_ok(), "missing Base1 preview checks doc");
+}
+
+#[test]
+fn base1_index_links_preview_checks_doc() {
+    let index = fs::read_to_string(INDEX).expect("Base1 index should be readable");
+
+    assert!(
+        index.contains("PREVIEW_CHECKS.md"),
+        "Base1 index should link preview checks doc"
+    );
+}
+
+#[test]
+fn base1_preview_checks_lists_current_test_set() {
+    let checks = fs::read_to_string(CHECKS).expect("Base1 preview checks doc should be readable");
+
+    for expected in [
+        "base1_preview_inputs_script",
+        "base1_emulator_preview_script",
+        "base1_emulator_doctor_script",
+        "base1_preview_gate_script",
+        "base1_preview_provenance_script",
+        "base1_preview_verify_script",
+        "base1_preview_stack_script",
+        "base1_preview_stack_runbook_docs",
+        "base1_preview_stack_validation_report_docs",
+    ] {
+        assert!(checks.contains(expected), "missing test target: {expected}");
+    }
+}
+
+#[test]
+fn base1_preview_checks_records_safe_manual_smoke() {
+    let checks = fs::read_to_string(CHECKS).expect("Base1 preview checks doc should be readable");
+
+    for expected in [
+        "scripts/base1-preview-stack.sh",
+        "--bundle build/base1-preview-stack-demo",
+        "--kernel build/base1-test-vmlinuz",
+        "--initrd build/base1-test-initrd.img",
+        "--no-qemu-check",
+        "reports/provenance.env",
+        "reports/SHA256SUMS",
+    ] {
+        assert!(checks.contains(expected), "missing smoke detail: {expected}");
+    }
+}
+
+#[test]
+fn base1_preview_checks_preserves_non_claims() {
+    let checks = fs::read_to_string(CHECKS).expect("Base1 preview checks doc should be readable");
+
+    for expected in [
+        "does not claim that Base1 is bootable",
+        "installer-ready",
+        "hardware-validated",
+        "recovery-complete",
+        "daily-driver ready",
+        "preview stack launches QEMU",
+        "validated Base1 kernel/initrd",
+        "preview-only path",
+    ] {
+        assert!(checks.contains(expected), "missing non-claim: {expected}");
+    }
+}


### PR DESCRIPTION
Adds a Base1 preview checks command-set page, links it from the Base1 docs index, and includes a docs guard test.