### PR TITLE
Show updater execute target branch

### DIFF
--- a/src/updater.rs
+++ b/src/updater.rs
@@ -146,6 +146,11 @@ fn guarded_execute(request: UpdateRequest) -> String {
     out.push_str("mode       : guarded host git update from inside phase1\n");
     out.push_str("host tools : enabled by boot TRUST HOST + --trust-host\n");
     out.push_str(&format!("protocol   : {}\n", UPDATE_PROTOCOL_FILE));
+    out.push_str(&format!(
+        "target     : {}/{}\n",
+        DEFAULT_REMOTE,
+        target.branch()
+    ));
     out.push_str("privacy    : command output is sanitized before display\n");
 
     if let Err(err) = ensure_git_repo() {


### PR DESCRIPTION
Adds the resolved updater target branch to execute output so live logs clearly show origin/edge/stable.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --bin phase1 updater
- cargo test -p phase1 --test smoke
- cargo build --release
- update now --trust-host live run shows target origin/edge/stable and blocks on tracked local changes before mutation

Non-claims:
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path