### PR TITLE
Add Phase1 AI collaboration guardrails

### DIFF
--- a/docs/developer/AI_COLLABORATION_GUARDRAILS.md
+++ b/docs/developer/AI_COLLABORATION_GUARDRAILS.md
@@ -1,0 +1,133 @@
+# Phase1 AI Collaboration Guardrails
+
+Status: active developer guidance
+Scope: AI-assisted Phase1 development, reviews, agent work, and session handoffs
+
+## Purpose
+
+Prevent AI/session/agent drift during Phase1 development.
+
+These guardrails translate observed AI collaboration failure modes into Phase1 project practice. They do not weaken real safety boundaries. They compensate for over-cautious, under-specified, or attribution-drifting development behavior when the project goal is already defined.
+
+## Core Principle
+
+Phase1 development should preserve evidence, source attribution, target scale, and execution clarity.
+
+AI output must distinguish:
+
+- user instruction
+- project fact
+- observed evidence
+- agent inference
+- recommendation
+- unvalidated hypothesis
+
+Only verified user statements and committed project files may be treated as authoritative instructions.
+
+## Guardrail 1: Source Attribution
+
+Do not convert assistant interpretation into user instruction.
+
+When carrying guidance across sessions, label it by source:
+
+- user quote
+- repository file
+- test output
+- live command output
+- assistant inference
+- recommendation
+
+Unattributed guidance is treated as drift until verified.
+
+## Guardrail 2: Positive Framing
+
+Prefer direct desired behavior over negative framing.
+
+Use:
+
+- spawn focused agents when the task benefits from parallel review
+- validate architecture against the stated target scale
+- record evidence and non-claims
+
+Avoid making unwanted behavior the anchor.
+
+## Guardrail 3: Evidence Beats Benchmark Claims
+
+Published metrics, benchmarks, and agent consensus are hypotheses until Phase1 validates them.
+
+A recommendation is not promoted until a live test, repo test, or recorded evidence supports it.
+
+## Guardrail 4: Decision-Time Review
+
+Evaluate exploration at the decision point, not after the outcome looks simple.
+
+Do not label a broad investigation as excessive merely because the final answer is compact.
+
+## Guardrail 5: Target Scale Over Current Scale
+
+Architecture decisions must be evaluated against Phase1 target scale, not only the current demo state.
+
+When the target scale is stated, use that target as the review baseline.
+
+## Guardrail 6: Config Visibility
+
+Tests and validation paths that depend on configuration should expose active config values when useful.
+
+Config drift is treated as a recurring risk during migrations, update paths, model changes, and runtime wiring.
+
+## Guardrail 7: One Change, One Validation
+
+Prefer small reviewable changes.
+
+For risky implementation work:
+
+- one change
+- one validation path
+- one commit or PR scope
+
+Bundled recommendations remain hypotheses until each part is isolated and validated.
+
+## Guardrail 8: Agent Prompt Self-Sufficiency
+
+Agent prompts must include enough context to stand alone.
+
+Do not assume a fresh agent can see the parent conversation, repository status, or project instructions unless that visibility is verified.
+
+A useful agent prompt should include:
+
+- project name
+- current goal
+- relevant constraints
+- target scale
+- exact files or surfaces to inspect
+- expected output shape
+
+## Guardrail 9: Bounded Agent Output
+
+Agent tasks should be narrow enough that the result remains useful and compact.
+
+Prefer multiple focused agents over one broad agent that returns oversized, low-signal output.
+
+## Guardrail 10: Test Pass Is Not Quality Certification
+
+Passing tests mean the checked behavior passed.
+
+Do not treat green tests as proof that the whole architecture, all edge cases, or all runtime paths are correct.
+
+## Phase1 Practice
+
+For AI-assisted Phase1 work, preserve the existing project style:
+
+- record validated commands
+- record non-claims
+- separate planning from promotion
+- keep destructive operations out of evidence reports
+- prefer dry-run/read-only validation until explicit write paths are reviewed separately
+
+## Non-Claims
+
+- This document does not authorize bypassing safety boundaries.
+- This document does not promote installer readiness.
+- This document does not promote hardware validation.
+- This document does not promote daily-driver readiness.
+- This document does not authorize destructive disk writes.

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,0 +1,2 @@
+# Phase1 Developer Documentation
+- [AI collaboration guardrails](AI_COLLABORATION_GUARDRAILS.md)

--- a/tests/ai_collaboration_guardrails_docs.rs
+++ b/tests/ai_collaboration_guardrails_docs.rs
@@ -1,0 +1,44 @@
+use std::fs;
+
+#[test]
+fn ai_collaboration_guardrails_doc_exists() {
+    let doc = fs::read_to_string("docs/developer/AI_COLLABORATION_GUARDRAILS.md").unwrap();
+    assert!(doc.contains("Phase1 AI Collaboration Guardrails"));
+    assert!(doc.contains("Status: active developer guidance"));
+    assert!(doc.contains("AI-assisted Phase1 development"));
+}
+
+#[test]
+fn ai_collaboration_guardrails_separate_sources_and_inferences() {
+    let doc = fs::read_to_string("docs/developer/AI_COLLABORATION_GUARDRAILS.md").unwrap();
+    assert!(doc.contains("user instruction"));
+    assert!(doc.contains("project fact"));
+    assert!(doc.contains("observed evidence"));
+    assert!(doc.contains("agent inference"));
+    assert!(doc.contains("recommendation"));
+    assert!(doc.contains("unvalidated hypothesis"));
+}
+
+#[test]
+fn ai_collaboration_guardrails_preserve_phase1_practice() {
+    let doc = fs::read_to_string("docs/developer/AI_COLLABORATION_GUARDRAILS.md").unwrap();
+    assert!(doc.contains("record validated commands"));
+    assert!(doc.contains("record non-claims"));
+    assert!(doc.contains("separate planning from promotion"));
+    assert!(doc.contains("prefer dry-run/read-only validation"));
+}
+
+#[test]
+fn ai_collaboration_guardrails_include_agent_and_config_rules() {
+    let doc = fs::read_to_string("docs/developer/AI_COLLABORATION_GUARDRAILS.md").unwrap();
+    assert!(doc.contains("Config Visibility"));
+    assert!(doc.contains("Agent Prompt Self-Sufficiency"));
+    assert!(doc.contains("Bounded Agent Output"));
+    assert!(doc.contains("One Change, One Validation"));
+}
+
+#[test]
+fn developer_index_links_ai_collaboration_guardrails() {
+    let index = fs::read_to_string("docs/developer/README.md").unwrap_or_default();
+    assert!(index.contains("AI_COLLABORATION_GUARDRAILS.md"));
+}


### PR DESCRIPTION
Adds neutral Phase1 AI collaboration guardrails translated from observed AI/session/agent drift patterns.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test ai_collaboration_guardrails_docs
- cargo test -p phase1 --test smoke

Non-claims:
- no safety-boundary bypass
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes