### PR TITLE
Add Base1 real-device read-only checklist

### DIFF
--- a/docs/base1/real-device/CHECKLIST.md
+++ b/docs/base1/real-device/CHECKLIST.md
@@ -1,0 +1,75 @@
+# Base1 Real-Device Read-Only Validation Checklist
+
+Status: read-only operator checklist
+Date: 2026-05-10
+Scope: Base1 real-device read-only validation evidence collection
+
+## Purpose
+
+Provide a short operator checklist before, during, and after Base1 real-device read-only validation.
+
+This checklist does not authorize writes, installation, formatting, partitioning, firmware flashing, bootloader installation, or repair actions.
+
+## Before Running
+
+- Confirm you are on the current `edge/stable` branch.
+- Review `docs/base1/real-device/README.md`.
+- Review `docs/base1/real-device/RUNBOOK.md`.
+- Review `docs/base1/real-device/READONLY_VALIDATION_PLAN.md`.
+- Review `docs/base1/real-device/READONLY_REPORT_TEMPLATE.md`.
+- Identify the target path manually.
+- Confirm the target path starts with `/dev/`.
+- Do not use automatic target selection.
+
+## Required Command
+
+```text
+scripts/base1-real-device-readonly-validation-bundle.sh --dry-run --target /dev/YOUR_TARGET
+```
+
+## During Running
+
+- Keep `--dry-run` enabled.
+- Confirm the printed target path matches the intended `/dev/` target.
+- Confirm writes remain disabled.
+- Confirm mutation remains disabled.
+- Confirm installer remains disabled.
+- Confirm hardware validation claim remains false.
+- Confirm daily-driver claim remains false.
+
+## After Running
+
+- Copy only read-only observations into a report.
+- Use `READONLY_REPORT_TEMPLATE.md` for report structure.
+- Choose one approved result label.
+- Preserve non-claims in the report.
+- Do not run any write, repair, installer, formatting, partitioning, firmware, or bootloader command.
+
+## Approved Result Labels
+
+- `read-only-observed`
+- `blocked-before-device-access`
+- `operator-aborted`
+- `needs-follow-up`
+
+## Guardrails
+
+- Dry-run required
+- `/dev/` target required
+- No disk writes
+- No partitioning
+- No formatting
+- No installer execution
+- No firmware flashing
+- No bootloader installation
+- No automatic target selection
+- No destructive repair commands
+- No real-device write path
+
+## Non-Claims
+
+- Not installer-ready
+- Not hardware-validated
+- Not daily-driver ready
+- No destructive disk writes
+- No real-device write path

--- a/docs/base1/real-device/README.md
+++ b/docs/base1/real-device/README.md
@@ -50,3 +50,4 @@ scripts/base1-real-device-readonly-validation-bundle.sh --dry-run --target /dev/
 - No destructive disk writes
 - No real-device write path
 - [Read-only validation runbook](RUNBOOK.md)
+- [Read-only validation checklist](CHECKLIST.md)

--- a/tests/base1_real_device_readonly_checklist_docs.rs
+++ b/tests/base1_real_device_readonly_checklist_docs.rs
@@ -1,0 +1,42 @@
+use std::fs;
+
+#[test]
+fn real_device_readonly_checklist_exists() {
+    let doc = fs::read_to_string("docs/base1/real-device/CHECKLIST.md").unwrap();
+    assert!(doc.contains("Base1 Real-Device Read-Only Validation Checklist"));
+    assert!(doc.contains("read-only operator checklist"));
+}
+
+#[test]
+fn real_device_readonly_checklist_lists_required_command() {
+    let doc = fs::read_to_string("docs/base1/real-device/CHECKLIST.md").unwrap();
+    assert!(doc.contains(
+        "base1-real-device-readonly-validation-bundle.sh --dry-run --target /dev/YOUR_TARGET"
+    ));
+}
+
+#[test]
+fn real_device_readonly_checklist_preserves_steps() {
+    let doc = fs::read_to_string("docs/base1/real-device/CHECKLIST.md").unwrap();
+    assert!(doc.contains("Before Running"));
+    assert!(doc.contains("During Running"));
+    assert!(doc.contains("After Running"));
+    assert!(doc.contains("READONLY_REPORT_TEMPLATE.md"));
+}
+
+#[test]
+fn real_device_readonly_checklist_preserves_guardrails_and_non_claims() {
+    let doc = fs::read_to_string("docs/base1/real-device/CHECKLIST.md").unwrap();
+    assert!(doc.contains("Dry-run required"));
+    assert!(doc.contains("No disk writes"));
+    assert!(doc.contains("No real-device write path"));
+    assert!(doc.contains("Not installer-ready"));
+    assert!(doc.contains("Not hardware-validated"));
+    assert!(doc.contains("Not daily-driver ready"));
+}
+
+#[test]
+fn real_device_index_links_checklist() {
+    let index = fs::read_to_string("docs/base1/real-device/README.md").unwrap_or_default();
+    assert!(index.contains("CHECKLIST.md"));
+}


### PR DESCRIPTION
Adds the Base1 real-device read-only validation checklist and links it from the real-device index.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test base1_real_device_readonly_checklist_docs
- cargo test -p phase1 --test base1_real_device_readonly_runbook_docs
- cargo test -p phase1 --test smoke

Non-claims:
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path