### PR TITLE
Add Base1 real-device read-only doctor

### DIFF
--- a/scripts/base1-real-device-readonly-doctor.sh
+++ b/scripts/base1-real-device-readonly-doctor.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -eu
+
+usage() {
+  echo "usage: scripts/base1-real-device-readonly-doctor.sh --dry-run"
+}
+
+dry_run=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) dry_run=1 ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "error: unknown argument: $arg" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [ "$dry_run" -ne 1 ]; then
+  echo "error: --dry-run is required" >&2
+  usage >&2
+  exit 2
+fi
+
+echo "Base1 real-device read-only doctor"
+echo "status: dry-run only"
+echo "scope: documentation, scripts, and local tool availability only"
+echo "writes: disabled"
+echo "mutation: disabled"
+echo "installer: disabled"
+echo "hardware-validation-claim: false"
+echo "daily-driver-claim: false"
+echo
+
+check_file() {
+  path="$1"
+  if [ -f "$path" ]; then
+    echo "- $path: present"
+  else
+    echo "- $path: missing"
+  fi
+}
+
+check_executable() {
+  path="$1"
+  if [ -x "$path" ]; then
+    echo "- $path: executable"
+  elif [ -f "$path" ]; then
+    echo "- $path: present-not-executable"
+  else
+    echo "- $path: missing"
+  fi
+}
+
+check_tool() {
+  tool="$1"
+  if command -v "$tool" >/dev/null 2>&1; then
+    echo "- $tool: available"
+  else
+    echo "- $tool: unavailable"
+  fi
+}
+
+echo "required docs:"
+check_file docs/base1/real-device/README.md
+check_file docs/base1/real-device/READONLY_VALIDATION_PLAN.md
+check_file docs/base1/real-device/READONLY_REPORT_TEMPLATE.md
+check_file docs/base1/real-device/READONLY_VALIDATION_BUNDLE_REPORT.md
+check_file docs/base1/real-device/RUNBOOK.md
+check_file docs/base1/real-device/CHECKLIST.md
+check_file docs/base1/real-device/STATUS_SUMMARY.md
+echo
+
+echo "required scripts:"
+check_executable scripts/base1-real-device-readonly-preview.sh
+check_executable scripts/base1-real-device-readonly-report.sh
+check_executable scripts/base1-real-device-readonly-validation-bundle.sh
+echo
+
+echo "local tools:"
+check_tool git
+check_tool cargo
+check_tool uname
+check_tool sed
+check_tool lsblk
+check_tool diskutil
+echo
+
+echo "non-claims:"
+echo "- not installer-ready"
+echo "- not hardware-validated"
+echo "- not daily-driver ready"
+echo "- no destructive disk writes"
+echo "- no real-device write path"

--- a/tests/base1_real_device_readonly_doctor_script.rs
+++ b/tests/base1_real_device_readonly_doctor_script.rs
@@ -1,0 +1,67 @@
+use std::fs;
+use std::process::Command;
+
+#[test]
+fn real_device_readonly_doctor_script_exists() {
+    let script = fs::read_to_string("scripts/base1-real-device-readonly-doctor.sh").unwrap();
+    assert!(script.contains("Base1 real-device read-only doctor"));
+    assert!(script.contains("--dry-run is required"));
+    assert!(script.contains("writes: disabled"));
+    assert!(script.contains("mutation: disabled"));
+    assert!(script.contains("installer: disabled"));
+}
+
+#[test]
+fn real_device_readonly_doctor_requires_dry_run() {
+    let output = Command::new("bash")
+        .arg("scripts/base1-real-device-readonly-doctor.sh")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--dry-run is required"));
+}
+
+#[test]
+fn real_device_readonly_doctor_reports_safe_surface() {
+    let output = Command::new("bash")
+        .args(["scripts/base1-real-device-readonly-doctor.sh", "--dry-run"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Base1 real-device read-only doctor"));
+    assert!(stdout.contains("status: dry-run only"));
+    assert!(stdout.contains("scope: documentation, scripts, and local tool availability only"));
+    assert!(stdout.contains("READONLY_VALIDATION_PLAN.md: present"));
+    assert!(stdout.contains("READONLY_REPORT_TEMPLATE.md: present"));
+    assert!(stdout.contains("base1-real-device-readonly-preview.sh"));
+    assert!(stdout.contains("base1-real-device-readonly-report.sh"));
+    assert!(stdout.contains("base1-real-device-readonly-validation-bundle.sh"));
+    assert!(stdout.contains("not installer-ready"));
+    assert!(stdout.contains("not hardware-validated"));
+    assert!(stdout.contains("not daily-driver ready"));
+    assert!(stdout.contains("no destructive disk writes"));
+    assert!(stdout.contains("no real-device write path"));
+}
+
+#[test]
+fn real_device_readonly_doctor_avoids_mutating_tools() {
+    let script = fs::read_to_string("scripts/base1-real-device-readonly-doctor.sh").unwrap();
+    for forbidden in [
+        "mkfs",
+        "dd if=",
+        "diskutil eraseDisk",
+        "diskutil partitionDisk",
+        "parted",
+        "fdisk",
+        "sgdisk",
+    ] {
+        assert!(
+            !script.contains(forbidden),
+            "found forbidden mutating token: {forbidden}"
+        );
+    }
+}


### PR DESCRIPTION
Adds a dry-run-only Base1 real-device read-only doctor that checks required docs, scripts, and local tool availability without touching target devices.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test base1_real_device_readonly_doctor_script
- cargo test -p phase1 --test base1_real_device_readonly_validation_bundle
- cargo test -p phase1 --test smoke

Non-claims:
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path