### PR TITLE
Record Base1 real-device read-only evidence capture

### DIFF
--- a/docs/base1/real-device/README.md
+++ b/docs/base1/real-device/README.md
@@ -51,3 +51,4 @@ scripts/base1-real-device-readonly-validation-bundle.sh --dry-run --target /dev/
 - No real-device write path
 - [Read-only validation runbook](RUNBOOK.md)
 - [Read-only validation checklist](CHECKLIST.md)
+- [Read-only evidence capture report](reports/2026-05-10-readonly-evidence-capture.md)

--- a/docs/base1/real-device/reports/2026-05-10-readonly-evidence-capture.md
+++ b/docs/base1/real-device/reports/2026-05-10-readonly-evidence-capture.md
@@ -1,0 +1,79 @@
+# Base1 Real-Device Read-Only Evidence Capture Report
+
+Status: draft-read-only evidence capture
+Date: 2026-05-10
+Scope: Base1 real-device read-only evidence capture instance
+
+## Summary
+
+This report records a read-only evidence capture instance for the Base1 real-device validation path.
+
+This report is evidence-only and does not authorize writes, installation, formatting, partitioning, firmware flashing, bootloader installation, repair actions, or automatic target selection.
+
+## Target Identity
+
+- Operator:
+- Device path: /dev/YOUR_TARGET
+- Device model:
+- Device serial:
+- Device size:
+- Transport:
+- Host platform:
+- Collection date: 2026-05-10
+
+## Required Command
+
+```text
+scripts/base1-real-device-readonly-validation-bundle.sh --dry-run --target /dev/YOUR_TARGET
+```
+
+## Evidence Sources
+
+- Base1 real-device read-only validation plan
+- Base1 real-device read-only validation runbook
+- Base1 real-device read-only checklist
+- Base1 real-device read-only preview script
+- Base1 real-device read-only report generator
+- Base1 real-device read-only validation bundle
+- QEMU evidence chain
+
+## Read-Only Observations
+
+- Boot environment:
+- Firmware/platform notes:
+- Storage layout notes:
+- Device identity notes:
+- QEMU evidence reference:
+- Operator notes:
+
+## Guardrails Confirmed
+
+- Dry-run required
+- `/dev/` target required
+- No disk writes
+- No partitioning
+- No formatting
+- No installer execution
+- No firmware flashing
+- No bootloader installation
+- No automatic target selection
+- No destructive repair commands
+- No real-device write path
+
+## Result Label
+
+- needs-follow-up
+
+## Promotion Rule
+
+This report may only promote read-only evidence capture preparation unless populated with actual read-only device observations.
+
+It does not promote Phase1 to installer-ready, hardware-validated, or daily-driver status.
+
+## Non-Claims
+
+- Not installer-ready
+- Not hardware-validated
+- Not daily-driver ready
+- No destructive disk writes
+- No real-device write path

--- a/tests/base1_real_device_readonly_evidence_capture_report_docs.rs
+++ b/tests/base1_real_device_readonly_evidence_capture_report_docs.rs
@@ -1,0 +1,55 @@
+use std::fs;
+
+#[test]
+fn real_device_readonly_evidence_capture_report_exists() {
+    let doc = fs::read_to_string(
+        "docs/base1/real-device/reports/2026-05-10-readonly-evidence-capture.md",
+    )
+    .unwrap();
+    assert!(doc.contains("Base1 Real-Device Read-Only Evidence Capture Report"));
+    assert!(doc.contains("draft-read-only evidence capture"));
+}
+
+#[test]
+fn real_device_readonly_evidence_capture_report_records_required_command() {
+    let doc = fs::read_to_string(
+        "docs/base1/real-device/reports/2026-05-10-readonly-evidence-capture.md",
+    )
+    .unwrap();
+    assert!(doc.contains(
+        "base1-real-device-readonly-validation-bundle.sh --dry-run --target /dev/YOUR_TARGET"
+    ));
+}
+
+#[test]
+fn real_device_readonly_evidence_capture_report_records_sources() {
+    let doc = fs::read_to_string(
+        "docs/base1/real-device/reports/2026-05-10-readonly-evidence-capture.md",
+    )
+    .unwrap();
+    assert!(doc.contains("Base1 real-device read-only validation plan"));
+    assert!(doc.contains("Base1 real-device read-only validation runbook"));
+    assert!(doc.contains("Base1 real-device read-only checklist"));
+    assert!(doc.contains("Base1 real-device read-only validation bundle"));
+    assert!(doc.contains("QEMU evidence chain"));
+}
+
+#[test]
+fn real_device_readonly_evidence_capture_report_preserves_guardrails_and_non_claims() {
+    let doc = fs::read_to_string(
+        "docs/base1/real-device/reports/2026-05-10-readonly-evidence-capture.md",
+    )
+    .unwrap();
+    assert!(doc.contains("Dry-run required"));
+    assert!(doc.contains("No disk writes"));
+    assert!(doc.contains("No real-device write path"));
+    assert!(doc.contains("Not installer-ready"));
+    assert!(doc.contains("Not hardware-validated"));
+    assert!(doc.contains("Not daily-driver ready"));
+}
+
+#[test]
+fn real_device_index_links_evidence_capture_report() {
+    let index = fs::read_to_string("docs/base1/real-device/README.md").unwrap_or_default();
+    assert!(index.contains("2026-05-10-readonly-evidence-capture.md"));
+}


### PR DESCRIPTION
Records the Base1 real-device read-only evidence capture report instance and links it from the real-device index.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test base1_real_device_readonly_evidence_capture_report_docs
- cargo test -p phase1 --test base1_real_device_readonly_checklist_docs
- cargo test -p phase1 --test smoke

Non-claims:
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path