### PR TITLE
Record Base1 real-device read-only bundle report

### DIFF
--- a/docs/base1/README.md
+++ b/docs/base1/README.md
@@ -62,3 +62,4 @@ Use [`VALIDATION_REPORT_TEMPLATE.md`](VALIDATION_REPORT_TEMPLATE.md) when record
 Store future Base1 reports under [`validation/`](validation/) so evidence remains discoverable and reviewable.
 - [Base1 real-device read-only validation plan](real-device/READONLY_VALIDATION_PLAN.md)
 - [Real-device read-only report template](real-device/READONLY_REPORT_TEMPLATE.md)
+- [Real-device read-only validation bundle report](real-device/READONLY_VALIDATION_BUNDLE_REPORT.md)

--- a/docs/base1/real-device/READONLY_VALIDATION_BUNDLE_REPORT.md
+++ b/docs/base1/real-device/READONLY_VALIDATION_BUNDLE_REPORT.md
@@ -1,0 +1,75 @@
+# Base1 Real-Device Read-Only Validation Bundle Report
+
+Status: read-only bundle evidence recorded
+Date: 2026-05-10
+Scope: Base1 real-device read-only validation bundle
+
+## Summary
+
+This report records the current Base1 real-device read-only validation bundle.
+
+The bundle joins the read-only validation plan, read-only preview script, read-only report generator, and docs checks into one dry-run-only workflow.
+
+## Evidence Chain
+
+- Base1 real-device read-only validation plan
+- Base1 real-device read-only preview script
+- Base1 real-device read-only report template
+- Base1 real-device read-only report generator
+- Base1 real-device read-only validation bundle
+
+## Bundle Command
+
+```text
+scripts/base1-real-device-readonly-validation-bundle.sh --dry-run --target /dev/YOUR_TARGET
+```
+
+## Confirmed Bundle Behavior
+
+- Requires `--dry-run`
+- Requires `--target /dev/<device>`
+- Rejects non-`/dev/` targets
+- Checks required real-device read-only docs
+- Runs the read-only preview path
+- Runs the read-only report generator path
+- Keeps writes disabled
+- Keeps mutation disabled
+- Keeps installer disabled
+- Keeps hardware validation claim false
+- Keeps daily-driver claim false
+
+## Guardrails
+
+- No disk writes
+- No partitioning
+- No formatting
+- No installer execution
+- No firmware flashing
+- No bootloader installation
+- No automatic target selection
+- No destructive repair commands
+- No real-device write path
+
+## Validated Commands
+
+```text
+cargo fmt --all --check
+cargo test -p phase1 --test base1_real_device_readonly_validation_bundle
+cargo test -p phase1 --test base1_real_device_readonly_report_script
+cargo test -p phase1 --test base1_real_device_readonly_preview_script
+cargo test -p phase1 --test smoke
+```
+
+## Promotion Rule
+
+This checkpoint only promotes the read-only validation bundle as a safe evidence collection workflow.
+
+It does not promote Phase1 to installer-ready, hardware-validated, or daily-driver status.
+
+## Non-Claims
+
+- Not installer-ready
+- Not hardware-validated
+- Not daily-driver ready
+- No destructive disk writes
+- No real-device write path

--- a/tests/base1_real_device_readonly_bundle_report_docs.rs
+++ b/tests/base1_real_device_readonly_bundle_report_docs.rs
@@ -1,0 +1,54 @@
+use std::fs;
+
+#[test]
+fn real_device_readonly_bundle_report_exists() {
+    let doc =
+        fs::read_to_string("docs/base1/real-device/READONLY_VALIDATION_BUNDLE_REPORT.md").unwrap();
+
+    assert!(doc.contains("Base1 Real-Device Read-Only Validation Bundle Report"));
+    assert!(doc.contains("read-only bundle evidence recorded"));
+    assert!(doc.contains("Base1 real-device read-only validation bundle"));
+}
+
+#[test]
+fn real_device_readonly_bundle_report_records_evidence_chain() {
+    let doc =
+        fs::read_to_string("docs/base1/real-device/READONLY_VALIDATION_BUNDLE_REPORT.md").unwrap();
+
+    assert!(doc.contains("Base1 real-device read-only validation plan"));
+    assert!(doc.contains("Base1 real-device read-only preview script"));
+    assert!(doc.contains("Base1 real-device read-only report template"));
+    assert!(doc.contains("Base1 real-device read-only report generator"));
+    assert!(doc.contains("Base1 real-device read-only validation bundle"));
+}
+
+#[test]
+fn real_device_readonly_bundle_report_preserves_guardrails() {
+    let doc =
+        fs::read_to_string("docs/base1/real-device/READONLY_VALIDATION_BUNDLE_REPORT.md").unwrap();
+
+    assert!(doc.contains("Requires `--dry-run`"));
+    assert!(doc.contains("Requires `--target /dev/<device>`"));
+    assert!(doc.contains("Rejects non-`/dev/` targets"));
+    assert!(doc.contains("No disk writes"));
+    assert!(doc.contains("No destructive repair commands"));
+}
+
+#[test]
+fn real_device_readonly_bundle_report_preserves_non_claims() {
+    let doc =
+        fs::read_to_string("docs/base1/real-device/READONLY_VALIDATION_BUNDLE_REPORT.md").unwrap();
+
+    assert!(doc.contains("Not installer-ready"));
+    assert!(doc.contains("Not hardware-validated"));
+    assert!(doc.contains("Not daily-driver ready"));
+    assert!(doc.contains("No destructive disk writes"));
+    assert!(doc.contains("No real-device write path"));
+}
+
+#[test]
+fn base1_index_links_real_device_readonly_bundle_report() {
+    let index = fs::read_to_string("docs/base1/README.md").unwrap_or_default();
+
+    assert!(index.contains("READONLY_VALIDATION_BUNDLE_REPORT.md"));
+}


### PR DESCRIPTION
Records the Base1 real-device read-only validation bundle evidence report and README link.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test base1_real_device_readonly_bundle_report_docs
- cargo test -p phase1 --test base1_real_device_readonly_validation_bundle
- cargo test -p phase1 --test smoke

Non-claims:
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path