### PR TITLE
Update Base1 real-device read-only report template

### DIFF
--- a/docs/base1/real-device/READONLY_REPORT_TEMPLATE.md
+++ b/docs/base1/real-device/READONLY_REPORT_TEMPLATE.md
@@ -1,35 +1,41 @@
 # Base1 Real-Device Read-Only Validation Report Template
 
 Status: template only
-Scope: read-only real-device observation
 Date: YYYY-MM-DD
-Operator: TBD
-Target identity: TBD
+Scope: read-only real-device evidence capture
 
-## Purpose
+## Target Identity
 
-Record real-device observations without writing to disks, firmware, boot media, partitions, or attached targets.
-
-## Required Target Identity
-
+- Operator:
 - Device path:
-- Model:
-- Serial or redacted identifier:
-- Size:
+- Device model:
+- Device serial:
+- Device size:
 - Transport:
-- Boot environment:
-- Operator notes:
+- Host platform:
+- Collection date:
 
-## Allowed Evidence
+## Evidence Source
 
-- Device identity summary
-- Read-only boot observations
-- Read-only firmware or platform observations
-- Read-only storage layout observations
+Use only read-only collection paths.
+
+Allowed examples:
+
+- `scripts/base1-real-device-readonly-preview.sh --dry-run --target /dev/<device>`
+- read-only `lsblk` identity output
+- read-only `diskutil info` identity output
+- operator-entered boot environment notes
 - QEMU evidence references
-- Operator-entered notes
 
-## Forbidden Actions
+## Read-Only Observations
+
+- Boot environment:
+- Firmware/platform notes:
+- Storage layout notes:
+- Device identity notes:
+- QEMU evidence reference:
+
+## Guardrails Confirmed
 
 - No disk writes
 - No partitioning
@@ -37,16 +43,23 @@ Record real-device observations without writing to disks, firmware, boot media, 
 - No installer execution
 - No firmware flashing
 - No bootloader installation
-- No destructive repair commands
 - No automatic target selection
+- No destructive repair commands
 
-## Validation Commands
+## Result Label
 
-- scripts/base1-real-device-readonly-preview.sh --dry-run --target /dev/...
+Choose one:
 
-## Result
+- `read-only-observed`
+- `blocked-before-device-access`
+- `operator-aborted`
+- `needs-follow-up`
 
-Result: observation-only / blocked / incomplete
+## Promotion Rule
+
+This report may only promote read-only real-device observation evidence.
+
+It does not promote Phase1 to installer-ready, hardware-validated, or daily-driver status.
 
 ## Non-Claims
 

--- a/tests/base1_real_device_readonly_report_template_docs.rs
+++ b/tests/base1_real_device_readonly_report_template_docs.rs
@@ -3,22 +3,23 @@ use std::fs;
 #[test]
 fn real_device_readonly_report_template_exists() {
     let doc = fs::read_to_string("docs/base1/real-device/READONLY_REPORT_TEMPLATE.md")
-        .expect("real-device read-only report template exists");
+        .expect("read-only report template exists");
 
     assert!(doc.contains("Base1 Real-Device Read-Only Validation Report Template"));
     assert!(doc.contains("Status: template only"));
-    assert!(doc.contains("Scope: read-only real-device observation"));
+    assert!(doc.contains("Scope: read-only real-device evidence capture"));
 }
 
 #[test]
-fn real_device_readonly_report_template_requires_identity() {
+fn real_device_readonly_report_template_records_identity_fields() {
     let doc = fs::read_to_string("docs/base1/real-device/READONLY_REPORT_TEMPLATE.md").unwrap();
 
-    assert!(doc.contains("Required Target Identity"));
     assert!(doc.contains("Device path:"));
-    assert!(doc.contains("Model:"));
-    assert!(doc.contains("Serial or redacted identifier:"));
+    assert!(doc.contains("Device model:"));
+    assert!(doc.contains("Device serial:"));
+    assert!(doc.contains("Device size:"));
     assert!(doc.contains("Transport:"));
+    assert!(doc.contains("Host platform:"));
 }
 
 #[test]
@@ -30,7 +31,9 @@ fn real_device_readonly_report_template_preserves_guardrails() {
     assert!(doc.contains("No formatting"));
     assert!(doc.contains("No installer execution"));
     assert!(doc.contains("No firmware flashing"));
+    assert!(doc.contains("No bootloader installation"));
     assert!(doc.contains("No automatic target selection"));
+    assert!(doc.contains("No destructive repair commands"));
 }
 
 #[test]
@@ -46,6 +49,7 @@ fn real_device_readonly_report_template_preserves_non_claims() {
 
 #[test]
 fn base1_index_links_real_device_readonly_report_template() {
-    let index = fs::read_to_string("docs/base1/README.md").unwrap_or_default();
-    assert!(index.contains("READONLY_REPORT_TEMPLATE.md"));
+    let base_index = fs::read_to_string("docs/base1/README.md").unwrap_or_default();
+
+    assert!(base_index.contains("READONLY_REPORT_TEMPLATE.md"));
 }


### PR DESCRIPTION
Updates the Base1 real-device read-only report template and matching docs tests after the initial template merge.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test base1_real_device_readonly_report_template_docs
- cargo test -p phase1 --test base1_real_device_readonly_preview_script
- cargo test -p phase1 --test base1_real_device_readonly_validation_docs
- cargo test -p phase1 --test smoke

Non-claims:
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path