### PR TITLE
Add Base1 real-device read-only preview

### DIFF
--- a/scripts/base1-real-device-readonly-preview.sh
+++ b/scripts/base1-real-device-readonly-preview.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target=""
+dry_run="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      target="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run="true"
+      shift
+      ;;
+    -h|--help)
+      cat <<'HELP'
+Base1 real-device read-only preview
+
+Usage:
+  scripts/base1-real-device-readonly-preview.sh --target /dev/<device> --dry-run
+
+Guardrails:
+  --dry-run is required
+  target must be a /dev/ path
+  no disk writes
+  no partitioning
+  no formatting
+  no mounting
+  no firmware writes
+  no installer execution
+HELP
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$dry_run" != "true" ]]; then
+  echo "--dry-run is required" >&2
+  exit 2
+fi
+
+if [[ -z "$target" ]]; then
+  echo "--target /dev/<device> is required" >&2
+  exit 2
+fi
+
+if [[ "$target" != /dev/* ]]; then
+  echo "target must be a /dev/ path" >&2
+  exit 2
+fi
+
+cat <<REPORT
+Base1 real-device read-only preview
+status: dry-run only
+target: $target
+writes: disabled
+mutation: disabled
+installer: disabled
+partitioning: disabled
+formatting: disabled
+mounting: disabled
+firmware-writes: disabled
+hardware-validation-claim: false
+daily-driver-claim: false
+
+Non-claims:
+- not installer-ready
+- not hardware-validated
+- not daily-driver ready
+- no destructive disk writes
+- no real-device write path
+REPORT

--- a/tests/base1_real_device_readonly_preview_script.rs
+++ b/tests/base1_real_device_readonly_preview_script.rs
@@ -1,0 +1,66 @@
+use std::process::Command;
+
+const SCRIPT: &str = "scripts/base1-real-device-readonly-preview.sh";
+
+#[test]
+fn real_device_readonly_preview_script_exists() {
+    let script = std::fs::read_to_string(SCRIPT).expect("read-only preview script exists");
+
+    assert!(script.contains("Base1 real-device read-only preview"));
+    assert!(script.contains("--dry-run is required"));
+    assert!(script.contains("no disk writes"));
+    assert!(script.contains("no partitioning"));
+    assert!(script.contains("no formatting"));
+    assert!(script.contains("no firmware writes"));
+    assert!(script.contains("no installer execution"));
+}
+
+#[test]
+fn real_device_readonly_preview_requires_dry_run() {
+    let output = Command::new("bash")
+        .args([SCRIPT, "--target", "/dev/disk-test"])
+        .output()
+        .expect("run preview script");
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--dry-run is required"));
+}
+
+#[test]
+fn real_device_readonly_preview_requires_dev_target() {
+    let output = Command::new("bash")
+        .args([SCRIPT, "--target", "disk-test", "--dry-run"])
+        .output()
+        .expect("run preview script");
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("target must be a /dev/ path"));
+}
+
+#[test]
+fn real_device_readonly_preview_reports_non_mutating_contract() {
+    let output = Command::new("bash")
+        .args([SCRIPT, "--target", "/dev/disk-test", "--dry-run"])
+        .output()
+        .expect("run preview script");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("status: dry-run only"));
+    assert!(stdout.contains("target: /dev/disk-test"));
+    assert!(stdout.contains("writes: disabled"));
+    assert!(stdout.contains("mutation: disabled"));
+    assert!(stdout.contains("installer: disabled"));
+    assert!(stdout.contains("partitioning: disabled"));
+    assert!(stdout.contains("formatting: disabled"));
+    assert!(stdout.contains("firmware-writes: disabled"));
+    assert!(stdout.contains("hardware-validation-claim: false"));
+    assert!(stdout.contains("daily-driver-claim: false"));
+    assert!(stdout.contains("no destructive disk writes"));
+    assert!(stdout.contains("no real-device write path"));
+}


### PR DESCRIPTION
Adds the Base1 real-device read-only preview script and tests as the safe next step after the real-device read-only validation plan.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test base1_real_device_readonly_validation_docs
- cargo test -p phase1 --test base1_real_device_readonly_preview_script
- cargo test -p phase1 --test smoke

Non-claims:
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path