### PR TITLE
Add Base1 real-device read-only report template

### DIFF
--- a/docs/base1/README.md
+++ b/docs/base1/README.md
@@ -61,3 +61,4 @@ Use [`VALIDATION_REPORT_TEMPLATE.md`](VALIDATION_REPORT_TEMPLATE.md) when record
 
 Store future Base1 reports under [`validation/`](validation/) so evidence remains discoverable and reviewable.
 - [Base1 real-device read-only validation plan](real-device/READONLY_VALIDATION_PLAN.md)
+- [Real-device read-only report template](real-device/READONLY_REPORT_TEMPLATE.md)

--- a/docs/base1/real-device/READONLY_REPORT_TEMPLATE.md
+++ b/docs/base1/real-device/READONLY_REPORT_TEMPLATE.md
@@ -1,0 +1,57 @@
+# Base1 Real-Device Read-Only Validation Report Template
+
+Status: template only
+Scope: read-only real-device observation
+Date: YYYY-MM-DD
+Operator: TBD
+Target identity: TBD
+
+## Purpose
+
+Record real-device observations without writing to disks, firmware, boot media, partitions, or attached targets.
+
+## Required Target Identity
+
+- Device path:
+- Model:
+- Serial or redacted identifier:
+- Size:
+- Transport:
+- Boot environment:
+- Operator notes:
+
+## Allowed Evidence
+
+- Device identity summary
+- Read-only boot observations
+- Read-only firmware or platform observations
+- Read-only storage layout observations
+- QEMU evidence references
+- Operator-entered notes
+
+## Forbidden Actions
+
+- No disk writes
+- No partitioning
+- No formatting
+- No installer execution
+- No firmware flashing
+- No bootloader installation
+- No destructive repair commands
+- No automatic target selection
+
+## Validation Commands
+
+- scripts/base1-real-device-readonly-preview.sh --dry-run --target /dev/...
+
+## Result
+
+Result: observation-only / blocked / incomplete
+
+## Non-Claims
+
+- Not installer-ready
+- Not hardware-validated
+- Not daily-driver ready
+- No destructive disk writes
+- No real-device write path

--- a/tests/base1_real_device_readonly_report_template_docs.rs
+++ b/tests/base1_real_device_readonly_report_template_docs.rs
@@ -1,0 +1,51 @@
+use std::fs;
+
+#[test]
+fn real_device_readonly_report_template_exists() {
+    let doc = fs::read_to_string("docs/base1/real-device/READONLY_REPORT_TEMPLATE.md")
+        .expect("real-device read-only report template exists");
+
+    assert!(doc.contains("Base1 Real-Device Read-Only Validation Report Template"));
+    assert!(doc.contains("Status: template only"));
+    assert!(doc.contains("Scope: read-only real-device observation"));
+}
+
+#[test]
+fn real_device_readonly_report_template_requires_identity() {
+    let doc = fs::read_to_string("docs/base1/real-device/READONLY_REPORT_TEMPLATE.md").unwrap();
+
+    assert!(doc.contains("Required Target Identity"));
+    assert!(doc.contains("Device path:"));
+    assert!(doc.contains("Model:"));
+    assert!(doc.contains("Serial or redacted identifier:"));
+    assert!(doc.contains("Transport:"));
+}
+
+#[test]
+fn real_device_readonly_report_template_preserves_guardrails() {
+    let doc = fs::read_to_string("docs/base1/real-device/READONLY_REPORT_TEMPLATE.md").unwrap();
+
+    assert!(doc.contains("No disk writes"));
+    assert!(doc.contains("No partitioning"));
+    assert!(doc.contains("No formatting"));
+    assert!(doc.contains("No installer execution"));
+    assert!(doc.contains("No firmware flashing"));
+    assert!(doc.contains("No automatic target selection"));
+}
+
+#[test]
+fn real_device_readonly_report_template_preserves_non_claims() {
+    let doc = fs::read_to_string("docs/base1/real-device/READONLY_REPORT_TEMPLATE.md").unwrap();
+
+    assert!(doc.contains("Not installer-ready"));
+    assert!(doc.contains("Not hardware-validated"));
+    assert!(doc.contains("Not daily-driver ready"));
+    assert!(doc.contains("No destructive disk writes"));
+    assert!(doc.contains("No real-device write path"));
+}
+
+#[test]
+fn base1_index_links_real_device_readonly_report_template() {
+    let index = fs::read_to_string("docs/base1/README.md").unwrap_or_default();
+    assert!(index.contains("READONLY_REPORT_TEMPLATE.md"));
+}


### PR DESCRIPTION
Adds a Base1 real-device read-only validation report template for future observation-only evidence.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test base1_real_device_readonly_report_template_docs
- cargo test -p phase1 --test base1_real_device_readonly_preview_script
- cargo test -p phase1 --test base1_real_device_readonly_validation_docs
- cargo test -p phase1 --test smoke

Non-claims:
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path