### PR TITLE
Add Base1 real-device read-only validation plan

### DIFF
--- a/docs/base1/README.md
+++ b/docs/base1/README.md
@@ -60,3 +60,4 @@ Use [`PREVIEW_CHECKS.md`](PREVIEW_CHECKS.md) after syncing `edge/stable` to run 
 Use [`VALIDATION_REPORT_TEMPLATE.md`](VALIDATION_REPORT_TEMPLATE.md) when recording Base1 evidence so reports name the scope, target, commands, result, observations, evidence links, boundaries, and promotion recommendation.
 
 Store future Base1 reports under [`validation/`](validation/) so evidence remains discoverable and reviewable.
+- [Base1 real-device read-only validation plan](real-device/READONLY_VALIDATION_PLAN.md)

--- a/docs/base1/real-device/READONLY_VALIDATION_PLAN.md
+++ b/docs/base1/real-device/READONLY_VALIDATION_PLAN.md
@@ -1,0 +1,51 @@
+# Base1 Real-Device Read-Only Validation Plan
+
+Status: planning only  
+Date: 2026-05-10  
+Scope: read-only real-device validation preparation
+
+## Purpose
+
+Define the safe path for collecting real-device evidence without writing to disks, firmware, boot media, partitions, or attached targets.
+
+## Allowed Evidence
+
+- Device identity summary
+- Boot environment notes
+- Read-only firmware or platform observations
+- Read-only storage layout observations
+- QEMU evidence references
+- Operator-entered target notes
+
+## Forbidden Actions
+
+- No disk writes
+- No partitioning
+- No formatting
+- No installer execution
+- No firmware flashing
+- No bootloader installation
+- No destructive repair commands
+- No automatic target selection
+
+## Required Guardrails
+
+- Target identity must be reviewed before any future device workflow.
+- Any future command that touches a target must default to dry-run.
+- Any future write path requires a separate PR and explicit confirmation phrase.
+- This plan does not claim hardware validation.
+
+## Current Evidence Chain
+
+- Repeatable real Phase1 initrd builder
+- QEMU Phase1 marker evidence
+- QEMU real Phase1 binary evidence
+- Base1 real QEMU boot promotion evidence
+
+## Non-Claims
+
+- Not installer-ready
+- Not hardware-validated
+- Not daily-driver ready
+- No destructive disk writes
+- No real-device write path

--- a/tests/base1_real_device_readonly_validation_docs.rs
+++ b/tests/base1_real_device_readonly_validation_docs.rs
@@ -1,0 +1,49 @@
+use std::fs;
+
+#[test]
+fn real_device_readonly_validation_plan_exists() {
+    let doc = fs::read_to_string("docs/base1/real-device/READONLY_VALIDATION_PLAN.md")
+        .expect("real-device read-only validation plan exists");
+
+    assert!(doc.contains("Base1 Real-Device Read-Only Validation Plan"));
+    assert!(doc.contains("Status: planning only"));
+    assert!(doc.contains("read-only real-device validation preparation"));
+}
+
+#[test]
+fn real_device_readonly_validation_preserves_guardrails() {
+    let doc = fs::read_to_string("docs/base1/real-device/READONLY_VALIDATION_PLAN.md")
+        .expect("real-device read-only validation plan exists");
+
+    assert!(doc.contains("No disk writes"));
+    assert!(doc.contains("No partitioning"));
+    assert!(doc.contains("No formatting"));
+    assert!(doc.contains("No installer execution"));
+    assert!(doc.contains("No firmware flashing"));
+    assert!(doc.contains("No bootloader installation"));
+    assert!(doc.contains("No automatic target selection"));
+}
+
+#[test]
+fn real_device_readonly_validation_preserves_non_claims() {
+    let doc = fs::read_to_string("docs/base1/real-device/READONLY_VALIDATION_PLAN.md")
+        .expect("real-device read-only validation plan exists");
+
+    assert!(doc.contains("Not installer-ready"));
+    assert!(doc.contains("Not hardware-validated"));
+    assert!(doc.contains("Not daily-driver ready"));
+    assert!(doc.contains("No destructive disk writes"));
+    assert!(doc.contains("No real-device write path"));
+}
+
+#[test]
+fn base1_index_links_real_device_readonly_plan() {
+    let base_index = fs::read_to_string("docs/base1/README.md").unwrap_or_default();
+    let validation_index =
+        fs::read_to_string("docs/base1/validation/README.md").unwrap_or_default();
+
+    assert!(
+        base_index.contains("READONLY_VALIDATION_PLAN.md")
+            || validation_index.contains("READONLY_VALIDATION_PLAN.md")
+    );
+}


### PR DESCRIPTION
Adds the Base1 real-device read-only validation plan as the next safe step after QEMU evidence promotion.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test base1_real_device_readonly_validation_docs
- cargo test -p phase1 --test base1_qemu_boot_check_script
- cargo test -p phase1 --test base1_qemu_phase1_marker_report_docs
- cargo test -p phase1 --test base1_qemu_real_phase1_binary_report_docs
- cargo test -p phase1 --test smoke

Non-claims:
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path