### PR TITLE
Link Base1 real-device read-only doctor

### DIFF
--- a/docs/base1/real-device/README.md
+++ b/docs/base1/real-device/README.md
@@ -53,3 +53,4 @@ scripts/base1-real-device-readonly-validation-bundle.sh --dry-run --target /dev/
 - [Read-only validation checklist](CHECKLIST.md)
 - [Read-only evidence capture report](reports/2026-05-10-readonly-evidence-capture.md)
 - [Read-only validation status summary](STATUS_SUMMARY.md)
+- [Read-only doctor script](../../../scripts/base1-real-device-readonly-doctor.sh)

--- a/docs/base1/real-device/STATUS_SUMMARY.md
+++ b/docs/base1/real-device/STATUS_SUMMARY.md
@@ -25,6 +25,7 @@ The path is designed to collect evidence without writes, installation, formattin
 - Real-device read-only runbook
 - Real-device read-only checklist
 - Real-device read-only evidence capture report instance
+- Real-device read-only doctor
 
 ## Primary Command
 

--- a/tests/base1_real_device_readonly_doctor_index_docs.rs
+++ b/tests/base1_real_device_readonly_doctor_index_docs.rs
@@ -1,0 +1,23 @@
+use std::fs;
+
+#[test]
+fn real_device_index_links_readonly_doctor() {
+    let index = fs::read_to_string("docs/base1/real-device/README.md").unwrap_or_default();
+    assert!(index.contains("base1-real-device-readonly-doctor.sh"));
+}
+
+#[test]
+fn real_device_status_summary_lists_readonly_doctor() {
+    let summary =
+        fs::read_to_string("docs/base1/real-device/STATUS_SUMMARY.md").unwrap_or_default();
+    assert!(summary.contains("Real-device read-only doctor"));
+}
+
+#[test]
+fn readonly_doctor_script_still_exists_and_is_guarded() {
+    let script = fs::read_to_string("scripts/base1-real-device-readonly-doctor.sh").unwrap();
+    assert!(script.contains("Base1 real-device read-only doctor"));
+    assert!(script.contains("--dry-run is required"));
+    assert!(script.contains("writes: disabled"));
+    assert!(script.contains("installer: disabled"));
+}


### PR DESCRIPTION
Links the Base1 real-device read-only doctor from the real-device index and status summary.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test base1_real_device_readonly_doctor_index_docs
- cargo test -p phase1 --test base1_real_device_readonly_doctor_script
- cargo test -p phase1 --test smoke

Non-claims:
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path