### PR TITLE
Refresh Phase1 wiki for v6, Base1, and Fyr

### DIFF
--- a/docs/wiki/01-Quick-Start.md
+++ b/docs/wiki/01-Quick-Start.md
@@ -1,16 +1,19 @@
 # Quick Start
 
-![Edge](https://img.shields.io/badge/edge-v3.10.9--dev-00d8ff) ![Stable](https://img.shields.io/badge/stable-v3.10.7-39ff88)
+![Edge](https://img.shields.io/badge/edge-v6.0.0-00d8ff) ![Stable](https://img.shields.io/badge/stable-v5.0.0-39ff88) ![Safe Mode](https://img.shields.io/badge/safe%20mode-default%20on-39ff88)
 
-This page gets a new user from clone to first commands.
+This page gets a new user from clone to first commands without weakening Phase1's default safety posture.
 
 ## Requirements
 
-- Rust toolchain with Cargo
 - Git
 - A terminal that supports ANSI output
+- Rust toolchain with Cargo for native builds and tests
+- macOS, Linux, or another environment capable of running Rust CLI tools
 
 ## Install and run
+
+Fresh clone, simplest launch:
 
 > [!TIP]
 > TRY THIS
@@ -18,66 +21,144 @@ This page gets a new user from clone to first commands.
 > ```bash
 > git clone https://github.com/Bryforge/phase1.git
 > cd phase1
-> cargo run
+> sh phase1
 > ```
 
-At the boot screen, press `1` or `Enter` to enter the shell.
+After the launcher is executable, this also works:
 
-## First session
+```bash
+./phase1
+```
+
+Rust-native launch remains available:
+
+```bash
+cargo run
+```
+
+At the boot selector, press `1` or `Enter` to enter the shell.
+
+## Optional local terminal command
+
+Install a local `phase1` command on macOS/Linux:
+
+```bash
+sh scripts/install-phase1-command.sh
+phase1
+```
+
+## First host checks
+
+Run these from the repository root:
+
+```bash
+sh phase1 version
+sh phase1 doctor
+sh phase1 selftest
+```
+
+## First Phase1 session
 
 > [!TIP]
 > TRY THIS INSIDE PHASE1
 >
 > ```text
 > help
+> help ui
+> help flows
 > cat readme.txt
+> wiki
+> wiki-quick
 > version
 > version --compare
 > security
+> capabilities
 > sysinfo
 > roadmap
 > ```
 
+You should learn:
+
+- which Phase1 version is running
+- whether safe mode is active
+- whether host trust is enabled
+- where the built-in guide and wiki live
+- which commands require host access
+
+## Create and edit a file
+
+```text
+ned notes.txt
+```
+
+Or use AVIM:
+
+```text
+avim hello.fyr
+```
+
+Inside AVIM:
+
+```text
+i                                      enter INSERT mode
+fn main() -> i32 { print("hi"); return 0; }
+Esc                                    return to NORMAL mode
+:wq                                    save and quit
+```
+
+Then run it:
+
+```text
+fyr run hello.fyr
+```
+
+Expected output:
+
+```text
+hi
+```
+
 ## Build a release binary
 
-> [!TIP]
-> TRY THIS
->
-> ```bash
-> cargo build --release
-> ./target/release/phase1
-> ```
+```bash
+cargo build --release
+./target/release/phase1
+```
 
 ## Run validation
 
-> [!TIP]
-> TRY THIS BEFORE PUSHING
->
-> ```bash
-> cargo fmt --all -- --check
-> cargo check --all-targets
-> cargo test --all-targets
-> ```
+Run the quick repository gate before ordinary pushes:
+
+```bash
+sh scripts/quality-check.sh quick
+```
+
+Run Rust-specific validation when changing source code:
+
+```bash
+cargo fmt --all -- --check
+cargo check --all-targets
+cargo clippy --all-targets -- -D warnings
+cargo test --all-targets
+```
+
+Run focused documentation or Base1 gates when changing those areas:
+
+```bash
+sh scripts/quality-check.sh base1-docs
+sh scripts/quality-check.sh security-crypto-docs
+```
 
 ## Enable local language runtimes
 
-Phase1 blocks host-backed tools by default. To run Python, Rust, C, browser fetches, plugins, or host network inspection, use the runtime launcher:
-
-> [!TIP]
-> TRY THIS
->
-> ```bash
-> chmod +x scripts/phase1-runtimes.sh
-> ./scripts/phase1-runtimes.sh
-> ```
-
-The launcher sets:
+Phase1 blocks host-backed tools by default. Python, Rust host execution, C, browser fetches, plugins, Git helpers, and host network inspection require explicit trust.
 
 ```bash
-PHASE1_SAFE_MODE=0
-PHASE1_ALLOW_HOST_TOOLS=1
-PHASE1_BLEEDING_EDGE=1
+chmod +x scripts/phase1-runtimes.sh
+./scripts/phase1-runtimes.sh
 ```
+
+The launcher sets runtime-oriented host gates for local development. Only use it on a machine and repository state you trust.
 
 ## Manual boot equivalent
 
@@ -98,30 +179,6 @@ ping example.com
 lang support
 ```
 
-## Create and edit a file
-
-> [!TIP]
-> TRY THIS
->
-> ```text
-> avim hello.py
-> ```
-
-Inside AVIM:
-
-```text
-i                 enter INSERT mode
-print("hello")    type a line
-Esc               return to NORMAL mode
-:wq               save and quit
-```
-
-Then run it when host runtimes are enabled:
-
-```text
-py hello.py
-```
-
 ## Read the built-in guide
 
 Every fresh boot creates:
@@ -136,4 +193,11 @@ Read it with:
 cat readme.txt
 ```
 
-The in-system guide reflects the exact package version currently booted.
+The in-system guide reflects the package version currently booted.
+
+## Next pages
+
+- Read [Version Guide](02-Version-Guide.md) to understand edge, stable, and compatibility labels.
+- Read [Boot Modes and Security](03-Boot-Modes-and-Security.md) before enabling host-backed workflows.
+- Read [Fyr Native Language](14-Fyr-Native-Language.md) for Phase1-native scripting.
+- Read [Base1 OS Track](13-Base1-OS-Track.md) for boot, recovery, and hardware-validation planning.

--- a/docs/wiki/02-Version-Guide.md
+++ b/docs/wiki/02-Version-Guide.md
@@ -1,19 +1,20 @@
 # Version Guide
 
-![Edge](https://img.shields.io/badge/edge-v4.1.0--dev-00d8ff) ![Stable](https://img.shields.io/badge/stable-v4.0.0-39ff88) ![Previous Stable](https://img.shields.io/badge/previous%20stable-v3.10.9-7f8cff) ![Base](https://img.shields.io/badge/compatibility-v3.6.0-7f8cff)
+![Edge](https://img.shields.io/badge/edge-v6.0.0-00d8ff) ![Stable](https://img.shields.io/badge/stable-v5.0.0-39ff88) ![Previous Stable](https://img.shields.io/badge/previous%20stable-v4.4.0-7f8cff) ![Compatibility](https://img.shields.io/badge/compatibility-v3.6.0-7f8cff)
 
-Phase1 has four version concepts that users may see.
+Phase1 uses several version labels because the project has a stable release line, an active edge line, historical compatibility references, and a long-term Base1 foundation track.
 
 | Name | Current value | Meaning |
 | --- | --- | --- |
-| Edge build | `v4.1.0-dev` | Bleeding-edge development line beyond v4.0.0 |
-| Stable release | `v4.0.0` | Current stable release point and tag target |
-| Previous stable | `v3.10.9` | Previous stable reference line |
-| Compatibility base | `v3.6.0` | Historical stable base used by compatibility comparisons |
+| Edge build | `v6.0.0` | Active development line on `edge/stable`. Use it for current wiki, v6 UI/help, Base1 planning, Fyr work, and validation. |
+| Stable release | `v5.0.0` | Current stable base for release-qualified public references. |
+| Previous stable | `v4.4.0` | Previous stable line for compatibility checks and historical comparison. |
+| Compatibility base | `v3.6.0` | Older comparison base retained for long-running compatibility language. |
+| Base1 | `foundation` | Host-foundation track for boot, recovery, storage, rollback, installer, and hardware validation work. |
 
 ## Runtime version behavior
 
-The package version is the booted Phase1 version. Runtime surfaces dynamically reflect `CARGO_PKG_VERSION`.
+The package version is the booted Phase1 version. Runtime surfaces should reflect `CARGO_PKG_VERSION`.
 
 ```text
 boot card version        v<CARGO_PKG_VERSION>
@@ -38,36 +39,45 @@ exit / shutdown banner    shutdown: phase1 <CARGO_PKG_VERSION>
 > cat readme.txt
 > ```
 
-## Edge release policy
+## Edge policy
 
-Use an edge build when the version ends in `-dev` or when new behavior is still being validated.
+Use the edge line for active development and documentation that reflects the current default branch.
 
-Current edge example:
-
-```text
-v4.1.0-dev
-```
-
-Edge builds are best for testing post-v4.0.0 work, including terminal behavior, editor improvements, website changes, Base1 integration, guarded AI/plugin experiments, and documentation changes that follow active development.
-
-## Stable release policy
-
-Use a stable release when the version has no `-dev` suffix and has passed the full validation suite.
-
-Current stable release point:
+Current edge line:
 
 ```text
-v4.0.0
+v6.0.0
 ```
 
-Stable builds are best for demos, README screenshots, public posts, tagged release notes, and normal users.
+Current active branch:
+
+```text
+edge/stable
+```
+
+Edge work may include UI improvements, help-system work, website polish, wiki updates, Base1 plans, recovery evidence, storage/rollback dry-runs, Fyr growth, and guarded host-integration experiments.
+
+> [!IMPORTANT]
+> Edge documentation must label experimental, host-backed, or future work clearly. Do not convert roadmap goals into release claims.
+
+## Stable policy
+
+Use stable references for public demos, release notes, screenshots, and safer checkpoints.
+
+Current stable base:
+
+```text
+v5.0.0
+```
+
+Stable builds should not rely on unsupported edge-only behavior.
 
 ## Previous stable line
 
-The previous stable reference line remains:
+The previous stable reference line is:
 
 ```text
-v3.10.9
+v4.4.0
 ```
 
 Use this when comparing the current stable behavior against the earlier stable series.
@@ -81,6 +91,18 @@ v3.6.0
 ```
 
 It is used for historical comparison and compatibility language.
+
+## Base1 foundation status
+
+Base1 is not a finished hardened OS. It is the host-foundation track that keeps boot, recovery, installer, rollback, storage, and hardware-validation claims separate from the Phase1 virtual OS console.
+
+Current Base1 status:
+
+```text
+foundation
+```
+
+Start with [Base1 OS Track](13-Base1-OS-Track.md) before writing boot or recovery claims.
 
 ## Check the current package version
 
@@ -97,33 +119,36 @@ version
 cat /proc/version
 ```
 
-## Prepare the v4.0.0 tag
-
-`release/v4.0.0` preserves the stable release point. Validate it before tagging:
+## Continue edge work
 
 ```bash
-git checkout release/v4.0.0
+git fetch origin
+git checkout edge/stable
+cargo metadata --no-deps --format-version 1 | grep '"version"'
+sh scripts/quality-check.sh quick
+```
+
+Expected package version on the current edge line:
+
+```text
+6.0.0
+```
+
+## Release-readiness rule
+
+Before promoting or publishing a release-facing change, update version-sensitive docs and run validation:
+
+```bash
 cargo fmt --all -- --check
 cargo check --all-targets
 cargo clippy --all-targets -- -D warnings
 cargo test --all-targets
-cargo audit
-cargo deny check
-git tag v4.0.0
-git push origin v4.0.0
+sh scripts/quality-check.sh quick
 ```
 
-## Continue bleeding-edge work
-
-`edge/v4.1.0-dev` is the post-v4.0.0 development line:
+Optional release/security checks:
 
 ```bash
-git checkout edge/v4.1.0-dev
-cargo metadata --no-deps --format-version 1 | grep '"version"'
-```
-
-Expected package version on the edge branch:
-
-```text
-4.1.0-dev
+cargo audit
+cargo deny check
 ```

--- a/docs/wiki/08-Updates-Releases-and-Validation.md
+++ b/docs/wiki/08-Updates-Releases-and-Validation.md
@@ -1,63 +1,74 @@
 # Updates, Releases, and Validation
 
-![Edge](https://img.shields.io/badge/edge-v4.1.0--dev-00d8ff) ![Stable](https://img.shields.io/badge/stable-v4.0.0-39ff88) ![Validation](https://img.shields.io/badge/tests-required-39ff88)
+![Edge](https://img.shields.io/badge/edge-v6.0.0-00d8ff) ![Stable](https://img.shields.io/badge/stable-v5.0.0-39ff88) ![Validation](https://img.shields.io/badge/tests-required-39ff88) ![Safe Defaults](https://img.shields.io/badge/safe%20defaults-required-39ff88)
 
 Phase1 treats updates and release work as guarded operator workflows. Dry-run plans are preferred until execution is explicitly requested.
 
 ## Current release tracks
 
-| Track | Branch | Version | Purpose |
+| Track | Branch or reference | Version | Purpose |
 | --- | --- | --- | --- |
-| Stable tag target | `release/v4.0.0` | `v4.0.0` | Preserved stable point for the `v4.0.0` tag |
-| Bleeding edge | `edge/v4.1.0-dev` | `v4.1.0-dev` | Post-v4.0.0 development and validation |
-| Previous stable | historical | `v3.10.9` | Previous stable reference line |
-| Compatibility base | historical | `v3.6.0` | Long-term comparison base |
+| Edge | `edge/stable` | `v6.0.0` | Active development, v6 docs, UI/help polish, Base1/Fyr work, and validation. |
+| Stable base | `base/v5.0.0` | `v5.0.0` | Current stable base for release-qualified work. |
+| Previous stable | historical | `v4.4.0` | Previous stable comparison line. |
+| Compatibility base | historical | `v3.6.0` | Long-term historical comparison base. |
+| Base1 | foundation track | `foundation` | Boot, recovery, installer, rollback, storage, and hardware-validation planning. |
 
 ## Validation checklist
 
-Run this before every push:
+Run this before ordinary pushes:
 
 > [!TIP]
 > TRY THIS
 >
 > ```bash
-> cargo fmt --all -- --check
-> cargo check --all-targets
-> cargo clippy --all-targets -- -D warnings
-> cargo test --all-targets
+> sh scripts/quality-check.sh quick
 > ```
 
-Full stable release validation:
+Run Rust-specific validation when changing code:
 
 ```bash
 cargo fmt --all -- --check
 cargo check --all-targets
 cargo clippy --all-targets -- -D warnings
 cargo test --all-targets
-cargo audit
-cargo deny check
 ```
 
-Optional targeted validation:
+Run the full validation gate before release work:
 
 ```bash
-cargo test --test smoke -- --nocapture
-cargo test --test bleeding -- --nocapture
-cargo test --test game -- --nocapture
+sh scripts/quality-check.sh full
+```
+
+Focused gates:
+
+```bash
+sh scripts/quality-check.sh base1-docs
+sh scripts/quality-check.sh base1-reorg
+sh scripts/quality-check.sh security-crypto-docs
+```
+
+Optional security tooling:
+
+```bash
+cargo install cargo-audit --locked
+cargo install cargo-deny --locked
+cargo audit
+cargo deny check
 ```
 
 ## In-app update commands
 
 | Command | Purpose |
 | --- | --- |
-| `update` | Show safe update plan |
-| `update protocol` | Show update safety rules |
-| `update latest --trust-host --check` | Check latest update with host trust gate |
-| `update latest --trust-host --execute --build` | Execute guarded update and build |
-| `update now --trust-host` | Run guarded update now workflow |
-| `update test quick` | Show quick test plan |
-| `update test full` | Show full test plan |
-| `update test quick --trust-host --execute` | Execute quick test workflow with host trust |
+| `update` | Show safe update plan. |
+| `update protocol` | Show update safety rules. |
+| `update latest --trust-host --check` | Check latest update with host trust gate. |
+| `update latest --trust-host --execute --build` | Execute guarded update and build. |
+| `update now --trust-host` | Run guarded update workflow. |
+| `update test quick` | Show quick test plan. |
+| `update test full` | Show full test plan. |
+| `update test quick --trust-host --execute` | Execute quick test workflow with host trust. |
 
 > [!TIP]
 > TRY THIS INSIDE PHASE1
@@ -79,71 +90,71 @@ Rules:
 - `update` defaults to a dry-run plan
 - `--execute` is required before file mutation
 - `--trust-host` is required for host-backed execution paths
-- SHIELD must be off
-- TRUST HOST must be on
+- SHIELD must be off for host-backed execution
+- TRUST HOST must be on for host-backed execution
 - tracked local changes block execution instead of being overwritten
 - updater output is sanitized before display
+- secrets must never be placed in issue text, wiki examples, logs, screenshots, or demo commands
 
-## v4.0.0 stable tag workflow
+## Edge workflow
 
-Stable releases have no `-dev` suffix and must pass validation.
-
-Current stable release point:
-
-```text
-v4.0.0
-```
-
-Previous stable reference:
-
-```text
-v3.10.9
-```
-
-Validate and tag from the stable release branch:
+Continue active development from `edge/stable`:
 
 ```bash
 git fetch origin
-git checkout release/v4.0.0
-cargo fmt --all -- --check
-cargo check --all-targets
-cargo clippy --all-targets -- -D warnings
-cargo test --all-targets
-cargo audit
-cargo deny check
-git status
-git tag v4.0.0
-git push origin v4.0.0
-```
-
-## v4.1.0-dev bleeding-edge workflow
-
-Bleeding-edge builds keep the `-dev` suffix and must not be advertised as stable.
-
-Current edge line:
-
-```text
-v4.1.0-dev
-```
-
-Continue development from the edge branch:
-
-```bash
-git fetch origin
-git checkout edge/v4.1.0-dev
+git checkout edge/stable
+git pull origin edge/stable
 cargo metadata --no-deps --format-version 1 | grep '"version"'
-cargo test --all-targets
+sh scripts/quality-check.sh quick
 ```
 
-Expected package version on edge:
+Expected package version on the current edge line:
 
 ```text
-4.1.0-dev
+6.0.0
+```
+
+## Stable base workflow
+
+Stable references should point at the stable base line and must not include unsupported edge-only claims.
+
+Current stable base:
+
+```text
+v5.0.0
+```
+
+Before release-facing work, verify the target branch, package version, and documentation status. Use release notes, README status, wiki pages, website demo output, and in-system wiki pages consistently.
+
+## Base1 validation workflow
+
+Base1 work must stay evidence-bound. Read-only and dry-run commands are preferred until implementation and review justify stronger claims.
+
+Common safe checks:
+
+```bash
+sh scripts/base1-x86_64-detect.sh --dry-run
+sh scripts/base1-b2-assembly-dry-run.sh --dry-run --profile x86_64-vm-validation
+sh scripts/base1-preflight.sh
+sh scripts/base1-libreboot-preflight.sh
+sh scripts/base1-install-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-recovery-dry-run.sh --dry-run
+sh scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-rollback-metadata-dry-run.sh --dry-run
+```
+
+Focused Base1 tests may include:
+
+```bash
+cargo test -p phase1 --test base1_x86_64_detect_script
+cargo test -p phase1 --test base1_b2_assembly_dry_run_script
+cargo test -p phase1 --test b1_read_only_detection_validation_docs
+cargo test -p phase1 --test b2_dry_run_assembly_validation_docs
 ```
 
 ## Documentation release checklist
 
-When version numbers change, update:
+When version numbers, public claims, wiki navigation, Base1 status, Fyr behavior, or command output changes, update:
 
 ```text
 Cargo.toml
@@ -151,35 +162,42 @@ Cargo.lock
 README.md
 site/site.js
 docs/wiki/Home.md
+docs/wiki/01-Quick-Start.md
 docs/wiki/02-Version-Guide.md
 docs/wiki/08-Updates-Releases-and-Validation.md
 docs/wiki/10-Publish-to-GitHub-Wiki.md
+docs/wiki/11-Tutorials.md
+docs/wiki/12-In-System-Wiki.md
+docs/wiki/13-Base1-OS-Track.md
+docs/wiki/14-Fyr-Native-Language.md
 plugins/wiki-version.wasi
 plugins/wiki-updates.wasi
+plugins/wiki-quick.wasi
 tests/release_metadata.rs
 /home/readme.txt generator if command behavior changed
 ```
 
 ## Tutorial: Run a complete release check
 
-> [!TIP]
-> TRY THIS
->
-> ```bash
-> git pull origin master
-> cargo fmt --all -- --check
-> cargo check --all-targets
-> cargo clippy --all-targets -- -D warnings
-> cargo test --all-targets
-> cargo audit
-> cargo deny check
-> git status
-> ```
+```bash
+git fetch origin
+git status
+cargo fmt --all -- --check
+cargo check --all-targets
+cargo clippy --all-targets -- -D warnings
+cargo test --all-targets
+sh scripts/quality-check.sh full
+git status
+```
 
 Expected result:
 
 ```text
-all tests pass
+format passes
+compile passes
+clippy passes
+tests pass
+quality gate passes
 working tree clean
 ```
 
@@ -187,9 +205,11 @@ working tree clean
 
 | Failure | Action |
 | --- | --- |
-| Formatting diff | Run `cargo fmt --all`, then re-check |
-| Compile error | Fix source, then run `cargo check --all-targets` |
-| Unit test failure | Fix implementation or expected behavior |
-| Smoke test failure | Compare expected output with current UI text |
-| Audit or dependency policy failure | Fix, update, or explicitly document the dependency decision before release |
-| Local changes block pull | Commit, stash, or discard local changes before pulling |
+| Formatting diff | Run `cargo fmt --all`, then re-check. |
+| Compile error | Fix source, then run `cargo check --all-targets`. |
+| Unit test failure | Fix implementation or expected behavior. |
+| Smoke test failure | Compare expected output with current UI text. |
+| Quality gate failure | Read the focused gate output and update docs/tests together. |
+| Audit or dependency policy failure | Fix, update, or explicitly document the dependency decision before release. |
+| Local changes block pull | Commit, stash, or discard local changes before pulling. |
+| Base1 claim is ahead of evidence | Reword as roadmap/dry-run/read-only status until validation exists. |

--- a/docs/wiki/09-Troubleshooting.md
+++ b/docs/wiki/09-Troubleshooting.md
@@ -1,8 +1,8 @@
 # Troubleshooting
 
-![Troubleshooting](https://img.shields.io/badge/troubleshooting-operator%20guide-00d8ff) ![Safe](https://img.shields.io/badge/safe-default-39ff88)
+![Troubleshooting](https://img.shields.io/badge/troubleshooting-operator%20guide-00d8ff) ![Safe](https://img.shields.io/badge/safe-default-39ff88) ![Edge](https://img.shields.io/badge/edge-v6.0.0-00d8ff)
 
-This page covers common Phase1 build, boot, terminal, browser, network, runtime, and Git workflow issues.
+This page covers common Phase1 build, boot, terminal, browser, network, runtime, wiki, Base1, Fyr, and Git workflow issues.
 
 ## Build fails after pull
 
@@ -10,7 +10,9 @@ This page covers common Phase1 build, boot, terminal, browser, network, runtime,
 > TRY THIS
 >
 > ```bash
-> git pull origin master
+> git fetch origin
+> git checkout edge/stable
+> git pull origin edge/stable
 > cargo fmt --all
 > cargo fmt --all -- --check
 > cargo check --all-targets
@@ -38,14 +40,14 @@ Keep local work:
 ```bash
 git add .
 git commit -m "Save local work"
-git pull --rebase origin master
+git pull --rebase origin edge/stable
 ```
 
 Temporarily move local work aside:
 
 ```bash
 git stash push -m "local phase1 changes"
-git pull origin master
+git pull origin edge/stable
 git stash pop
 ```
 
@@ -53,7 +55,7 @@ Discard local work:
 
 ```bash
 git restore <file>
-git pull origin master
+git pull origin edge/stable
 ```
 
 ## Safe mode blocks Python, browser, or runtimes
@@ -84,6 +86,7 @@ Verify:
 
 ```text
 security
+capabilities
 ```
 
 ## Browser fetch fails
@@ -99,11 +102,11 @@ Possible causes:
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| Disabled by safe boot | SHIELD is on | Use runtime launcher or press `4` at boot |
-| Trusted host tools disabled | TRUST HOST is off | Use runtime launcher or press `t` at boot |
-| Curl unavailable | Host lacks curl | Install curl on the host |
-| URL rejected | Unsupported protocol or URL credentials | Use plain HTTP/HTTPS without embedded credentials |
-| Empty readable output | Page is script-heavy | Try another URL or inspect with a full browser outside Phase1 |
+| Disabled by safe boot | SHIELD is on | Use runtime launcher or press `4` at boot. |
+| Trusted host tools disabled | TRUST HOST is off | Use runtime launcher or press `t` at boot. |
+| Curl unavailable | Host lacks curl | Install curl on the host. |
+| URL rejected | Unsupported protocol or URL credentials | Use plain HTTP/HTTPS without embedded credentials. |
+| Empty readable output | Page is script-heavy | Try another URL or inspect with a full browser outside Phase1. |
 
 ## Network commands fail
 
@@ -120,10 +123,44 @@ Possible causes:
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| Safe-mode denial | SHIELD is on | Disable SHIELD only when intended |
-| Host-tools denial | TRUST HOST is off | Enable TRUST HOST |
-| WiFi scan unavailable | Host command unsupported | Use OS-native WiFi tools |
-| WiFi connect blocked | Mutation gate off | Set `PHASE1_ALLOW_HOST_NETWORK_CHANGES=1` |
+| Safe-mode denial | SHIELD is on | Disable SHIELD only when intended. |
+| Host-tools denial | TRUST HOST is off | Enable TRUST HOST. |
+| WiFi scan unavailable | Host command unsupported | Use OS-native WiFi tools. |
+| WiFi connect blocked | Mutation gate off | Set `PHASE1_ALLOW_HOST_NETWORK_CHANGES=1`. |
+
+## Fyr script does not run
+
+Check the file extension and command:
+
+```text
+ls
+cat hello.fyr
+fyr run hello.fyr
+```
+
+Common causes:
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| File not found | Script is not in the current VFS directory | Run `pwd`, `ls`, or use the correct path. |
+| Parse error | Example uses unsupported Fyr syntax | Start from the examples in `14-Fyr-Native-Language.md`. |
+| No output | Script did not call `print` | Add a supported `print(...)` statement. |
+| Unexpected behavior | Language surface changed | Re-run tests and update docs with implementation. |
+
+## Base1 dry-run looks like an install
+
+Base1 dry-run commands are previews and checks. They should not be described as completed installs.
+
+Verify that commands include read-only or dry-run flags:
+
+```bash
+sh scripts/base1-x86_64-detect.sh --dry-run
+sh scripts/base1-b2-assembly-dry-run.sh --dry-run --profile x86_64-vm-validation
+sh scripts/base1-install-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-recovery-dry-run.sh --dry-run
+```
+
+Use [Base1 OS Track](13-Base1-OS-Track.md) for correct public wording.
 
 ## Termius or mobile SSH sends a stale Enter
 
@@ -167,6 +204,23 @@ cat readme.txt
 ```
 
 The generated readme should reflect the current booted version when persistent state is fresh.
+
+## Wiki page looks stale
+
+Check whether you are viewing the reviewable source wiki, native GitHub Wiki, or website copy.
+
+| Surface | Source |
+| --- | --- |
+| Reviewable source | `docs/wiki/` |
+| Native GitHub Wiki | `Bryforge/phase1.wiki` after publishing |
+| In-system compact wiki | `plugins/wiki-*.wasi` |
+| Website links | `site/` and GitHub Pages output |
+
+If the native GitHub Wiki is stale, publish the reviewed source:
+
+```bash
+scripts/publish-wiki.sh
+```
 
 ## Smoke test expected output fails
 
@@ -217,11 +271,14 @@ Fix options:
 > TRY THIS
 >
 > ```bash
-> git pull origin master
+> git fetch origin
+> git checkout edge/stable
+> git pull origin edge/stable
 > cargo fmt --all
 > cargo fmt --all -- --check
 > cargo check --all-targets
 > cargo test --all-targets
+> sh scripts/quality-check.sh quick
 > cargo run
 > ```
 
@@ -231,6 +288,7 @@ Expected result:
 format passes
 compile passes
 tests pass
+quality gate passes
 Phase1 boots
 shutdown banner reports the current package version
 ```

--- a/docs/wiki/10-Publish-to-GitHub-Wiki.md
+++ b/docs/wiki/10-Publish-to-GitHub-Wiki.md
@@ -1,8 +1,8 @@
 # Publish to GitHub Wiki
 
-![Wiki Source](https://img.shields.io/badge/wiki%20source-docs%2Fwiki-00d8ff) ![Manual](https://img.shields.io/badge/manual-v4.0.0-39ff88) ![Previous Stable](https://img.shields.io/badge/previous%20stable-v3.10.9-7f8cff)
+![Wiki Source](https://img.shields.io/badge/wiki%20source-docs%2Fwiki-00d8ff) ![Manual](https://img.shields.io/badge/manual-v6.0.0-39ff88) ![Stable](https://img.shields.io/badge/stable-v5.0.0-39ff88) ![Base1](https://img.shields.io/badge/Base1-foundation-ff8a00)
 
-This repository stores the Phase1 wiki source in `docs/wiki/` so the manual can be reviewed, versioned, and tested with normal code changes.
+This repository stores the Phase1 wiki source in `docs/wiki/` so the manual can be reviewed, versioned, and tested with normal code changes before it is copied to the native GitHub Wiki repository.
 
 ## Native GitHub Wiki status
 
@@ -23,7 +23,9 @@ From the main Phase1 checkout:
 
 ```bash
 cd phase1
-git pull origin master
+git fetch origin
+git checkout edge/stable
+git pull origin edge/stable
 ```
 
 Clone the wiki repository beside the main checkout:
@@ -45,38 +47,48 @@ Commit and push:
 cd phase1.wiki
 git status
 git add .
-git commit -m "Update Phase1 user manual for v4.0.0"
+git commit -m "Update Phase1 user manual"
 git push origin master
 ```
 
 ## One-command publish script
 
-The repository includes a helper script path reserved for publishing:
+The repository includes a helper script:
 
-```text
+```bash
 scripts/publish-wiki.sh
 ```
 
-Use that script once the native wiki repository exists.
+The script clones the native wiki repository when needed, copies `docs/wiki/` with `rsync --delete`, commits changes, and pushes to the wiki `master` branch.
+
+Useful environment overrides:
+
+```bash
+PHASE1_REPO_SLUG=Bryforge/phase1 scripts/publish-wiki.sh
+PHASE1_WIKI_WORKDIR=../phase1.wiki scripts/publish-wiki.sh
+```
 
 ## Wiki file map
 
 | File | Purpose |
 | --- | --- |
-| `Home.md` | Manual index and version matrix |
-| `_Sidebar.md` | GitHub Wiki sidebar |
-| `01-Quick-Start.md` | First-run tutorial |
-| `02-Version-Guide.md` | Stable and compatibility version model |
-| `03-Boot-Modes-and-Security.md` | Boot selector and guard model |
-| `04-Command-Manual.md` | Command reference by task |
-| `05-Files-Editors-and-Pipelines.md` | VFS, AVIM, and pipelines |
-| `06-Browser-and-Networking.md` | Browser and network manual |
-| `07-Language-Runtimes.md` | Python, Rust, C, and runtime support |
-| `08-Updates-Releases-and-Validation.md` | Update and release workflow |
-| `09-Troubleshooting.md` | Common problems and fixes |
-| `10-Publish-to-GitHub-Wiki.md` | This publishing guide |
-| `11-Tutorials.md` | Guided learning paths |
-| `12-v4-Edge-Manual.md` | v4 stable manual; filename kept for compatibility |
+| `Home.md` | Manual index, reader paths, version matrix, and public guardrails. |
+| `_Sidebar.md` | GitHub Wiki sidebar. |
+| `01-Quick-Start.md` | First-run tutorial. |
+| `02-Version-Guide.md` | Edge, stable, compatibility, and Base1 version model. |
+| `03-Boot-Modes-and-Security.md` | Boot selector and guard model. |
+| `04-Command-Manual.md` | Command reference by task. |
+| `05-Files-Editors-and-Pipelines.md` | VFS, AVIM, and pipelines. |
+| `06-Browser-and-Networking.md` | Browser and network manual. |
+| `07-Language-Runtimes.md` | Python, Rust, C, WASI-lite, and runtime support. |
+| `08-Updates-Releases-and-Validation.md` | Update, validation, and release workflow. |
+| `09-Troubleshooting.md` | Common problems and fixes. |
+| `10-Publish-to-GitHub-Wiki.md` | This publishing guide. |
+| `11-Tutorials.md` | Guided learning paths. |
+| `12-In-System-Wiki.md` | Compact manual commands available from inside Phase1. |
+| `13-Base1-OS-Track.md` | Base1 boot, recovery, hardware, and evidence-bound OS-track guide. |
+| `14-Fyr-Native-Language.md` | Fyr native language quick guide and public example policy. |
+| `12-v4-Edge-Manual.md` | Legacy v4 reference retained for compatibility. |
 
 ## Version update checklist
 
@@ -88,13 +100,18 @@ Cargo.lock
 README.md
 site/site.js
 docs/wiki/Home.md
+docs/wiki/01-Quick-Start.md
 docs/wiki/02-Version-Guide.md
 docs/wiki/08-Updates-Releases-and-Validation.md
 docs/wiki/10-Publish-to-GitHub-Wiki.md
 docs/wiki/11-Tutorials.md
-docs/wiki/12-v4-Edge-Manual.md
+docs/wiki/12-In-System-Wiki.md
+docs/wiki/13-Base1-OS-Track.md
+docs/wiki/14-Fyr-Native-Language.md
 plugins/wiki-version.wasi
 plugins/wiki-updates.wasi
+plugins/wiki-quick.wasi
+tests/release_metadata.rs
 ```
 
 Then validate:
@@ -104,9 +121,24 @@ cargo fmt --all -- --check
 cargo check --all-targets
 cargo clippy --all-targets -- -D warnings
 cargo test --all-targets
+sh scripts/quality-check.sh quick
+```
+
+Optional release/security checks:
+
+```bash
 cargo audit
 cargo deny check
 ```
+
+## Publish safety rules
+
+- Publish from reviewed `docs/wiki/` content.
+- Do not publish secrets, tokens, private keys, account passwords, recovery codes, or private environment details.
+- Keep Base1 claims evidence-bound.
+- Keep Fyr examples limited to implemented language behavior.
+- Keep stable and edge version labels consistent with README and `Cargo.toml`.
+- Keep native Wiki publishing separate from GitHub Pages deployment.
 
 ## Color policy
 

--- a/docs/wiki/11-Tutorials.md
+++ b/docs/wiki/11-Tutorials.md
@@ -1,12 +1,18 @@
 # Tutorials
 
-![Tutorials](https://img.shields.io/badge/tutorials-TRY%20THIS-00d8ff) ![Stable](https://img.shields.io/badge/stable-v4.0.0-39ff88) ![Previous Stable](https://img.shields.io/badge/previous%20stable-v3.10.9-7f8cff)
+![Tutorials](https://img.shields.io/badge/tutorials-TRY%20THIS-00d8ff) ![Edge](https://img.shields.io/badge/edge-v6.0.0-00d8ff) ![Stable](https://img.shields.io/badge/stable-v5.0.0-39ff88) ![Safe Defaults](https://img.shields.io/badge/safe%20defaults-on-39ff88)
 
 These tutorials are designed for a new Phase1 user. Run them in order or jump to the workflow you need.
 
 ## Tutorial 1: First boot and orientation
 
 Start Phase1:
+
+```bash
+sh phase1
+```
+
+Alternative Rust-native start:
 
 ```bash
 cargo run
@@ -23,19 +29,26 @@ At the boot selector:
 >
 > ```text
 > help
+> help ui
+> help flows
 > version
 > version --compare
 > cat readme.txt
+> wiki
+> wiki-quick
 > security
+> capabilities
 > sysinfo
 > ```
 
 You should understand:
 
 - what version is running
+- whether safe mode is active
 - whether SHIELD is on
 - whether TRUST HOST is on
 - where the built-in quick start lives
+- which commands require host access
 
 ## Tutorial 2: Create a small virtual filesystem lab
 
@@ -69,7 +82,53 @@ Expected ideas:
 - pipeline filters can process VFS content
 - `/home` is the normal workspace
 
-## Tutorial 3: Use AVIM to write Python
+## Tutorial 3: Write and run Fyr
+
+Create a simple Fyr script:
+
+```text
+echo 'fn main() -> i32 { print("hello from Fyr"); return 0; }' > hello.fyr
+fyr run hello.fyr
+```
+
+Expected output:
+
+```text
+hello from Fyr
+```
+
+Use AVIM for a slightly larger script:
+
+```text
+avim math.fyr
+```
+
+In AVIM:
+
+```text
+i
+fn main() -> i32 {
+    let answer = 40 + 2;
+    print(answer);
+    return 0;
+}
+Esc
+:wq
+```
+
+Run it:
+
+```text
+fyr run math.fyr
+```
+
+Expected output:
+
+```text
+42
+```
+
+## Tutorial 4: Use AVIM to write Python
 
 Start Phase1 with host runtimes enabled:
 
@@ -104,7 +163,10 @@ Alternative run path:
 lang run python hello.py
 ```
 
-## Tutorial 4: Use AVIM to write Rust
+> [!IMPORTANT]
+> Python execution is host-backed. Use it only after you understand SHIELD, TRUST HOST, and safe mode.
+
+## Tutorial 5: Use AVIM to write Rust
 
 Start runtime mode:
 
@@ -135,7 +197,7 @@ Run it:
 lang run rust main.rs
 ```
 
-## Tutorial 5: Inspect browser output
+## Tutorial 6: Inspect browser output
 
 Start runtime mode:
 
@@ -165,7 +227,7 @@ Look for:
 - readable extracted text
 - indexed link list
 
-## Tutorial 6: Inspect network state
+## Tutorial 7: Inspect network state
 
 Start runtime mode:
 
@@ -191,7 +253,7 @@ Look for:
 - WiFi summary where supported
 - safe denial messages when a command is intentionally blocked
 
-## Tutorial 7: Use dashboard and audit tools
+## Tutorial 8: Use dashboard, audit, and nested context tools
 
 > [!TIP]
 > TRY THIS
@@ -202,6 +264,12 @@ Look for:
 > audit
 > opslog status
 > opslog tail
+> nest status
+> nest spawn lab
+> nest list
+> nest tree
+> nest inspect lab
+> nest destroy lab
 > ```
 
 You should see:
@@ -212,8 +280,9 @@ You should see:
 - network safety summary
 - latest audit event
 - local operations log status
+- nested metadata contexts and topology
 
-## Tutorial 8: Simulate process and hardware commands
+## Tutorial 9: Simulate process and hardware commands
 
 > [!TIP]
 > TRY THIS
@@ -234,7 +303,7 @@ You should see:
 
 This tutorial is educational. The process and hardware commands are simulated and audited.
 
-## Tutorial 9: Enable persistence
+## Tutorial 10: Enable persistence
 
 At boot selector:
 
@@ -268,18 +337,36 @@ phase1.history
 > [!CAUTION]
 > Do not store secrets in persistent VFS files.
 
-## Tutorial 10: Run the full validation loop
+## Tutorial 11: Run Base1 read-only and dry-run checks
+
+Base1 checks should stay read-only or dry-run until implementation, review, and validation support stronger action.
+
+```bash
+sh scripts/base1-x86_64-detect.sh --dry-run
+sh scripts/base1-b2-assembly-dry-run.sh --dry-run --profile x86_64-vm-validation
+sh scripts/base1-preflight.sh
+sh scripts/base1-install-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-recovery-dry-run.sh --dry-run
+```
+
+Expected idea:
+
+```text
+no host disk writes are required for these checks
+```
+
+## Tutorial 12: Run the full validation loop
 
 From the host:
 
 ```bash
-git pull origin master
+git fetch origin
+git status
 cargo fmt --all -- --check
 cargo check --all-targets
 cargo clippy --all-targets -- -D warnings
 cargo test --all-targets
-cargo audit
-cargo deny check
+sh scripts/quality-check.sh quick
 cargo run
 ```
 
@@ -290,39 +377,45 @@ format passes
 compile passes
 clippy passes
 tests pass
-audit passes
-dependency policy passes
+quality gate passes
 Phase1 boots
 shutdown reports the current package version
 ```
 
-## Tutorial 11: Prepare a stable release
+## Tutorial 13: Prepare release-facing documentation
 
 From the host:
 
 ```bash
 git status
 git log -1 --oneline
-cargo fmt --all -- --check
-cargo check --all-targets
-cargo clippy --all-targets -- -D warnings
-cargo test --all-targets
-cargo audit
-cargo deny check
+cargo metadata --no-deps --format-version 1 | grep '"version"'
+sh scripts/quality-check.sh quick
 ```
 
-For a stable build, remove `-dev`, update docs and in-system wiki fixtures, validate again, commit, tag, and push.
+Then check that these surfaces agree:
 
-Current stable target:
+```text
+README.md
+docs/wiki/Home.md
+docs/wiki/02-Version-Guide.md
+docs/wiki/08-Updates-Releases-and-Validation.md
+site/site.js
+plugins/wiki-version.wasi
+plugins/wiki-updates.wasi
+```
+
+For stable release-facing docs, avoid edge-only claims. For Base1 docs, keep claims tied to evidence. For Fyr docs, only use examples supported by current language behavior.
+
+## Tutorial 14: Publish manual pages to the native wiki
+
+Only do this after GitHub Wiki support exists for the repository and the source docs have been reviewed.
 
 ```bash
-git tag v4.0.0
-git push origin v4.0.0
+scripts/publish-wiki.sh
 ```
 
-## Tutorial 12: Publish manual pages to the native wiki
-
-Only do this after GitHub Wiki support exists for the repository.
+Manual equivalent:
 
 ```bash
 cd ..
@@ -330,7 +423,7 @@ git clone https://github.com/Bryforge/phase1.wiki.git phase1.wiki
 rsync -av --delete phase1/docs/wiki/ phase1.wiki/
 cd phase1.wiki
 git add .
-git commit -m "Update Phase1 user manual for v4.0.0"
+git commit -m "Update Phase1 user manual"
 git push origin master
 ```
 

--- a/docs/wiki/12-In-System-Wiki.md
+++ b/docs/wiki/12-In-System-Wiki.md
@@ -1,8 +1,8 @@
 # In-System Wiki
 
-![In System](https://img.shields.io/badge/in--system-wiki-00d8ff) ![Sandbox](https://img.shields.io/badge/runtime-WASI--lite-39ff88) ![Host Tools](https://img.shields.io/badge/host%20tools-not%20required-ffcc00)
+![In System](https://img.shields.io/badge/in--system-wiki-00d8ff) ![Sandbox](https://img.shields.io/badge/runtime-WASI--lite-39ff88) ![Host Tools](https://img.shields.io/badge/host%20tools-not%20required-ffcc00) ![Manual](https://img.shields.io/badge/manual-v6.0.0-39ff88)
 
-Phase1 now includes a compact manual that is readable directly from inside the Phase1 shell.
+Phase1 includes a compact manual that is readable directly from inside the Phase1 shell.
 
 The in-system wiki is provided as sandboxed WASI-lite manual pages in `plugins/`. It does not require SHIELD off, TRUST HOST, browser access, Python, or any host tool.
 
@@ -38,7 +38,7 @@ The index prints the available wiki sections and version targets.
 wiki-quick
 ```
 
-This page shows host install, first Phase1 commands, and runtime enablement.
+This page shows host install, first Phase1 commands, runtime enablement, and safe defaults.
 
 ## Version page
 
@@ -46,7 +46,7 @@ This page shows host install, first Phase1 commands, and runtime enablement.
 wiki-version
 ```
 
-This page explains the edge, stable, and compatibility tracks.
+This page explains the edge, stable, previous stable, compatibility, and Base1 foundation tracks.
 
 ## Boot and security page
 
@@ -88,6 +88,12 @@ wiki-lang
 
 This page covers Python, Rust, C, WASI-lite, and runtime gates.
 
+For Phase1-native scripting, read the full source wiki page:
+
+```text
+docs/wiki/14-Fyr-Native-Language.md
+```
+
 ## Updates page
 
 ```text
@@ -96,13 +102,19 @@ wiki-updates
 
 This page covers validation, update safety, and release rules.
 
+For Base1 boot, recovery, storage, rollback, and evidence-bound OS-track language, read the full source wiki page:
+
+```text
+docs/wiki/13-Base1-OS-Track.md
+```
+
 ## Troubleshooting page
 
 ```text
 wiki-trouble
 ```
 
-This page lists common failures and fixes.
+This page lists common failures and fixes, including stale wiki surfaces, Base1 dry-run wording, and Fyr script issues.
 
 ## Tutorials page
 
@@ -110,10 +122,10 @@ This page lists common failures and fixes.
 wiki-tutorials
 ```
 
-This page contains guided labs for boot, VFS, Python, browser, network, validation, and release work.
+This page contains guided labs for boot, VFS, Fyr, Python, browser, network, Base1 dry-runs, validation, and wiki publishing.
 
 ## Design notes
 
 The full manual source remains in `docs/wiki/` for GitHub Wiki publishing. The in-system pages are smaller terminal-readable summaries that work inside Phase1 without host access.
 
-When adding a new full wiki page, add a matching compact in-system page when it helps users at the prompt.
+When adding a new full wiki page, add a matching compact in-system page when it helps users at the prompt. If no compact command exists yet, link from this page to the full source wiki page so users still have a clear path.

--- a/docs/wiki/13-Base1-OS-Track.md
+++ b/docs/wiki/13-Base1-OS-Track.md
@@ -1,0 +1,123 @@
+# Base1 OS Track
+
+![Base1](https://img.shields.io/badge/Base1-foundation-ff8a00) ![Boot](https://img.shields.io/badge/boot-readiness%20tracked-00d8ff) ![Recovery](https://img.shields.io/badge/recovery-evidence%20bound-39ff88) ![Claims](https://img.shields.io/badge/claims-conservative-39ff88)
+
+Base1 is the long-term host-foundation track for making Phase1 a bootable, recoverable, Phase1-first computing environment. It keeps host recovery, boot support, installer behavior, rollback metadata, and hardware validation separate from the Phase1 virtual OS console.
+
+> [!IMPORTANT]
+> Base1 is not currently a finished hardened operating system. It is a staged foundation. Use read-only, dry-run, and evidence-bound language until boot images, recovery validation, update validation, audit evidence, and hardware reports exist.
+
+## What Base1 is for
+
+| Area | Purpose |
+| --- | --- |
+| Boot foundation | Define how a Phase1-first environment can start safely on real hardware. |
+| Recovery path | Keep emergency recovery outside Phase1 control so the host remains recoverable. |
+| Installer path | Plan installation and target selection with dry-run validation before writes. |
+| Storage layout | Describe target disks, partitions, mount expectations, and rollback metadata. |
+| Hardware matrix | Track Raspberry Pi, x86_64 VM, X200-class, Libreboot, and generic targets honestly. |
+| Supervisor path | Define future control-plane, policy, artifact, profile, and storage-tier surfaces. |
+| Evidence gates | Require validation reports before stronger public claims. |
+
+## Current safe posture
+
+Base1 work should prefer these categories:
+
+1. Documentation and design notes.
+2. Read-only detection.
+3. Dry-run assembly previews.
+4. Preflight checks.
+5. Recovery evidence.
+6. Hardware checklists.
+7. Validation reports.
+8. Reviewed implementation.
+
+Do not describe dry-run output as a completed install. Do not describe a hardware checklist as hardware support. Do not describe planned hardening as audited hardening.
+
+## Start here
+
+From the main repository documentation:
+
+- `docs/os/ROADMAP.md` — Phase1 operating-system track.
+- `docs/os/BOOT_READINESS_STATUS.md` — boot-readiness tracker.
+- `docs/os/BOOT_READINESS_RACE_PLAN.md` — evidence-bound path toward boot readiness.
+- `docs/os/X86_64_BOOT_SUPPORT_ROADMAP.md` — x86_64 boot support planning.
+- `docs/os/BASE1_IMAGE_BUILDER.md` — image-builder design.
+- `docs/os/INSTALLER_RECOVERY.md` — installer and recovery design.
+- `docs/os/BASE1_DRY_RUN_COMMANDS.md` — Base1 dry-run command index.
+- `base1/README.md` — Base1 overview.
+- `base1/SECURITY_MODEL.md` — Base1 boundary and security model.
+- `base1/HARDWARE_TARGETS.md` — hardware target matrix.
+
+## B1 and B2 path
+
+B1 focuses on read-only detection:
+
+```bash
+sh scripts/base1-x86_64-detect.sh --dry-run
+```
+
+B2 focuses on dry-run assembly preview:
+
+```bash
+sh scripts/base1-b2-assembly-dry-run.sh --dry-run --profile x86_64-vm-validation
+```
+
+Related validation:
+
+```bash
+cargo test -p phase1 --test base1_x86_64_detect_script
+cargo test -p phase1 --test b1_read_only_detection_limitations_docs
+cargo test -p phase1 --test b1_read_only_detection_validation_docs
+cargo test -p phase1 --test b2_dry_run_assembly_plan_docs
+cargo test -p phase1 --test base1_b2_assembly_dry_run_script
+cargo test -p phase1 --test b2_dry_run_assembly_limitations_docs
+cargo test -p phase1 --test b2_dry_run_assembly_validation_docs
+```
+
+## Recovery and rollback path
+
+Recovery and rollback work must preserve a strong host boundary. Phase1 can describe, prepare, and validate recovery artifacts, but the recovery path must not depend on a broken Phase1 runtime to recover the host.
+
+Useful read-only or dry-run commands:
+
+```bash
+sh scripts/base1-preflight.sh
+sh scripts/base1-libreboot-preflight.sh
+sh scripts/base1-install-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-recovery-dry-run.sh --dry-run
+sh scripts/base1-storage-layout-dry-run.sh --dry-run --target /dev/example
+sh scripts/base1-rollback-metadata-dry-run.sh --dry-run
+```
+
+## Hardware target language
+
+Use precise wording:
+
+| Better wording | Avoid |
+| --- | --- |
+| `planned target` | `fully supported` |
+| `read-only detected` | `installed` |
+| `dry-run preview` | `assembled image` |
+| `validation checklist exists` | `validated hardware` |
+| `recovery design documented` | `recovery guaranteed` |
+| `Libreboot profile notes` | `Libreboot certified` |
+
+## Public claim checklist
+
+Before making a stronger Base1 public claim, confirm:
+
+- the implementation exists
+- tests cover the claimed behavior
+- docs explain limits and non-claims
+- dry-run and write paths are clearly separated
+- host recovery remains outside Phase1 control
+- validation reports are present
+- screenshots and website copy match the actual status
+- README, wiki, in-system wiki, and release metadata agree
+
+## Next pages
+
+- [Updates, Releases, and Validation](08-Updates-Releases-and-Validation.md)
+- [Boot Modes and Security](03-Boot-Modes-and-Security.md)
+- [Fyr Native Language](14-Fyr-Native-Language.md)

--- a/docs/wiki/14-Fyr-Native-Language.md
+++ b/docs/wiki/14-Fyr-Native-Language.md
@@ -1,0 +1,145 @@
+# Fyr Native Language
+
+![Fyr](https://img.shields.io/badge/Fyr-native%20language-ff5a00) ![Scripts](https://img.shields.io/badge/scripts-.fyr-00d8ff) ![Phase1](https://img.shields.io/badge/Phase1-owned-39ff88)
+
+Fyr is the Phase1-native language track for VFS automation, operator-owned scripts, and future self-construction work. It is designed around C-style explicit control, a Rust-style safety posture, and Python-style readability while staying owned by Phase1.
+
+## What Fyr is for
+
+| Area | Purpose |
+| --- | --- |
+| First scripts | Run `.fyr` files directly inside Phase1. |
+| Operator automation | Build small repeatable workflows without leaving the Phase1 environment. |
+| VFS-first tasks | Work naturally with Phase1 files and command output. |
+| Testing | Assert behavior through simple language-level checks. |
+| Future system work | Grow toward deeper Phase1-owned automation and self-hosted tools. |
+
+## Current language surface
+
+Current Fyr work includes:
+
+- `.fyr` script files
+- `print` output
+- `return` values
+- `let` bindings
+- arithmetic expressions
+- grouped expressions
+- comparisons
+- boolean chains
+- simple `if` return statements
+- assertions
+- package checks
+- test runner flow
+- syntax-color output
+
+> [!IMPORTANT]
+> Fyr is growing. Treat unsupported language features as roadmap items, not hidden behavior.
+
+## First script
+
+Inside Phase1:
+
+```text
+echo 'fn main() -> i32 { print("Hello, hacker!"); return 0; }' > hello_hacker.fyr
+fyr run hello_hacker.fyr
+```
+
+Expected output:
+
+```text
+Hello, hacker!
+```
+
+## AVIM workflow
+
+```text
+avim hello.fyr
+```
+
+Inside AVIM:
+
+```text
+i
+fn main() -> i32 { print("hello from Fyr"); return 0; }
+Esc
+:wq
+```
+
+Run it:
+
+```text
+fyr run hello.fyr
+```
+
+## Host quick check
+
+From the repository root, use normal Phase1 validation before changing Fyr-facing behavior:
+
+```bash
+cargo fmt --all -- --check
+cargo check --all-targets
+cargo test --all-targets
+sh scripts/quality-check.sh quick
+```
+
+## Documentation sources
+
+Start with these repository docs:
+
+- `docs/project/PHASE1_NATIVE_LANGUAGE.md` — Phase1 native-language overview.
+- `docs/fyr/ROADMAP.md` — Fyr roadmap.
+- `assets/fyr_symbol.png` — Fyr symbol.
+- `assets/fyr_word.png` — Fyr word mark.
+
+## Good wiki examples
+
+Use short, copyable examples:
+
+```text
+fn main() -> i32 {
+    let x = 40 + 2;
+    print(x);
+    return 0;
+}
+```
+
+Use explicit expected output:
+
+```text
+42
+```
+
+Use current command names:
+
+```text
+fyr run example.fyr
+```
+
+## Avoid in public examples
+
+Do not use Fyr examples that:
+
+- imply unimplemented language features
+- require private secrets or credentials
+- disable Phase1 safety gates without explaining why
+- claim kernel-level or hardened-host behavior
+- mix Base1 boot claims into ordinary Fyr scripting examples
+
+## Roadmap language
+
+Use conservative language for future features:
+
+| Better wording | Avoid |
+| --- | --- |
+| `planned` | `supported` |
+| `target` | `guaranteed` |
+| `prototype` | `production-ready` |
+| `Phase1-native scripting` | `complete systems language` |
+| `future self-hosting path` | `self-hosted today` |
+
+## Next pages
+
+- [Quick Start](01-Quick-Start.md)
+- [Command Manual](04-Command-Manual.md)
+- [Language Runtimes](07-Language-Runtimes.md)
+- [Base1 OS Track](13-Base1-OS-Track.md)

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,18 +1,20 @@
 # Phase1 User Manual
 
-![Edge](https://img.shields.io/badge/edge-v4.1.0--dev-00d8ff) ![Stable](https://img.shields.io/badge/stable-v4.0.0-39ff88) ![Previous Stable](https://img.shields.io/badge/previous%20stable-v3.10.9-7f8cff) ![Base](https://img.shields.io/badge/compatibility-v3.6.0-7f8cff)
+![Edge](https://img.shields.io/badge/edge-v6.0.0-00d8ff) ![Stable](https://img.shields.io/badge/stable-v5.0.0-39ff88) ![Previous Stable](https://img.shields.io/badge/previous%20stable-v4.4.0-7f8cff) ![Compatibility](https://img.shields.io/badge/compatibility-v3.6.0-7f8cff) ![Base1](https://img.shields.io/badge/Base1-foundation-ff8a00) ![Fyr](https://img.shields.io/badge/Fyr-native%20language-ff5a00)
 
-Welcome to the Phase1 manual. This wiki source distinguishes the stable `v4.0.0` release point from the bleeding-edge `v4.1.0-dev` development line.
+Welcome to the Phase1 manual. This wiki source tracks the current `edge/stable` development line, the current stable base, the Base1 host-foundation track, and the Fyr native-language track.
 
-| Track | Version | Use it for |
+| Track | Current value | Use it for |
 | --- | --- | --- |
-| Edge | `v4.1.0-dev` | Development beyond v4.0.0, experiments, integration work, and pre-release validation |
-| Stable | `v4.0.0` | Current stable usage, public demos, website, docs, release notes, and the `v4.0.0` tag target |
-| Previous stable | `v3.10.9` | Previous stable reference usage and compatibility checks |
-| Compatibility base | `v3.6.0` | Historical stable comparison shown by some in-app version checks |
+| Edge | `v6.0.0` | Active development, v6 UI/help polish, wiki updates, Base1 planning, Fyr growth, and validation work. |
+| Stable | `v5.0.0` | Release-qualified demos, public-facing stable references, and safer checkpoint work. |
+| Previous stable | `v4.4.0` | Compatibility comparison against the prior stable line. |
+| Compatibility base | `v3.6.0` | Historical comparison point shown by older in-app version checks. |
+| Base1 | `foundation` | Long-term secure host layer for boot, recovery, installer, storage, rollback, and hardware validation. |
+| Fyr | `native language` | Phase1-owned scripting and automation language surface. |
 
-> [!NOTE]
-> GitHub renders these manual callouts with colored accents. This manual intentionally avoids emojis and uses clear command blocks instead.
+> [!IMPORTANT]
+> Phase1 is a terminal-first virtual operating-system console. Base1 is the staged host-foundation path toward real boot and recovery work. This wiki must not describe Phase1 as a hardened drop-in replacement for Linux, macOS, or Windows until boot images, recovery evidence, update paths, audits, and hardware validation exist.
 
 ## Start here
 
@@ -28,27 +30,37 @@ Welcome to the Phase1 manual. This wiki source distinguishes the stable `v4.0.0`
 10. [Publish to GitHub Wiki](10-Publish-to-GitHub-Wiki.md)
 11. [Tutorials](11-Tutorials.md)
 12. [In-System Wiki](12-In-System-Wiki.md)
-13. [v4 Stable Manual](12-v4-Edge-Manual.md)
+13. [Base1 OS Track](13-Base1-OS-Track.md)
+14. [Fyr Native Language](14-Fyr-Native-Language.md)
+15. [Legacy v4 Reference](12-v4-Edge-Manual.md)
 
 ## What Phase1 is
 
-Phase1 is a terminal-first virtual OS and advanced operator console written in Rust. It includes a simulated kernel, virtual filesystem, process table, audit log, guarded browser, guarded network inspection, language runtime manager, storage helper, update protocol, modal editor, Base1 secure-host foundation, and Neo Tokyo style terminal interface.
+Phase1 is a Rust-built, terminal-first virtual OS console created by Chase Bryan / Bryforge. It combines a futuristic operator surface with practical systems ideas: a simulated kernel, virtual filesystem, process table, audit log, command metadata, guarded host access, storage helpers, local learning, the Fyr native language, Nested Phase1 metadata-control, and a long-term operating-system track through Base1.
+
+Phase1 is useful for learning, experimentation, terminal workflows, documentation, and staged OS design. It is not a current hardened sandbox, kernel, or daily-driver operating-system replacement.
 
 ## Core rules
 
 > [!IMPORTANT]
-> Phase1 starts secure by default. Host-backed tools are blocked until SHIELD is off and TRUST HOST is enabled.
+> Phase1 starts secure by default. Host-backed tools require explicit trust gates. Do not enter tokens, private keys, account passwords, recovery codes, or other secrets into demos, issues, logs, wiki examples, or screenshots.
 
 > [!TIP]
-> TRY THIS
+> TRY THIS INSIDE PHASE1
 >
 > ```text
 > help
-> cat readme.txt
+> help ui
+> help flows
 > wiki
 > wiki-quick
+> version
 > version --compare
 > security
+> capabilities
+> sysinfo
+> nest status
+> nest tree
 > roadmap
 > ```
 
@@ -57,32 +69,43 @@ Phase1 is a terminal-first virtual OS and advanced operator console written in R
 | Goal | Command |
 | --- | --- |
 | Show command map | `help` |
+| Show modern launch pad | `help ui` |
+| Show workflow deck | `help flows` |
 | Read in-system guide | `cat readme.txt` |
 | Open in-system wiki index | `wiki` |
 | Open in-system wiki quick start | `wiki-quick` |
 | Check current version | `version` |
-| Compare stable and previous lines | `version --compare` |
+| Compare release lines | `version --compare` |
 | Inspect security posture | `security` |
+| Inspect command gates | `capabilities` |
 | Show dashboard | `dash` |
 | Show system info | `sysinfo` |
 | Edit quickly | `ned notes.txt` |
-| Edit with avim | `avim hello.py` |
-| Run browser reader | `browser example.com` |
-| Show language support | `lang support` |
+| Edit with AVIM | `avim hello.fyr` |
+| Run Fyr script | `fyr run hello.fyr` |
+| Inspect nested contexts | `nest status` |
+| Show nested topology | `nest tree` |
 | Show update protocol | `update protocol` |
 
-## Tutorial paths
+## Reader paths
 
 | Path | Best first page |
 | --- | --- |
 | New user | [Quick Start](01-Quick-Start.md) |
-| v4 stable | [v4 Stable Manual](12-v4-Edge-Manual.md) |
-| In-system wiki commands | [In-System Wiki](12-In-System-Wiki.md) |
-| Operator commands | [Command Manual](04-Command-Manual.md) |
-| Python/Rust/C | [Language Runtimes](07-Language-Runtimes.md) |
-| Browser/network | [Browser and Networking](06-Browser-and-Networking.md) |
+| Current release model | [Version Guide](02-Version-Guide.md) |
+| In-system manual commands | [In-System Wiki](12-In-System-Wiki.md) |
+| Operator command reference | [Command Manual](04-Command-Manual.md) |
+| Python/Rust/C/WASI-lite | [Language Runtimes](07-Language-Runtimes.md) |
+| Browser and network tools | [Browser and Networking](06-Browser-and-Networking.md) |
+| Base1 boot/recovery path | [Base1 OS Track](13-Base1-OS-Track.md) |
+| Fyr scripting path | [Fyr Native Language](14-Fyr-Native-Language.md) |
 | Full guided labs | [Tutorials](11-Tutorials.md) |
+| Native GitHub Wiki publish flow | [Publish to GitHub Wiki](10-Publish-to-GitHub-Wiki.md) |
+
+## Public wiki source rule
+
+The reviewable wiki source lives in `docs/wiki/`. Publish those files to the native GitHub Wiki only after the source changes are reviewed and validation-sensitive docs stay aligned with the repository README, in-system `wiki-*` pages, release metadata, and website links.
 
 ## Manual maintenance rule
 
-When the Cargo package version changes, update this manual version matrix, README status, in-system `wiki-*` pages, website demo output, release workflow examples, and release metadata tests together. Stable release branches must avoid `-dev` suffixes; edge branches must keep the `-dev` suffix visible.
+When the Cargo package version, stable base, branch model, public asset path, command behavior, or Base1/Fyr status changes, update the README, this manual, in-system `wiki-*` pages, website demo output, release workflow examples, and release metadata tests together. Stable release branches must avoid unsupported edge claims; edge docs must label experimental or host-backed behavior clearly.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -13,3 +13,6 @@
 - [Publish to GitHub Wiki](10-Publish-to-GitHub-Wiki.md)
 - [Tutorials](11-Tutorials.md)
 - [In-System Wiki](12-In-System-Wiki.md)
+- [Base1 OS Track](13-Base1-OS-Track.md)
+- [Fyr Native Language](14-Fyr-Native-Language.md)
+- [Legacy v4 Reference](12-v4-Edge-Manual.md)


### PR DESCRIPTION
## Summary

Refreshes the Phase1 wiki source for the current v6 edge/stable documentation posture.

### Changed

- Updates wiki Home, Quick Start, Version Guide, release/validation, troubleshooting, tutorials, publishing, and in-system wiki docs for v6-era wording.
- Adds a dedicated Base1 OS Track wiki page with conservative, evidence-bound boot/recovery/hardware language.
- Adds a dedicated Fyr Native Language wiki page with copyable `.fyr` examples and public example guardrails.
- Wires the new pages into `_Sidebar.md` and the publishing guide.
- Replaces stale `master`, v3, and v4 workflow language in the refreshed wiki paths with `edge/stable`, `v6.0.0`, `v5.0.0`, `v4.4.0`, and Base1 foundation language.

## Validation

Documentation-only change. No code was changed.

Recommended local checks before merge:

```bash
sh scripts/quality-check.sh quick
sh scripts/quality-check.sh base1-docs
```

## Notes

This keeps Base1 described as a staged foundation rather than a finished hardened OS, and keeps Fyr examples limited to the currently documented language surface.