### PR TITLE
Add Base1 real-device read-only index

### DIFF
--- a/docs/base1/README.md
+++ b/docs/base1/README.md
@@ -63,3 +63,4 @@ Store future Base1 reports under [`validation/`](validation/) so evidence remain
 - [Base1 real-device read-only validation plan](real-device/READONLY_VALIDATION_PLAN.md)
 - [Real-device read-only report template](real-device/READONLY_REPORT_TEMPLATE.md)
 - [Real-device read-only validation bundle report](real-device/READONLY_VALIDATION_BUNDLE_REPORT.md)
+- [Real-device read-only validation index](real-device/README.md)

--- a/docs/base1/real-device/README.md
+++ b/docs/base1/real-device/README.md
@@ -1,0 +1,51 @@
+# Base1 Real-Device Read-Only Validation Index
+
+Status: read-only planning and evidence workflow index
+Date: 2026-05-10
+Scope: Base1 real-device read-only validation path
+
+## Purpose
+
+This index collects the Base1 real-device read-only validation materials.
+
+The path is intentionally non-mutating and evidence-only.
+
+## Documents
+
+- [Read-only validation plan](READONLY_VALIDATION_PLAN.md)
+- [Read-only report template](READONLY_REPORT_TEMPLATE.md)
+- [Read-only validation bundle report](READONLY_VALIDATION_BUNDLE_REPORT.md)
+
+## Scripts
+
+- `scripts/base1-real-device-readonly-preview.sh`
+- `scripts/base1-real-device-readonly-report.sh`
+- `scripts/base1-real-device-readonly-validation-bundle.sh`
+
+## Required Workflow
+
+```text
+scripts/base1-real-device-readonly-validation-bundle.sh --dry-run --target /dev/YOUR_TARGET
+```
+
+## Guardrails
+
+- Dry-run required
+- `/dev/` target required
+- No disk writes
+- No partitioning
+- No formatting
+- No installer execution
+- No firmware flashing
+- No bootloader installation
+- No automatic target selection
+- No destructive repair commands
+- No real-device write path
+
+## Non-Claims
+
+- Not installer-ready
+- Not hardware-validated
+- Not daily-driver ready
+- No destructive disk writes
+- No real-device write path

--- a/tests/base1_real_device_readonly_index_docs.rs
+++ b/tests/base1_real_device_readonly_index_docs.rs
@@ -1,0 +1,41 @@
+use std::fs;
+
+#[test]
+fn real_device_readonly_index_exists() {
+    let doc = fs::read_to_string("docs/base1/real-device/README.md").unwrap();
+    assert!(doc.contains("Base1 Real-Device Read-Only Validation Index"));
+    assert!(doc.contains("read-only planning and evidence workflow index"));
+}
+
+#[test]
+fn real_device_readonly_index_links_documents() {
+    let doc = fs::read_to_string("docs/base1/real-device/README.md").unwrap();
+    assert!(doc.contains("READONLY_VALIDATION_PLAN.md"));
+    assert!(doc.contains("READONLY_REPORT_TEMPLATE.md"));
+    assert!(doc.contains("READONLY_VALIDATION_BUNDLE_REPORT.md"));
+}
+
+#[test]
+fn real_device_readonly_index_lists_scripts() {
+    let doc = fs::read_to_string("docs/base1/real-device/README.md").unwrap();
+    assert!(doc.contains("base1-real-device-readonly-preview.sh"));
+    assert!(doc.contains("base1-real-device-readonly-report.sh"));
+    assert!(doc.contains("base1-real-device-readonly-validation-bundle.sh"));
+}
+
+#[test]
+fn real_device_readonly_index_preserves_guardrails_and_non_claims() {
+    let doc = fs::read_to_string("docs/base1/real-device/README.md").unwrap();
+    assert!(doc.contains("Dry-run required"));
+    assert!(doc.contains("No disk writes"));
+    assert!(doc.contains("No real-device write path"));
+    assert!(doc.contains("Not installer-ready"));
+    assert!(doc.contains("Not hardware-validated"));
+    assert!(doc.contains("Not daily-driver ready"));
+}
+
+#[test]
+fn base1_index_links_real_device_readonly_index() {
+    let index = fs::read_to_string("docs/base1/README.md").unwrap_or_default();
+    assert!(index.contains("real-device/README.md"));
+}


### PR DESCRIPTION
Adds the Base1 real-device read-only validation index and links it from the Base1 docs.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test base1_real_device_readonly_index_docs
- cargo test -p phase1 --test base1_real_device_readonly_bundle_report_docs
- cargo test -p phase1 --test smoke

Non-claims:
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path