### PR TITLE
Advance Fyr F3 package diagnostics

### DIFF
--- a/docs/fyr/ROADMAP.md
+++ b/docs/fyr/ROADMAP.md
@@ -10,6 +10,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 - `fyr status`, `fyr spec`, and seed `fyr run <file.fyr>` support are wired into Phase1.
 - The seed runner can execute simple print string literals from `.fyr` files stored in the Phase1 VFS.
 - The 100% promotion gate is tracked in [`../status/FYR_PHASE1_100_COMPLETION_GATES.md`](../status/FYR_PHASE1_100_COMPLETION_GATES.md).
+- F3 parser diagnostics now include package manifest, package entry-point, duplicate-main, missing-main, string, semicolon, return-value, and boolean-condition checks.
 
 ## Roadmap
 
@@ -18,7 +19,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 | F0 — Identity | Establish the language name, file extension, command, and visual mark. | `assets/fyr_symbol.png`, `assets/fyr_word.png`, README reference, native language spec, roadmap. | Active |
 | F1 — Seed runner | Let Phase1 run simple `.fyr` programs from the VFS. | `fyr status`, `fyr spec`, `fyr run`, print literal support, guard tests. | Active |
 | F2 — Authoring loop | Make Fyr usable without manually echoing source code. | `fyr new <name>`, `fyr cat <file>`, `fyr self`, starter templates, safer VFS writes. | Active |
-| F3 — Core syntax | Define stable parser behavior inspired by C, Rust, and Python. | Lexer, parser, function blocks, variables, return values, comments, diagnostics. | Planned |
+| F3 — Core syntax | Define stable parser behavior inspired by C, Rust, and Python. | Lexer, parser, function blocks, variables, return values, comments, diagnostics. | Active |
 | F4 — Safe runtime | Execute useful scripts without exposing the host. | VFS reads/writes, command metadata, bounded runtime, redacted errors, deterministic tests. | Planned |
 | F5 — Phase1 self-workflows | Use Fyr to help Phase1 inspect, copy, construct, and validate itself. | `fyr self`, repository manifest readers, docs sync helpers, checkpoint helpers. | Planned |
 | F6 — Standard library | Provide a small Phase1-owned standard library. | `vfs`, `text`, `json-lite`, `audit`, `process`, `package`, and `doc` modules. | Planned |

--- a/tests/fyr_f3_package_diagnostics.rs
+++ b/tests/fyr_f3_package_diagnostics.rs
@@ -1,0 +1,93 @@
+use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn run_phase1(script: &str) -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let seq = RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let run_dir = std::env::temp_dir().join(format!(
+        "phase1-fyr-f3-package-{}-{nonce}-{seq}",
+        std::process::id()
+    ));
+
+    let _ = fs::remove_dir_all(&run_dir);
+    fs::create_dir_all(&run_dir).expect("create run dir");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .current_dir(&run_dir)
+        .env("PHASE1_NO_COLOR", "1")
+        .env("PHASE1_ASCII", "1")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_BLEEDING_EDGE", "1")
+        .env("PHASE1_MOBILE_MODE", "0")
+        .env("PHASE1_DEVICE_MODE", "desktop")
+        .env_remove("PHASE1_THEME")
+        .env_remove("PHASE1_ALLOW_HOST_TOOLS")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{script}").as_bytes())
+        .expect("write script");
+
+    let output = child.wait_with_output().expect("wait phase1");
+    let _ = fs::remove_dir_all(&run_dir);
+
+    let mut combined = String::new();
+    combined.push_str(&String::from_utf8_lossy(&output.stdout));
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success(), "phase1 failed:\n{combined}");
+    combined
+}
+
+#[test]
+fn fyr_f3_reports_missing_package_manifest() {
+    let output = run_phase1("fyr check ghost_package\nexit\n");
+
+    assert!(
+        output.contains("fyr check: ghost_package: missing package manifest ghost_package/fyr.toml"),
+        "{output}"
+    );
+}
+
+#[test]
+fn fyr_f3_reports_missing_package_main() {
+    let output = run_phase1("mkdir app\necho 'name = \"app\"' > app/fyr.toml\nfyr check app\nexit\n");
+
+    assert!(
+        output.contains("fyr check: app: missing package main app/src/main.fyr"),
+        "{output}"
+    );
+}
+
+#[test]
+fn fyr_f3_reports_duplicate_package_main() {
+    let output = run_phase1(
+        "fyr init app\necho 'fn main() -> i32 { return 0; }' > app/src/extra.fyr\nfyr check app\nexit\n",
+    );
+
+    assert!(output.contains("fyr check: app: duplicate fn main"), "{output}");
+}
+
+#[test]
+fn fyr_f3_build_surfaces_package_source_path() {
+    let output = run_phase1("fyr init app\nfyr build app\nexit\n");
+
+    assert!(output.contains("package : app"), "{output}");
+    assert!(output.contains("source  : app/src/main.fyr"), "{output}");
+    assert!(output.contains("backend : seed/interpreted"), "{output}");
+    assert!(output.contains("host    : none"), "{output}");
+}


### PR DESCRIPTION
## Summary

This PR is the next implementation-facing slice after the Fyr/Phase1 100% gate landed. It pushes Fyr F3 forward by expanding package-level diagnostic coverage and recording F3 diagnostics as active in the roadmap.

## Changes

- Adds `tests/fyr_f3_package_diagnostics.rs` with package diagnostic coverage for:
  - missing package manifest
  - missing package main
  - duplicate package `fn main`
  - package build source/backend/host reporting
- Updates `docs/fyr/ROADMAP.md` to mark F3 core syntax as active and note the diagnostics now covered.

## Why

The 100% gate says Fyr F3 needs deterministic parser diagnostics, duplicate-main, and missing-main coverage. This PR turns that gate into an enforced test slice without claiming F3 is complete.

## Validation

Not run locally through this connector. The new tests are deterministic Rust integration tests following the existing `fyr_parser_diagnostics.rs` harness shape.