### PR TITLE
Add Fyr and Phase1 100% completion gates

### DIFF
--- a/docs/fyr/ROADMAP.md
+++ b/docs/fyr/ROADMAP.md
@@ -9,6 +9,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 - `examples/fyr/hello.fyr` and `examples/fyr/self_check.fyr` document the first source shape.
 - `fyr status`, `fyr spec`, and seed `fyr run <file.fyr>` support are wired into Phase1.
 - The seed runner can execute simple print string literals from `.fyr` files stored in the Phase1 VFS.
+- The 100% promotion gate is tracked in [`../status/FYR_PHASE1_100_COMPLETION_GATES.md`](../status/FYR_PHASE1_100_COMPLETION_GATES.md).
 
 ## Roadmap
 
@@ -22,6 +23,20 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 | F5 — Phase1 self-workflows | Use Fyr to help Phase1 inspect, copy, construct, and validate itself. | `fyr self`, repository manifest readers, docs sync helpers, checkpoint helpers. | Planned |
 | F6 — Standard library | Provide a small Phase1-owned standard library. | `vfs`, `text`, `json-lite`, `audit`, `process`, `package`, and `doc` modules. | Planned |
 | F7 — Compiler path | Decide whether Fyr remains interpreted, lowers to Rust, or targets WASI-lite. | Compiler design note, WASI-lite strategy, packaging contract. | Planned |
+
+## 100% promotion gate
+
+Fyr is not promoted to 100% because the name, command, or docs exist. It reaches 100% only when all F0-F7 stages are implemented, tested, documented, and reflected in public release evidence.
+
+Required promotion evidence:
+
+- F0-F2 remain stable after every parser/runtime change.
+- F3 core syntax has deterministic parser, diagnostics, duplicate-main, and missing-main tests.
+- F4 safe runtime stays VFS-only by default and has bounded runtime/error-redaction tests.
+- F5 Phase1 self-workflows operate on deterministic fixture data.
+- F6 standard library has smoke and failure-mode tests for each stable module.
+- F7 packaging/compiler decision has a design note, compatibility policy, and versioned examples.
+- `docs/status/FYR_PHASE1_100_COMPLETION_GATES.md` is satisfied before public status percentages are raised to 100%.
 
 ## Design rules
 

--- a/docs/project/FOCUS.md
+++ b/docs/project/FOCUS.md
@@ -18,6 +18,33 @@ The active project target is:
 Phase1/Base1: one bootable, testable, documented system path
 ```
 
+## Fyr completion exception
+
+Fyr language work is allowed only when it directly advances Phase1/Base1 completion.
+
+Allowed Fyr work:
+
+```text
+core syntax needed for operator scripts
+VFS-only runtime features
+safe package/check/test/build workflows
+Phase1 self-workflows
+validation helpers
+language-book updates that match implemented behavior
+```
+
+Still frozen for Fyr:
+
+```text
+speculative language expansion
+branding-only changes
+production-language claims
+host shell access outside guarded Phase1 policy
+new compiler claims without design evidence
+```
+
+The Fyr-to-100 and Phase1-to-100 gate is tracked in [`../status/FYR_PHASE1_100_COMPLETION_GATES.md`](../status/FYR_PHASE1_100_COMPLETION_GATES.md).
+
 ## Freeze rule
 
 All other project areas are frozen for new feature work unless they directly support Phase1/Base1 integration.
@@ -25,12 +52,11 @@ All other project areas are frozen for new feature work unless they directly sup
 Frozen areas include:
 
 ```text
-Fyr language work
 website/branding expansion
 community/support expansion
 new crypto-policy expansion
-new roadmap branches not required for Phase1/Base1 boot/runtime
-new release/public-claim work
+new roadmap branches not required for Phase1/Base1 boot/runtime/Fyr validation
+new release/public-claim work not backed by implementation and tests
 ```
 
 Existing files and documentation are preserved. Nothing is deleted just because it is frozen.
@@ -42,6 +68,7 @@ security fixes
 secret/privacy cleanup
 broken-link fixes
 build/test fixes required by Phase1/Base1
+Fyr changes that satisfy the completion exception above
 short notes pointing back to this focus policy
 ```
 
@@ -53,10 +80,13 @@ short notes pointing back to this focus policy
 4. Build the framebuffer path into a controlled Phase1/Base1 boot option.
 5. Preserve terminal and ASCII fallback paths.
 6. Add SSH/transfer support only after the boot/runtime path is organized.
-7. Promote only known-good work from `black-phase1` to `edge/stable`.
+7. Advance Fyr only where it improves Phase1 operator automation, validation, or self-workflows.
+8. Promote only known-good work from `black-phase1` to `edge/stable`.
 
 ## Non-claims
 
 This focus policy does not claim Phase1/Base1 is stable, hardened, audited, production-ready, or a daily-driver OS.
+
+It also does not claim Fyr is a production language or a general replacement for Rust, Python, C, or shell.
 
 It only defines what the project is focusing on now.

--- a/docs/status/FYR_PHASE1_100_COMPLETION_GATES.md
+++ b/docs/status/FYR_PHASE1_100_COMPLETION_GATES.md
@@ -1,0 +1,201 @@
+# Fyr and Phase1 100% completion gates
+
+Status: planning gate and evidence checklist  
+Scope: Fyr first, then Phase1 promotion alongside Fyr  
+Branch target: `edge/stable`
+
+This document defines what "100%" means for Fyr and for Phase1 without weakening the repository's existing non-claims. The goal is to move fast, but only promote percentages when implementation, tests, docs, and release evidence all agree.
+
+## Current public baseline
+
+The current public status marker lists:
+
+| Track | Current estimate | Current state | Next milestone |
+| --- | ---: | --- | --- |
+| Phase1 operator console | 82% | Usable edge console with guarded host access, VFS, dashboards, help UI, themes, learning, and tests. | Polish release-facing flows and keep safe defaults simple. |
+| Fyr native language | 44% | Seed language and toolchain surface exist with scripts, tests, assertions, package checks, and docs. | Expand language book, package workflow, and runtime integration. |
+| Overall roadmap | 65% | Active edge development with public status and evidence checkpoints. | Keep progress evidence-bound. |
+
+The repository organization track may remain 100% as long as root cleanliness, generated-artifact exclusion, and compatibility links stay clean.
+
+## Definition of 100%
+
+A track reaches 100% only when all of these are true:
+
+1. The feature is implemented in source, not only described in docs.
+2. The behavior has deterministic tests that pass in CI or in the recorded validation log.
+3. Public docs describe exactly what works and what does not.
+4. The public status marker and release notes match the evidence.
+5. Security, host-access, hardware, installer, daily-driver, and production-readiness non-claims remain explicit unless separately proven.
+
+## Fyr path to 100%
+
+### F0-F2: Identity, seed runner, and authoring loop
+
+Gate status: present but should stay evidence-checked.
+
+Required evidence:
+
+- `fyr status`, `fyr spec`, `fyr new`, `fyr cat`, `fyr self`, and `fyr run` are covered by tests.
+- README, native language spec, examples, and command help agree on `.fyr`, `fyr`, and VFS-first behavior.
+- No host shell, Cargo, network, or external compiler is required for seed workflows.
+
+Promotion target: keep this foundation stable; do not call it complete until the smoke suite is green after each parser/toolchain change.
+
+### F3: Core syntax
+
+Target after completion: Fyr can be described as a small, stable, Phase1-native scripting language instead of only a seed language.
+
+Required implementation:
+
+- Lexer/token handling for identifiers, integers, strings, punctuation, comments, and simple operators.
+- Parser support for `fn`, `let`, `return`, `print`, assertions, basic arithmetic, comparisons, and predictable blocks.
+- Diagnostics that name the file and explain the failure without leaking host details.
+- Duplicate entry-point detection and missing-main detection.
+
+Required tests:
+
+- Passing tests for valid single-file programs.
+- Passing tests for package `src/*.fyr` modules.
+- Failing tests for invalid identifiers, malformed blocks, unsupported values, duplicate `fn main`, and missing `fn main`.
+
+### F4: Safe runtime
+
+Target after completion: Fyr can run useful operator scripts inside Phase1 without expanding host authority.
+
+Required implementation:
+
+- Runtime remains VFS-only by default.
+- Read/write operations are explicit and bounded.
+- Runtime output is deterministic.
+- Errors are redacted, structured, and testable.
+- Time, size, and recursion limits are enforced before broader language growth.
+
+Required tests:
+
+- VFS read/write happy path.
+- Permission/guard failure path.
+- Bounded runtime path.
+- Error-redaction path.
+
+### F5: Phase1 self-workflows
+
+Target after completion: Fyr helps Phase1 inspect and maintain itself without replacing Rust.
+
+Required implementation:
+
+- Repository manifest reader.
+- Documentation sync helper.
+- Checkpoint helper.
+- Public status helper or read-only public status inspector.
+- `fyr self` explains current capability and limits.
+
+Required tests:
+
+- Self-workflow commands operate on fixture data.
+- Generated or inspected outputs remain deterministic.
+- The workflows refuse to alter host files unless a guarded Phase1 path explicitly permits it.
+
+### F6: Standard library
+
+Target after completion: Fyr has a small Phase1-owned standard library with stable names.
+
+Required modules:
+
+- `vfs`
+- `text`
+- `json-lite`
+- `audit`
+- `process` as metadata-only unless host execution is separately guarded
+- `package`
+- `doc`
+
+Required tests:
+
+- One smoke test per module.
+- One failure-mode test per module.
+- Compatibility tests for command-help and language-book examples.
+
+### F7: Compiler or packaging path
+
+Target after completion: the repository has a clear decision on whether Fyr remains interpreted, lowers to Rust, or targets WASI-lite.
+
+Required evidence:
+
+- Design note explaining the chosen path and rejected alternatives.
+- Packaging contract for `.fyr` projects.
+- Release compatibility policy.
+- Versioned example packages.
+
+## Fyr 100% release checklist
+
+Fyr may be marked 100% only when:
+
+- All F0-F7 gates are satisfied.
+- `cargo test` or the documented validation group passes.
+- Language-book examples match real command behavior.
+- Toolchain docs match real command behavior.
+- Public status moves from "seed language" wording to "Phase1-native scripting language" wording.
+- Non-claims still state that Fyr is not a production replacement for Rust, Python, C, or shell unless a separate production readiness review proves that claim.
+
+## Phase1 path alongside Fyr
+
+Phase1 should rise with Fyr, but not by hiding unfinished OS/security work. The Phase1 percentage can move when Fyr increases the practical operator surface and when the broader console remains stable.
+
+### P1: Release-facing operator flow
+
+Required evidence:
+
+- Quick start works from a clean checkout.
+- Main help, Fyr help, Base1 help, storage help, and update/status docs agree.
+- Public status, badge, and project status are generated from current repository state.
+
+### P2: Guarded host workspace
+
+Required evidence:
+
+- Host tool execution stays opt-in.
+- Git/Cargo flows, if enabled, run inside `.phase1/host-workspaces/` or another documented guarded workspace.
+- Argument filtering, timeout handling, audit output, and failure redaction are tested.
+
+### P3: Validation matrix
+
+Required evidence:
+
+- Unit tests pass.
+- Script syntax checks pass for maintained shell scripts.
+- Documentation integrity checks pass.
+- Link checks pass or publish a scoped exception file.
+- Public status generation is tested.
+
+### P4: Release candidate boundary
+
+Required evidence:
+
+- Release notes name what is included and what is not.
+- Hardware, installer, security-hardening, daily-driver, and production claims remain separate from roadmap progress.
+- Recovery and rollback instructions exist for any public release candidate.
+
+## Promotion rule
+
+Do not edit `site/status.json` or public percentage values manually to reach 100%. Update implementation and tests first, then regenerate public status from the repository state.
+
+Recommended order:
+
+1. Finish Fyr F3 core syntax and tests.
+2. Finish Fyr F4 safe runtime and tests.
+3. Land Phase1 guarded host workspace v2 so Git/Cargo flows are useful but contained.
+4. Finish F5 self-workflows.
+5. Add F6 standard library smoke/failure tests.
+6. Decide and document F7 packaging/compiler path.
+7. Regenerate status and publish release notes only after validation passes.
+
+## Public wording rule
+
+Use this wording until every 100% gate is satisfied:
+
+> Fyr is the Phase1-native language track. It has a seed runner, package bootstrap, checks, tests, and growing parser/runtime support. It is not yet a production language or a general replacement for Rust, Python, C, or shell.
+
+Use this wording only after the 100% gate is satisfied:
+
+> Fyr is Phase1's native scripting language for VFS-first operator automation, with documented syntax, deterministic tests, a bounded runtime, package workflow, standard library surface, and release compatibility policy.

--- a/tests/fyr_phase1_completion_gates.rs
+++ b/tests/fyr_phase1_completion_gates.rs
@@ -1,0 +1,47 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn fyr_phase1_completion_gate_defines_evidence_bound_100_percent() {
+    let path = "docs/status/FYR_PHASE1_100_COMPLETION_GATES.md";
+
+    assert_contains(path, "# Fyr and Phase1 100% completion gates");
+    assert_contains(path, "The feature is implemented in source, not only described in docs.");
+    assert_contains(path, "The behavior has deterministic tests");
+    assert_contains(path, "Public docs describe exactly what works and what does not.");
+    assert_contains(path, "Do not edit `site/status.json` or public percentage values manually to reach 100%.");
+    assert_contains(path, "All F0-F7 gates are satisfied.");
+    assert_contains(path, "Phase1 guarded host workspace v2");
+}
+
+#[test]
+fn fyr_roadmap_points_to_completion_gate() {
+    assert_contains(
+        "docs/fyr/ROADMAP.md",
+        "../status/FYR_PHASE1_100_COMPLETION_GATES.md",
+    );
+    assert_contains("docs/fyr/ROADMAP.md", "## 100% promotion gate");
+    assert_contains(
+        "docs/fyr/ROADMAP.md",
+        "Fyr is not promoted to 100% because the name, command, or docs exist.",
+    );
+}
+
+#[test]
+fn focus_policy_allows_only_phase1_aligned_fyr_work() {
+    assert_contains("docs/project/FOCUS.md", "## Fyr completion exception");
+    assert_contains(
+        "docs/project/FOCUS.md",
+        "Fyr language work is allowed only when it directly advances Phase1/Base1 completion.",
+    );
+    assert_contains("docs/project/FOCUS.md", "production-language claims");
+    assert_contains("docs/project/FOCUS.md", "host shell access outside guarded Phase1 policy");
+}


### PR DESCRIPTION
## Summary

This PR sets the evidence-bound path for pushing Fyr to 100% first, then promoting Phase1 alongside it without making premature production, hardware, security, installer, or daily-driver claims.

## Changes

- Adds `docs/status/FYR_PHASE1_100_COMPLETION_GATES.md` with explicit F0-F7 Fyr gates and Phase1 promotion gates.
- Updates the Fyr roadmap to point at the 100% promotion gate.
- Updates the Phase1/Base1 focus policy to allow Fyr work only when it directly advances Phase1/Base1 completion.
- Adds regression tests that require the completion-gate doc, roadmap link, and focus-policy exception to stay aligned.

## Intent

Current public baseline remains evidence-bound: Phase1 operator console 82%, Fyr 44%, overall 65%, repository organization 100%. This PR does not fake a percentage jump; it creates the checklist and tests needed to earn the next jumps toward 100%.

## Validation

Not run locally through this connector. Added deterministic Rust tests in `tests/fyr_phase1_completion_gates.rs` for the new documentation gates.