### PR TITLE
Add Base1 real-device read-only status summary

### DIFF
--- a/docs/base1/real-device/README.md
+++ b/docs/base1/real-device/README.md
@@ -52,3 +52,4 @@ scripts/base1-real-device-readonly-validation-bundle.sh --dry-run --target /dev/
 - [Read-only validation runbook](RUNBOOK.md)
 - [Read-only validation checklist](CHECKLIST.md)
 - [Read-only evidence capture report](reports/2026-05-10-readonly-evidence-capture.md)
+- [Read-only validation status summary](STATUS_SUMMARY.md)

--- a/docs/base1/real-device/STATUS_SUMMARY.md
+++ b/docs/base1/real-device/STATUS_SUMMARY.md
@@ -1,0 +1,45 @@
+# Base1 Real-Device Read-Only Validation Status Summary
+
+Status: read-only validation workflow assembled
+Date: 2026-05-10
+Scope: Base1 real-device read-only validation status
+
+## Summary
+
+Base1 now has a complete read-only real-device validation preparation path.
+
+The path is designed to collect evidence without writes, installation, formatting, partitioning, firmware flashing, bootloader installation, destructive repair commands, or automatic target selection.
+
+## Completed Chain
+
+- Real Phase1 initrd builder evidence
+- QEMU boot evidence
+- QEMU real Phase1 binary evidence
+- Real-device read-only validation plan
+- Real-device read-only preview script
+- Real-device read-only report template
+- Real-device read-only report generator
+- Real-device read-only validation bundle
+- Real-device read-only bundle report
+- Real-device read-only index
+- Real-device read-only runbook
+- Real-device read-only checklist
+- Real-device read-only evidence capture report instance
+
+## Primary Command
+
+```text
+scripts/base1-real-device-readonly-validation-bundle.sh --dry-run --target /dev/YOUR_TARGET
+```
+
+## Current Claim
+
+Base1 has a safe read-only real-device validation workflow prepared for evidence collection.
+
+## Non-Claims
+
+- Not installer-ready
+- Not hardware-validated
+- Not daily-driver ready
+- No destructive disk writes
+- No real-device write path

--- a/tests/base1_real_device_readonly_status_summary_docs.rs
+++ b/tests/base1_real_device_readonly_status_summary_docs.rs
@@ -1,0 +1,43 @@
+use std::fs;
+
+#[test]
+fn real_device_readonly_status_summary_exists() {
+    let doc = fs::read_to_string("docs/base1/real-device/STATUS_SUMMARY.md").unwrap();
+    assert!(doc.contains("Base1 Real-Device Read-Only Validation Status Summary"));
+    assert!(doc.contains("read-only validation workflow assembled"));
+}
+
+#[test]
+fn real_device_readonly_status_summary_records_completed_chain() {
+    let doc = fs::read_to_string("docs/base1/real-device/STATUS_SUMMARY.md").unwrap();
+    assert!(doc.contains("Real Phase1 initrd builder evidence"));
+    assert!(doc.contains("QEMU boot evidence"));
+    assert!(doc.contains("Real-device read-only validation plan"));
+    assert!(doc.contains("Real-device read-only validation bundle"));
+    assert!(doc.contains("Real-device read-only evidence capture report instance"));
+}
+
+#[test]
+fn real_device_readonly_status_summary_lists_primary_command() {
+    let doc = fs::read_to_string("docs/base1/real-device/STATUS_SUMMARY.md").unwrap();
+    assert!(doc.contains(
+        "base1-real-device-readonly-validation-bundle.sh --dry-run --target /dev/YOUR_TARGET"
+    ));
+}
+
+#[test]
+fn real_device_readonly_status_summary_preserves_current_claim_and_non_claims() {
+    let doc = fs::read_to_string("docs/base1/real-device/STATUS_SUMMARY.md").unwrap();
+    assert!(doc.contains("safe read-only real-device validation workflow prepared"));
+    assert!(doc.contains("Not installer-ready"));
+    assert!(doc.contains("Not hardware-validated"));
+    assert!(doc.contains("Not daily-driver ready"));
+    assert!(doc.contains("No destructive disk writes"));
+    assert!(doc.contains("No real-device write path"));
+}
+
+#[test]
+fn real_device_index_links_status_summary() {
+    let index = fs::read_to_string("docs/base1/real-device/README.md").unwrap_or_default();
+    assert!(index.contains("STATUS_SUMMARY.md"));
+}


### PR DESCRIPTION
Adds the Base1 real-device read-only validation status summary and links it from the real-device index.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test base1_real_device_readonly_status_summary_docs
- cargo test -p phase1 --test base1_real_device_readonly_evidence_capture_report_docs
- cargo test -p phase1 --test smoke

Non-claims:
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path