### PR TITLE
Record updater edge stable target evidence

### DIFF
--- a/UPDATE_PROTOCOL.md
+++ b/UPDATE_PROTOCOL.md
@@ -95,3 +95,6 @@ RELEASE_NOTES_vX.Y.Z.md
 ## Privacy promise
 
 phase1 update logic should never expose real emails, private account identifiers, tokens, cookies, SSH keys, or recovery codes. Keep examples generic and redact host command output before showing it in the terminal.
+
+## Evidence Reports
+- [2026-05-10 updater edge/stable target evidence](docs/update/2026-05-10-updater-edge-stable-target.md)

--- a/docs/update/2026-05-10-updater-edge-stable-target.md
+++ b/docs/update/2026-05-10-updater-edge-stable-target.md
@@ -1,0 +1,50 @@
+# Phase1 Updater Edge Stable Target Evidence
+
+Status: updater fix validated
+Date: 2026-05-10
+Scope: in-system updater target and build validation
+
+## Summary
+
+The in-system updater now targets `origin/edge/stable` for the latest bleeding-edge update path.
+
+The updater also prints the resolved target branch during execute mode so live logs clearly show the update target before git or cargo work continues.
+
+## Fixed Behavior
+
+- `update now --trust-host` targets `origin/edge/stable`.
+- `cargo build --release` uses the longer build timeout path.
+- Updater environment-mutating tests are serialized.
+- Execute output prints `target     : origin/edge/stable`.
+- Tracked local changes still block update execution before mutation.
+
+## Final Live Evidence
+
+```text
+phase1 updater // execute latest bleeding edge
+target     : origin/edge/stable
+git fetch           [ok]
+git checkout        [ok]
+git pull --ff-only  [ok]
+cargo build --release [ok]
+build path : target/release/phase1
+update: complete; exit and relaunch phase1 to run the updated code
+```
+
+## Validated Commands
+
+```text
+cargo fmt --all --check
+cargo test -p phase1 --bin phase1 updater
+cargo test -p phase1 --test smoke
+cargo build --release
+update now --trust-host live run
+```
+
+## Non-Claims
+
+- No installer readiness claim
+- No hardware validation claim
+- No daily-driver claim
+- No destructive disk writes
+- No real-device write path

--- a/tests/updater_edge_stable_evidence_docs.rs
+++ b/tests/updater_edge_stable_evidence_docs.rs
@@ -1,0 +1,35 @@
+use std::fs;
+
+#[test]
+fn updater_edge_stable_evidence_report_exists() {
+    let doc = fs::read_to_string("docs/update/2026-05-10-updater-edge-stable-target.md").unwrap();
+    assert!(doc.contains("Phase1 Updater Edge Stable Target Evidence"));
+    assert!(doc.contains("updater fix validated"));
+}
+
+#[test]
+fn updater_edge_stable_evidence_records_target_and_success_path() {
+    let doc = fs::read_to_string("docs/update/2026-05-10-updater-edge-stable-target.md").unwrap();
+    assert!(doc.contains("target     : origin/edge/stable"));
+    assert!(doc.contains("git fetch           [ok]"));
+    assert!(doc.contains("git checkout        [ok]"));
+    assert!(doc.contains("git pull --ff-only  [ok]"));
+    assert!(doc.contains("cargo build --release [ok]"));
+    assert!(doc.contains("update: complete"));
+}
+
+#[test]
+fn updater_edge_stable_evidence_preserves_non_claims() {
+    let doc = fs::read_to_string("docs/update/2026-05-10-updater-edge-stable-target.md").unwrap();
+    assert!(doc.contains("No installer readiness claim"));
+    assert!(doc.contains("No hardware validation claim"));
+    assert!(doc.contains("No daily-driver claim"));
+    assert!(doc.contains("No destructive disk writes"));
+    assert!(doc.contains("No real-device write path"));
+}
+
+#[test]
+fn update_protocol_links_updater_edge_stable_evidence() {
+    let protocol = fs::read_to_string("UPDATE_PROTOCOL.md").unwrap_or_default();
+    assert!(protocol.contains("2026-05-10-updater-edge-stable-target.md"));
+}


### PR DESCRIPTION
Records updater edge/stable target evidence after the in-system updater target, timeout, and output fixes.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test updater_edge_stable_evidence_docs
- cargo test -p phase1 --bin phase1 updater
- cargo test -p phase1 --test smoke
- live update now --trust-host run showed target origin/edge/stable and cargo build --release [ok]

Non-claims:
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path