### PR TITLE
Add Base1 real-device read-only runbook

### DIFF
--- a/docs/base1/real-device/README.md
+++ b/docs/base1/real-device/README.md
@@ -49,3 +49,4 @@ scripts/base1-real-device-readonly-validation-bundle.sh --dry-run --target /dev/
 - Not daily-driver ready
 - No destructive disk writes
 - No real-device write path
+- [Read-only validation runbook](RUNBOOK.md)

--- a/docs/base1/real-device/RUNBOOK.md
+++ b/docs/base1/real-device/RUNBOOK.md
@@ -1,0 +1,70 @@
+# Base1 Real-Device Read-Only Validation Runbook
+
+Status: read-only workflow runbook
+Date: 2026-05-10
+Scope: Base1 real-device read-only validation execution
+
+## Purpose
+
+Define the safe operator flow for collecting read-only real-device validation evidence.
+
+This runbook does not authorize writes, installation, formatting, partitioning, firmware flashing, bootloader installation, or repair actions.
+
+## Preconditions
+
+- Work from the current `edge/stable` branch.
+- Review the read-only validation plan.
+- Review the read-only report template.
+- Review the real-device read-only index.
+- Identify the candidate target path manually.
+- Do not rely on automatic target selection.
+
+## Required Command
+
+```text
+scripts/base1-real-device-readonly-validation-bundle.sh --dry-run --target /dev/YOUR_TARGET
+```
+
+## Operator Steps
+
+1. Confirm the target path is a `/dev/` path.
+2. Run the validation bundle with `--dry-run`.
+3. Review the printed device identity information.
+4. Copy relevant read-only output into a report based on `READONLY_REPORT_TEMPLATE.md`.
+5. Label the result as one of the approved result labels.
+6. Do not perform any write action from this workflow.
+
+## Approved Result Labels
+
+- `read-only-observed`
+- `blocked-before-device-access`
+- `operator-aborted`
+- `needs-follow-up`
+
+## Guardrails
+
+- Dry-run required
+- `/dev/` target required
+- No disk writes
+- No partitioning
+- No formatting
+- No installer execution
+- No firmware flashing
+- No bootloader installation
+- No automatic target selection
+- No destructive repair commands
+- No real-device write path
+
+## Promotion Rule
+
+This runbook may only support read-only real-device evidence collection.
+
+It does not promote Phase1 to installer-ready, hardware-validated, or daily-driver status.
+
+## Non-Claims
+
+- Not installer-ready
+- Not hardware-validated
+- Not daily-driver ready
+- No destructive disk writes
+- No real-device write path

--- a/tests/base1_real_device_readonly_runbook_docs.rs
+++ b/tests/base1_real_device_readonly_runbook_docs.rs
@@ -1,0 +1,42 @@
+use std::fs;
+
+#[test]
+fn real_device_readonly_runbook_exists() {
+    let doc = fs::read_to_string("docs/base1/real-device/RUNBOOK.md").unwrap();
+    assert!(doc.contains("Base1 Real-Device Read-Only Validation Runbook"));
+    assert!(doc.contains("read-only workflow runbook"));
+}
+
+#[test]
+fn real_device_readonly_runbook_lists_required_command() {
+    let doc = fs::read_to_string("docs/base1/real-device/RUNBOOK.md").unwrap();
+    assert!(doc.contains(
+        "base1-real-device-readonly-validation-bundle.sh --dry-run --target /dev/YOUR_TARGET"
+    ));
+}
+
+#[test]
+fn real_device_readonly_runbook_preserves_result_labels() {
+    let doc = fs::read_to_string("docs/base1/real-device/RUNBOOK.md").unwrap();
+    assert!(doc.contains("read-only-observed"));
+    assert!(doc.contains("blocked-before-device-access"));
+    assert!(doc.contains("operator-aborted"));
+    assert!(doc.contains("needs-follow-up"));
+}
+
+#[test]
+fn real_device_readonly_runbook_preserves_guardrails_and_non_claims() {
+    let doc = fs::read_to_string("docs/base1/real-device/RUNBOOK.md").unwrap();
+    assert!(doc.contains("Dry-run required"));
+    assert!(doc.contains("No disk writes"));
+    assert!(doc.contains("No real-device write path"));
+    assert!(doc.contains("Not installer-ready"));
+    assert!(doc.contains("Not hardware-validated"));
+    assert!(doc.contains("Not daily-driver ready"));
+}
+
+#[test]
+fn real_device_index_links_runbook() {
+    let index = fs::read_to_string("docs/base1/real-device/README.md").unwrap_or_default();
+    assert!(index.contains("RUNBOOK.md"));
+}


### PR DESCRIPTION
Adds the Base1 real-device read-only validation runbook and links it from the real-device index.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test base1_real_device_readonly_runbook_docs
- cargo test -p phase1 --test base1_real_device_readonly_index_docs
- cargo test -p phase1 --test smoke

Non-claims:
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path