### PR TITLE
Define Fyr F4 safety model boundary

### DIFF
--- a/docs/fyr/SAFETY_MODEL.md
+++ b/docs/fyr/SAFETY_MODEL.md
@@ -1,0 +1,83 @@
+# Fyr safety model
+
+Status: active F4 boundary document  
+Scope: current Fyr runtime/toolchain safety rules  
+Non-claim: this does not make Fyr production-ready, hardened, audited, or a general-purpose sandbox.
+
+Fyr is designed to become useful for Phase1 operator automation without expanding host authority. The current rule is simple: Fyr is VFS-first and host-independent by default.
+
+## Current safety boundary
+
+Current Fyr workflows must preserve these defaults:
+
+- VFS-only behavior by default.
+- No host shell.
+- No network.
+- No host compiler.
+- No Cargo invocation from Fyr commands.
+- Deterministic check/build/test/run output.
+- Package build output reports `backend : seed/interpreted` and `host    : none`.
+- Diagnostics should name Fyr files/packages without exposing host paths unless the operator explicitly chose a host-facing workflow outside Fyr.
+
+## Current allowed operations
+
+Current Fyr commands may:
+
+- create `.fyr` files in the Phase1 VFS;
+- create Fyr package structure in the Phase1 VFS;
+- read `.fyr` files from the Phase1 VFS;
+- parse and check supported source shapes;
+- dry-run build supported files/packages;
+- run supported print-literal seed programs;
+- run package tests stored under the package `tests/` directory;
+- report deterministic diagnostics.
+
+## Current denied operations
+
+Current Fyr commands must not:
+
+- call the host shell;
+- call Cargo;
+- call rustc or another host compiler;
+- access the network;
+- read arbitrary host files;
+- write arbitrary host files;
+- promise hardened sandboxing;
+- claim production language readiness.
+
+## F4 promotion requirements
+
+F4 may move from planned to active/completed only after the repository includes evidence for:
+
+- VFS read/write happy path tests.
+- Guard failure tests.
+- Bounded runtime tests.
+- Error-redaction tests.
+- Deterministic output tests.
+- Documentation that matches the implemented command behavior.
+
+## Operator wording
+
+Use this wording while F4 is still being built:
+
+> Fyr currently runs as a Phase1-owned, VFS-first seed language/toolchain. It avoids host shell, network, Cargo, and host compiler access by default. F4 safe runtime work is still in progress.
+
+Do not use this wording yet:
+
+> Fyr is a hardened sandbox.
+
+## Validation links
+
+Related docs:
+
+- [`TOOLCHAIN.md`](TOOLCHAIN.md)
+- [`LANGUAGE_BOOK.md`](LANGUAGE_BOOK.md)
+- [`ROADMAP.md`](ROADMAP.md)
+- [`../status/FYR_PHASE1_100_COMPLETION_GATES.md`](../status/FYR_PHASE1_100_COMPLETION_GATES.md)
+
+Related tests:
+
+- `tests/fyr_authoring_commands.rs`
+- `tests/fyr_parser_diagnostics.rs`
+- `tests/fyr_f3_package_diagnostics.rs`
+- `tests/fyr_f3_expression_diagnostics.rs`

--- a/docs/fyr/TOOLCHAIN.md
+++ b/docs/fyr/TOOLCHAIN.md
@@ -12,6 +12,8 @@ fyr check <file.fyr|package>
 fyr build <file.fyr|package>
 ```
 
+Additional active command surface is documented in [`LANGUAGE_BOOK.md`](LANGUAGE_BOOK.md).
+
 ## Package layout
 
 ```text
@@ -24,12 +26,17 @@ tests/
 
 ## Safety model
 
+The Fyr safety boundary is documented in [`SAFETY_MODEL.md`](SAFETY_MODEL.md).
+
+Current defaults:
+
 - VFS-only.
 - No Cargo invocation.
 - No host shell.
 - No network.
 - No host compiler.
 - Deterministic dry-run build output.
+- Build output reports `backend : seed/interpreted` and `host    : none`.
 
 ## Example
 

--- a/tests/fyr_safety_model_docs.rs
+++ b/tests/fyr_safety_model_docs.rs
@@ -1,0 +1,61 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn fyr_safety_model_preserves_no_host_boundary() {
+    let path = "docs/fyr/SAFETY_MODEL.md";
+
+    for boundary in [
+        "VFS-only behavior by default.",
+        "No host shell.",
+        "No network.",
+        "No host compiler.",
+        "No Cargo invocation from Fyr commands.",
+        "Deterministic check/build/test/run output.",
+        "host    : none",
+    ] {
+        assert_contains(path, boundary);
+    }
+}
+
+#[test]
+fn fyr_safety_model_keeps_non_claims_visible() {
+    let path = "docs/fyr/SAFETY_MODEL.md";
+
+    assert_contains(path, "does not make Fyr production-ready");
+    assert_contains(path, "hardened");
+    assert_contains(path, "audited");
+    assert_contains(path, "Do not use this wording yet:");
+    assert_contains(path, "Fyr is a hardened sandbox.");
+}
+
+#[test]
+fn fyr_safety_model_lists_f4_promotion_evidence() {
+    let path = "docs/fyr/SAFETY_MODEL.md";
+
+    for gate in [
+        "VFS read/write happy path tests.",
+        "Guard failure tests.",
+        "Bounded runtime tests.",
+        "Error-redaction tests.",
+        "Deterministic output tests.",
+    ] {
+        assert_contains(path, gate);
+    }
+}
+
+#[test]
+fn fyr_toolchain_links_to_safety_model() {
+    assert_contains("docs/fyr/TOOLCHAIN.md", "[`SAFETY_MODEL.md`](SAFETY_MODEL.md)");
+    assert_contains("docs/fyr/TOOLCHAIN.md", "No host shell.");
+    assert_contains("docs/fyr/TOOLCHAIN.md", "No network.");
+    assert_contains("docs/fyr/TOOLCHAIN.md", "No host compiler.");
+}


### PR DESCRIPTION
## Summary

This PR starts the F4 safe-runtime boundary work by documenting and testing Fyr's VFS-first/no-host-access safety model before adding more runtime authority.

## Changes

- Adds `docs/fyr/SAFETY_MODEL.md` with the current Fyr safety boundary:
  - VFS-only by default
  - no host shell
  - no network
  - no host compiler
  - no Cargo invocation from Fyr commands
  - deterministic output expectations
  - explicit non-claims
  - F4 promotion evidence requirements
- Links `docs/fyr/TOOLCHAIN.md` to the safety model and repeats the critical host-boundary defaults.
- Adds `tests/fyr_safety_model_docs.rs` to keep the safety boundary, non-claims, and F4 promotion requirements visible.

## Why

Before Fyr grows into F4 safe-runtime work, the boundary needs to be explicit and regression-tested. This avoids accidentally expanding Fyr into host shell/network/compiler access while pushing toward 100%.

## Validation

Not run locally through this connector. Added deterministic documentation regression tests.