### PR TITLE
Record Base1 QEMU Phase1 marker validation

### DIFF
--- a/docs/base1/validation/2026-05-10-qemu-phase1-marker.md
+++ b/docs/base1/validation/2026-05-10-qemu-phase1-marker.md
@@ -1,0 +1,65 @@
+# Base1 QEMU Phase1 Marker Validation Report — 2026-05-10
+
+## Result
+
+PASS: Base1 QEMU Phase1 marker boot path validated.
+
+## Scope
+
+This report records emulator-only evidence that:
+
+- QEMU launched a real Linux kernel.
+- A Base1-controlled init wrapper executed.
+- The serial log emitted `phase1 6.0.0 ready`.
+- The original Alpine init remained preserved as `/init.alpine`.
+
+## Evidence
+
+Command:
+
+~~~sh
+PATH="/opt/homebrew/bin:$PATH" sh scripts/base1-qemu-boot-check.sh \
+  --bundle build/base1-phase1-marker-demo \
+  --execute \
+  --confirm launch-qemu-base1-preview \
+  --timeout 60 \
+  --expect "phase1 6.0.0 ready"
+~~~
+
+Observed result:
+
+~~~text
+qemu-exit-code: 124
+result: pass
+log: build/base1-phase1-marker-demo/reports/qemu-boot.log
+summary: build/base1-phase1-marker-demo/reports/qemu-boot-summary.env
+~~~
+
+Marker evidence:
+
+~~~text
+Linux version 6.18.22-0-virt
+base1 init wrapper reached
+phase1 6.0.0 ready
+base1 handoff: exec alpine init
+~~~
+
+## Interpretation
+
+Exit code `124` is expected for this bounded emulator run because `gtimeout` terminates QEMU after the timeout. The validation result is PASS because the expected serial marker was observed before timeout.
+
+## Non-claims
+
+This report does not claim:
+
+- Full Phase1 OS payload boot.
+- Installer readiness.
+- Hardware validation.
+- Recovery completeness.
+- Daily-driver readiness.
+- A released Base1 image.
+- That the marker initramfs is a production initramfs.
+
+## Promotion rule
+
+Base1 may only move beyond this evidence level after a real Phase1 binary is included in the boot payload and launched by the boot path, with serial evidence captured by the guarded QEMU checker.

--- a/docs/base1/validation/README.md
+++ b/docs/base1/validation/README.md
@@ -55,3 +55,4 @@ Roadmap -> Design -> Dry-run -> Preview -> Validated
 - [`2026-05-10-preview-stack.md`](2026-05-10-preview-stack.md) — safe Base1 preview-stack mechanics evidence report.
 
 Add reports only when there is evidence to preserve.
+- [`2026-05-10-qemu-phase1-marker.md`](2026-05-10-qemu-phase1-marker.md)

--- a/tests/base1_qemu_phase1_marker_report_docs.rs
+++ b/tests/base1_qemu_phase1_marker_report_docs.rs
@@ -1,0 +1,66 @@
+use std::fs;
+
+const REPORT: &str = "docs/base1/validation/2026-05-10-qemu-phase1-marker.md";
+const INDEX: &str = "docs/base1/validation/README.md";
+
+#[test]
+fn qemu_phase1_marker_report_exists() {
+    assert!(fs::metadata(REPORT).is_ok(), "missing QEMU Phase1 marker report");
+}
+
+#[test]
+fn validation_index_links_qemu_phase1_marker_report() {
+    let index = fs::read_to_string(INDEX).expect("validation index should be readable");
+    assert!(
+        index.contains("2026-05-10-qemu-phase1-marker.md"),
+        "validation index should link QEMU Phase1 marker report"
+    );
+}
+
+#[test]
+fn qemu_phase1_marker_report_records_evidence() {
+    let report = fs::read_to_string(REPORT).expect("report should be readable");
+
+    for expected in [
+        "PASS: Base1 QEMU Phase1 marker boot path validated.",
+        "phase1 6.0.0 ready",
+        "base1 init wrapper reached",
+        "base1 handoff: exec alpine init",
+        "qemu-exit-code: 124",
+        "result: pass",
+        "scripts/base1-qemu-boot-check.sh",
+    ] {
+        assert!(report.contains(expected), "missing evidence: {expected}");
+    }
+}
+
+#[test]
+fn qemu_phase1_marker_report_preserves_non_claims() {
+    let report = fs::read_to_string(REPORT).expect("report should be readable");
+
+    for expected in [
+        "Full Phase1 OS payload boot",
+        "Installer readiness",
+        "Hardware validation",
+        "Recovery completeness",
+        "Daily-driver readiness",
+        "released Base1 image",
+        "production initramfs",
+    ] {
+        assert!(report.contains(expected), "missing non-claim: {expected}");
+    }
+}
+
+#[test]
+fn qemu_phase1_marker_report_preserves_promotion_rule() {
+    let report = fs::read_to_string(REPORT).expect("report should be readable");
+
+    for expected in [
+        "real Phase1 binary",
+        "included in the boot payload",
+        "launched by the boot path",
+        "serial evidence captured by the guarded QEMU checker",
+    ] {
+        assert!(report.contains(expected), "missing promotion rule: {expected}");
+    }
+}


### PR DESCRIPTION
Adds the dated Base1 QEMU Phase1 marker validation report and a guard test. The report records emulator-only marker evidence and preserves the non-claims around full payload, installer, hardware, recovery, and daily-driver readiness.