### PR TITLE
Add Base1 documentation organization plan

### DIFF
--- a/docs/base1/DOCUMENTATION_ORGANIZATION_PLAN.md
+++ b/docs/base1/DOCUMENTATION_ORGANIZATION_PLAN.md
@@ -1,0 +1,59 @@
+# Base1 Documentation Organization Plan
+
+Status: proposed organization plan
+Scope: Base1 markdown organization only
+
+## Purpose
+
+Define a safer documentation layout for Base1 without moving files in this PR.
+
+This plan exists so future file moves can happen one group at a time with tests and link updates.
+
+## Current Rule
+
+Do not move existing Base1 markdown files unless the same PR updates every link, test, and index reference.
+
+## Proposed Groups
+
+### Core
+- README.md
+- DOCUMENTATION_MAP.md
+- VALIDATION_RUNBOOK.md
+- VALIDATION_REPORT_TEMPLATE.md
+- VALIDATION_REPORTS.md
+
+### Real-Device Read-Only
+- real-device/README.md
+- real-device/READONLY_VALIDATION_PLAN.md
+- real-device/READONLY_REPORT_TEMPLATE.md
+- real-device/READONLY_VALIDATION_BUNDLE_REPORT.md
+- real-device/RUNBOOK.md
+- real-device/CHECKLIST.md
+- real-device/STATUS_SUMMARY.md
+- real-device/reports/*.md
+
+### Future Candidate Folders
+- core/
+- validation/
+- real-device/
+- real-device/reports/
+- design/
+- archive/
+
+## Migration Rules
+
+- Move one document group per PR.
+- Keep or update every inbound link in the same PR.
+- Add or update tests for every moved document.
+- Preserve non-claims and promotion rules.
+- Prefer indexes before file movement.
+
+## Non-Claims
+
+- No file moves in this plan.
+- No runtime behavior change.
+- Not installer-ready.
+- Not hardware-validated.
+- Not daily-driver ready.
+- No destructive disk writes.
+- No real-device write path.

--- a/docs/base1/README.md
+++ b/docs/base1/README.md
@@ -65,3 +65,4 @@ Store future Base1 reports under [`validation/`](validation/) so evidence remain
 - [Real-device read-only validation bundle report](real-device/READONLY_VALIDATION_BUNDLE_REPORT.md)
 - [Real-device read-only validation index](real-device/README.md)
 - [Documentation map](DOCUMENTATION_MAP.md)
+- [Documentation organization plan](DOCUMENTATION_ORGANIZATION_PLAN.md)

--- a/tests/base1_documentation_organization_plan_docs.rs
+++ b/tests/base1_documentation_organization_plan_docs.rs
@@ -1,0 +1,44 @@
+use std::fs;
+
+#[test]
+fn base1_documentation_organization_plan_exists() {
+    let doc = fs::read_to_string("docs/base1/DOCUMENTATION_ORGANIZATION_PLAN.md").unwrap();
+    assert!(doc.contains("Base1 Documentation Organization Plan"));
+    assert!(doc.contains("Status: proposed organization plan"));
+    assert!(doc.contains("without moving files in this PR"));
+}
+
+#[test]
+fn base1_documentation_organization_plan_preserves_move_rules() {
+    let doc = fs::read_to_string("docs/base1/DOCUMENTATION_ORGANIZATION_PLAN.md").unwrap();
+    assert!(doc.contains("Do not move existing Base1 markdown files"));
+    assert!(doc.contains("Move one document group per PR"));
+    assert!(doc.contains("Keep or update every inbound link"));
+    assert!(doc.contains("Add or update tests for every moved document"));
+}
+
+#[test]
+fn base1_documentation_organization_plan_lists_groups() {
+    let doc = fs::read_to_string("docs/base1/DOCUMENTATION_ORGANIZATION_PLAN.md").unwrap();
+    assert!(doc.contains("### Core"));
+    assert!(doc.contains("### Real-Device Read-Only"));
+    assert!(doc.contains("### Future Candidate Folders"));
+    assert!(doc.contains("real-device/reports/*.md"));
+}
+
+#[test]
+fn base1_documentation_organization_plan_preserves_non_claims() {
+    let doc = fs::read_to_string("docs/base1/DOCUMENTATION_ORGANIZATION_PLAN.md").unwrap();
+    assert!(doc.contains("No file moves in this plan"));
+    assert!(doc.contains("No runtime behavior change"));
+    assert!(doc.contains("Not installer-ready"));
+    assert!(doc.contains("Not hardware-validated"));
+    assert!(doc.contains("No destructive disk writes"));
+    assert!(doc.contains("No real-device write path"));
+}
+
+#[test]
+fn base1_index_links_documentation_organization_plan() {
+    let index = fs::read_to_string("docs/base1/README.md").unwrap_or_default();
+    assert!(index.contains("DOCUMENTATION_ORGANIZATION_PLAN.md"));
+}


### PR DESCRIPTION
Adds a Base1 documentation organization plan for safer future markdown cleanup without moving files in this PR.

Validated:
- cargo fmt --all --check
- cargo test -p phase1 --test base1_documentation_organization_plan_docs
- cargo test -p phase1 --test base1_documentation_map_docs
- cargo test -p phase1 --test smoke

Non-claims:
- no file moves
- no runtime behavior change
- no installer readiness claim
- no hardware validation claim
- no daily-driver claim
- no destructive disk writes
- no real-device write path