### PR TITLE
Add Base1 documentation map

### DIFF
--- a/docs/base1/DOCUMENTATION_MAP.md
+++ b/docs/base1/DOCUMENTATION_MAP.md
@@ -1,0 +1,49 @@
+# Base1 Documentation Map
+
+Status: active documentation index
+Scope: Base1 docs, scripts, validation reports, and read-only evidence paths
+
+## Purpose
+
+This map organizes the Base1 documentation surface without moving files.
+
+It is a navigation aid only. It does not change runtime behavior, validation status, installer readiness, or hardware claims.
+
+## Core Base1 Entry Points
+
+- [Base1 index](README.md)
+- [Base1 validation runbook](VALIDATION_RUNBOOK.md)
+- [Base1 validation report template](VALIDATION_REPORT_TEMPLATE.md)
+- [Base1 validation reports index](VALIDATION_REPORTS.md)
+
+## Real-Device Read-Only Track
+
+- [Real-device read-only index](real-device/README.md)
+- [Read-only validation plan](real-device/READONLY_VALIDATION_PLAN.md)
+- [Read-only report template](real-device/READONLY_REPORT_TEMPLATE.md)
+- [Read-only validation bundle report](real-device/READONLY_VALIDATION_BUNDLE_REPORT.md)
+- [Read-only runbook](real-device/RUNBOOK.md)
+- [Read-only checklist](real-device/CHECKLIST.md)
+- [Read-only status summary](real-device/STATUS_SUMMARY.md)
+- [Read-only evidence capture report](real-device/reports/2026-05-10-readonly-evidence-capture.md)
+
+## Real-Device Read-Only Scripts
+
+- scripts/base1-real-device-readonly-preview.sh
+- scripts/base1-real-device-readonly-report.sh
+- scripts/base1-real-device-readonly-validation-bundle.sh
+- scripts/base1-real-device-readonly-doctor.sh
+
+## Promotion Rule
+
+This map may only improve discoverability.
+
+It does not promote Base1 to installer-ready, hardware-validated, or daily-driver status.
+
+## Non-Claims
+
+- Not installer-ready
+- Not hardware-validated
+- Not daily-driver ready
+- No destructive disk writes
+- No real-device write path

--- a/docs/base1/README.md
+++ b/docs/base1/README.md
@@ -64,3 +64,4 @@ Store future Base1 reports under [`validation/`](validation/) so evidence remain
 - [Real-device read-only report template](real-device/READONLY_REPORT_TEMPLATE.md)
 - [Real-device read-only validation bundle report](real-device/READONLY_VALIDATION_BUNDLE_REPORT.md)
 - [Real-device read-only validation index](real-device/README.md)
+- [Documentation map](DOCUMENTATION_MAP.md)

--- a/tests/base1_documentation_map_docs.rs
+++ b/tests/base1_documentation_map_docs.rs
@@ -1,0 +1,54 @@
+use std::fs;
+
+#[test]
+fn base1_documentation_map_exists() {
+    let doc = fs::read_to_string("docs/base1/DOCUMENTATION_MAP.md").unwrap();
+    assert!(doc.contains("Base1 Documentation Map"));
+    assert!(doc.contains("Status: active documentation index"));
+    assert!(doc.contains("without moving files"));
+}
+
+#[test]
+fn base1_documentation_map_links_core_entry_points() {
+    let doc = fs::read_to_string("docs/base1/DOCUMENTATION_MAP.md").unwrap();
+    assert!(doc.contains("README.md"));
+    assert!(doc.contains("VALIDATION_RUNBOOK.md"));
+    assert!(doc.contains("VALIDATION_REPORT_TEMPLATE.md"));
+    assert!(doc.contains("VALIDATION_REPORTS.md"));
+}
+
+#[test]
+fn base1_documentation_map_links_real_device_track() {
+    let doc = fs::read_to_string("docs/base1/DOCUMENTATION_MAP.md").unwrap();
+    assert!(doc.contains("real-device/README.md"));
+    assert!(doc.contains("real-device/READONLY_VALIDATION_PLAN.md"));
+    assert!(doc.contains("real-device/READONLY_REPORT_TEMPLATE.md"));
+    assert!(doc.contains("real-device/RUNBOOK.md"));
+    assert!(doc.contains("real-device/CHECKLIST.md"));
+    assert!(doc.contains("real-device/STATUS_SUMMARY.md"));
+}
+
+#[test]
+fn base1_documentation_map_lists_readonly_scripts() {
+    let doc = fs::read_to_string("docs/base1/DOCUMENTATION_MAP.md").unwrap();
+    assert!(doc.contains("base1-real-device-readonly-preview.sh"));
+    assert!(doc.contains("base1-real-device-readonly-report.sh"));
+    assert!(doc.contains("base1-real-device-readonly-validation-bundle.sh"));
+    assert!(doc.contains("base1-real-device-readonly-doctor.sh"));
+}
+
+#[test]
+fn base1_documentation_map_preserves_non_claims() {
+    let doc = fs::read_to_string("docs/base1/DOCUMENTATION_MAP.md").unwrap();
+    assert!(doc.contains("Not installer-ready"));
+    assert!(doc.contains("Not hardware-validated"));
+    assert!(doc.contains("Not daily-driver ready"));
+    assert!(doc.contains("No destructive disk writes"));
+    assert!(doc.contains("No real-device write path"));
+}
+
+#[test]
+fn base1_index_links_documentation_map() {
+    let index = fs::read_to_string("docs/base1/README.md").unwrap_or_default();
+    assert!(index.contains("DOCUMENTATION_MAP.md"));
+}


### PR DESCRIPTION
Adds a Base1 documentation map to improve discoverability without moving files.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test base1_documentation_map_docs
- cargo test -p phase1 --test base1_real_device_readonly_doctor_index_docs
- cargo test -p phase1 --test smoke

Non-claims:
- no file moves
- no runtime behavior change
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path