### PR TITLE
Add Base1 real-device read-only validation bundle

### DIFF
--- a/scripts/base1-real-device-readonly-validation-bundle.sh
+++ b/scripts/base1-real-device-readonly-validation-bundle.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Base1 real-device read-only validation bundle
+
+Usage:
+  scripts/base1-real-device-readonly-validation-bundle.sh --dry-run --target /dev/<device>
+
+Runs read-only previews only:
+  - real-device read-only preview
+  - real-device read-only report
+  - docs presence checks
+
+Non-claims:
+  - not installer-ready
+  - not hardware-validated
+  - not daily-driver ready
+  - no destructive disk writes
+  - no real-device write path
+USAGE
+}
+
+dry_run=0
+target=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --target)
+      target="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$dry_run" -ne 1 ]; then
+  echo "error: --dry-run is required" >&2
+  exit 2
+fi
+
+if [ -z "$target" ]; then
+  echo "error: --target /dev/<device> is required" >&2
+  exit 2
+fi
+
+case "$target" in
+  /dev/*) ;;
+  *)
+    echo "error: target must be under /dev/" >&2
+    exit 2
+    ;;
+esac
+
+echo "Base1 real-device read-only validation bundle"
+echo "status: dry-run only"
+echo "target: $target"
+echo "writes: disabled"
+echo "mutation: disabled"
+echo "installer: disabled"
+echo "hardware-validation-claim: false"
+echo "daily-driver-claim: false"
+echo
+
+echo "checking docs:"
+test -f docs/base1/real-device/READONLY_VALIDATION_PLAN.md
+echo "- READONLY_VALIDATION_PLAN.md: present"
+test -f docs/base1/real-device/READONLY_REPORT_TEMPLATE.md
+echo "- READONLY_REPORT_TEMPLATE.md: present"
+echo
+
+echo "running read-only preview:"
+scripts/base1-real-device-readonly-preview.sh --dry-run --target "$target" | sed -n '1,40p'
+echo
+
+echo "running read-only report generator:"
+scripts/base1-real-device-readonly-report.sh --dry-run --target "$target" | sed -n '1,60p'
+echo
+
+echo "non-claims:"
+echo "- not installer-ready"
+echo "- not hardware-validated"
+echo "- not daily-driver ready"
+echo "- no destructive disk writes"
+echo "- no real-device write path"

--- a/tests/base1_real_device_readonly_validation_bundle.rs
+++ b/tests/base1_real_device_readonly_validation_bundle.rs
@@ -1,0 +1,77 @@
+use std::fs;
+use std::process::Command;
+
+const SCRIPT: &str = "scripts/base1-real-device-readonly-validation-bundle.sh";
+
+#[test]
+fn real_device_readonly_validation_bundle_exists() {
+    let script = fs::read_to_string(SCRIPT).expect("validation bundle script exists");
+
+    assert!(script.contains("--dry-run"));
+    assert!(script.contains("--target"));
+    assert!(script.contains("base1-real-device-readonly-preview.sh"));
+    assert!(script.contains("base1-real-device-readonly-report.sh"));
+    assert!(script.contains("READONLY_VALIDATION_PLAN.md"));
+    assert!(script.contains("READONLY_REPORT_TEMPLATE.md"));
+}
+
+#[test]
+fn real_device_readonly_validation_bundle_requires_dry_run() {
+    let output = Command::new("bash")
+        .arg(SCRIPT)
+        .arg("--target")
+        .arg("/dev/disk-test")
+        .output()
+        .expect("script runs");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--dry-run is required"));
+}
+
+#[test]
+fn real_device_readonly_validation_bundle_requires_dev_target() {
+    let output = Command::new("bash")
+        .arg(SCRIPT)
+        .arg("--dry-run")
+        .arg("--target")
+        .arg("disk-test")
+        .output()
+        .expect("script runs");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("target must be under /dev/"));
+}
+
+#[test]
+fn real_device_readonly_validation_bundle_runs_non_mutating_previews() {
+    let output = Command::new("bash")
+        .arg(SCRIPT)
+        .arg("--dry-run")
+        .arg("--target")
+        .arg("/dev/disk-test")
+        .output()
+        .expect("script runs");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Base1 real-device read-only validation bundle"));
+    assert!(stdout.contains("status: dry-run only"));
+    assert!(stdout.contains("target: /dev/disk-test"));
+    assert!(stdout.contains("writes: disabled"));
+    assert!(stdout.contains("mutation: disabled"));
+    assert!(stdout.contains("installer: disabled"));
+    assert!(stdout.contains("hardware-validation-claim: false"));
+    assert!(stdout.contains("daily-driver-claim: false"));
+    assert!(stdout.contains("READONLY_VALIDATION_PLAN.md: present"));
+    assert!(stdout.contains("READONLY_REPORT_TEMPLATE.md: present"));
+    assert!(stdout.contains("Base1 real-device read-only preview"));
+    assert!(stdout.contains("Base1 Real-Device Read-Only Validation Report"));
+    assert!(stdout.contains("not installer-ready"));
+    assert!(stdout.contains("not hardware-validated"));
+    assert!(stdout.contains("not daily-driver ready"));
+    assert!(stdout.contains("no destructive disk writes"));
+    assert!(stdout.contains("no real-device write path"));
+}


### PR DESCRIPTION
Adds the Base1 real-device read-only validation bundle that runs the read-only preview and report paths together.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test base1_real_device_readonly_validation_bundle
- cargo test -p phase1 --test base1_real_device_readonly_report_script
- cargo test -p phase1 --test base1_real_device_readonly_report_template_docs
- cargo test -p phase1 --test base1_real_device_readonly_preview_script
- cargo test -p phase1 --test base1_real_device_readonly_validation_docs
- cargo test -p phase1 --test smoke

Non-claims:
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path