### PR TITLE
Run Base1 read-only doctor in validation bundle

### DIFF
--- a/scripts/base1-real-device-readonly-validation-bundle.sh
+++ b/scripts/base1-real-device-readonly-validation-bundle.sh
@@ -82,6 +82,10 @@ test -f docs/base1/real-device/READONLY_REPORT_TEMPLATE.md
 echo "- READONLY_REPORT_TEMPLATE.md: present"
 echo
 
+echo "running read-only doctor:"
+scripts/base1-real-device-readonly-doctor.sh --dry-run | sed -n '1,80p'
+echo
+
 echo "running read-only preview:"
 scripts/base1-real-device-readonly-preview.sh --dry-run --target "$target" | sed -n '1,40p'
 echo

--- a/tests/base1_real_device_readonly_validation_bundle.rs
+++ b/tests/base1_real_device_readonly_validation_bundle.rs
@@ -67,6 +67,9 @@ fn real_device_readonly_validation_bundle_runs_non_mutating_previews() {
     assert!(stdout.contains("daily-driver-claim: false"));
     assert!(stdout.contains("READONLY_VALIDATION_PLAN.md: present"));
     assert!(stdout.contains("READONLY_REPORT_TEMPLATE.md: present"));
+    assert!(stdout.contains("running read-only doctor:"));
+    assert!(stdout.contains("Base1 real-device read-only doctor"));
+    assert!(stdout.contains("scope: documentation, scripts, and local tool availability only"));
     assert!(stdout.contains("Base1 real-device read-only preview"));
     assert!(stdout.contains("Base1 Real-Device Read-Only Validation Report"));
     assert!(stdout.contains("not installer-ready"));


### PR DESCRIPTION
Updates the Base1 real-device read-only validation bundle to run the read-only doctor before preview and report generation.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test base1_real_device_readonly_validation_bundle
- cargo test -p phase1 --test base1_real_device_readonly_doctor_script
- cargo test -p phase1 --test smoke
- scripts/base1-real-device-readonly-validation-bundle.sh --dry-run --target /dev/disk-test

Non-claims:
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path