### PR TITLE
Add Fyr F4 runtime safety tests

### DIFF
--- a/docs/fyr/ROADMAP.md
+++ b/docs/fyr/ROADMAP.md
@@ -11,6 +11,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 - The seed runner can execute simple print string literals from `.fyr` files stored in the Phase1 VFS.
 - The 100% promotion gate is tracked in [`../status/FYR_PHASE1_100_COMPLETION_GATES.md`](../status/FYR_PHASE1_100_COMPLETION_GATES.md).
 - F3 parser diagnostics now include package manifest, package entry-point, duplicate-main, missing-main, string, semicolon, return-value, boolean-condition, grouped-expression, division-by-zero, missing-operand, and boolean-operator checks.
+- F4 runtime-safety evidence now checks that `fyr build`, `fyr run`, and `fyr test` stay VFS-oriented and report no host-tool markers even when host tools are enabled for the wider Phase1 process.
 
 ## Roadmap
 
@@ -20,7 +21,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 | F1 — Seed runner | Let Phase1 run simple `.fyr` programs from the VFS. | `fyr status`, `fyr spec`, `fyr run`, print literal support, guard tests. | Active |
 | F2 — Authoring loop | Make Fyr usable without manually echoing source code. | `fyr new <name>`, `fyr cat <file>`, `fyr self`, starter templates, safer VFS writes. | Active |
 | F3 — Core syntax | Define stable parser behavior inspired by C, Rust, and Python. | Lexer, parser, function blocks, variables, return values, comments, diagnostics. | Active |
-| F4 — Safe runtime | Execute useful scripts without exposing the host. | VFS reads/writes, command metadata, bounded runtime, redacted errors, deterministic tests. | Planned |
+| F4 — Safe runtime | Execute useful scripts without exposing the host. | VFS reads/writes, command metadata, bounded runtime, redacted errors, deterministic tests. | Active |
 | F5 — Phase1 self-workflows | Use Fyr to help Phase1 inspect, copy, construct, and validate itself. | `fyr self`, repository manifest readers, docs sync helpers, checkpoint helpers. | Planned |
 | F6 — Standard library | Provide a small Phase1-owned standard library. | `vfs`, `text`, `json-lite`, `audit`, `process`, `package`, and `doc` modules. | Planned |
 | F7 — Compiler path | Decide whether Fyr remains interpreted, lowers to Rust, or targets WASI-lite. | Compiler design note, WASI-lite strategy, packaging contract. | Planned |

--- a/tests/fyr_f4_runtime_safety.rs
+++ b/tests/fyr_f4_runtime_safety.rs
@@ -1,0 +1,110 @@
+use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn run_phase1(script: &str) -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let seq = RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let run_dir = std::env::temp_dir().join(format!(
+        "phase1-fyr-f4-runtime-{}-{nonce}-{seq}",
+        std::process::id()
+    ));
+
+    let _ = fs::remove_dir_all(&run_dir);
+    fs::create_dir_all(&run_dir).expect("create run dir");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .current_dir(&run_dir)
+        .env("PHASE1_NO_COLOR", "1")
+        .env("PHASE1_ASCII", "1")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_BLEEDING_EDGE", "1")
+        .env("PHASE1_MOBILE_MODE", "0")
+        .env("PHASE1_DEVICE_MODE", "desktop")
+        .env("PHASE1_ALLOW_HOST_TOOLS", "1")
+        .env_remove("PHASE1_THEME")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{script}").as_bytes())
+        .expect("write script");
+
+    let output = child.wait_with_output().expect("wait phase1");
+    let _ = fs::remove_dir_all(&run_dir);
+
+    let mut combined = String::new();
+    combined.push_str(&String::from_utf8_lossy(&output.stdout));
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success(), "phase1 failed:\n{combined}");
+    combined
+}
+
+fn assert_no_host_tool_output(output: &str) {
+    for forbidden in [
+        "cargo run",
+        "cargo build",
+        "rustc ",
+        "sh:",
+        "bash:",
+        "network",
+        "download",
+    ] {
+        assert!(
+            !output.to_lowercase().contains(&forbidden.to_lowercase()),
+            "unexpected host-tool marker {forbidden:?} in output:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn fyr_build_reports_host_none_even_when_host_tools_are_allowed() {
+    let output = run_phase1("fyr init app\nfyr build app\nexit\n");
+
+    assert!(output.contains("fyr build"), "{output}");
+    assert!(output.contains("package : app"), "{output}");
+    assert!(output.contains("source  : app/src/main.fyr"), "{output}");
+    assert!(output.contains("backend : seed/interpreted"), "{output}");
+    assert!(output.contains("host    : none"), "{output}");
+    assert!(
+        output.contains("status  : dry-run artifact ready"),
+        "{output}"
+    );
+    assert_no_host_tool_output(&output);
+}
+
+#[test]
+fn fyr_run_uses_vfs_source_without_host_tool_markers() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { print(\"f4 runtime stays vfs only\"); return 0; }' > safe.fyr\nfyr check safe.fyr\nfyr run safe.fyr\nexit\n",
+    );
+
+    assert!(output.contains("fyr check: ok safe.fyr"), "{output}");
+    assert!(output.contains("f4 runtime stays vfs only"), "{output}");
+    assert_no_host_tool_output(&output);
+}
+
+#[test]
+fn fyr_test_runs_vfs_package_tests_without_host_tool_markers() {
+    let output = run_phase1(
+        "fyr init app\necho 'fn main() -> i32 { assert_eq(21 + 21, 42); return 0; }' > app/tests/math.fyr\nfyr test app\nexit\n",
+    );
+
+    assert!(output.contains("test    : app/tests/math.fyr ok"), "{output}");
+    assert!(output.contains("failed  : 0"), "{output}");
+    assert!(output.contains("status  : ok"), "{output}");
+    assert_no_host_tool_output(&output);
+}


### PR DESCRIPTION
## Summary

This PR moves Fyr F4 from a documented safety boundary into runtime-facing evidence by testing that build/run/test workflows stay VFS-oriented and host-independent.

## Changes

- Adds `tests/fyr_f4_runtime_safety.rs` covering:
  - `fyr build` reports `backend : seed/interpreted` and `host    : none`
  - `fyr run` uses VFS source and avoids host-tool markers
  - `fyr test` runs package tests without host-tool markers
  - behavior remains host-independent even when `PHASE1_ALLOW_HOST_TOOLS=1` is present for the wider Phase1 process
- Updates `docs/fyr/ROADMAP.md` to mark F4 as active and record this runtime-safety evidence.

## Why

F4 requires evidence that useful Fyr workflows do not expand host authority. This adds tests that exercise real Phase1 command flows instead of only documenting the boundary.

## Validation

Not run locally through this connector. Added deterministic Phase1 integration tests.