### PR TITLE
Add Fyr F4 error redaction evidence

### DIFF
--- a/docs/fyr/ROADMAP.md
+++ b/docs/fyr/ROADMAP.md
@@ -12,6 +12,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 - The 100% promotion gate is tracked in [`../status/FYR_PHASE1_100_COMPLETION_GATES.md`](../status/FYR_PHASE1_100_COMPLETION_GATES.md).
 - F3 parser diagnostics now include package manifest, package entry-point, duplicate-main, missing-main, string, semicolon, return-value, boolean-condition, grouped-expression, division-by-zero, missing-operand, and boolean-operator checks.
 - F4 runtime-safety evidence now checks that `fyr build`, `fyr run`, and `fyr test` stay VFS-oriented and report no host-tool markers even when host tools are enabled for the wider Phase1 process.
+- F4 error-redaction evidence now checks that check/package/test diagnostics stay target-scoped and avoid host temp paths, host-tool environment markers, shell/compiler text, and network URLs.
 
 ## Roadmap
 

--- a/docs/fyr/SAFETY_MODEL.md
+++ b/docs/fyr/SAFETY_MODEL.md
@@ -45,6 +45,38 @@ Current Fyr commands must not:
 - promise hardened sandboxing;
 - claim production language readiness.
 
+## Current bounded-runtime behavior
+
+Fyr does not yet expose unbounded language features such as open-ended loops, recursion, host process execution, network access, or external compiler calls.
+
+Current bounds are intentionally conservative:
+
+- supported execution is limited to parsed `.fyr` files stored in the Phase1 VFS;
+- package tests execute only discovered `.fyr` files under the package `tests/` directory;
+- build output is a deterministic dry-run artifact summary;
+- unsupported or malformed source should fail during check/build/test/run instead of falling through to a host tool;
+- diagnostics should remain target-scoped and deterministic.
+
+## Current error-redaction behavior
+
+Fyr diagnostics should identify the Phase1 VFS target, not the host workspace used to run Phase1 tests.
+
+Expected diagnostic shape:
+
+```text
+fyr check: bad.fyr: <deterministic message>
+fyr check: app: <deterministic package message>
+```
+
+Diagnostics must not require or expose:
+
+- host temp directories;
+- checkout paths;
+- host shell error text;
+- compiler command lines;
+- network URLs;
+- secrets or environment values.
+
 ## F4 promotion requirements
 
 F4 may move from planned to active/completed only after the repository includes evidence for:
@@ -81,3 +113,5 @@ Related tests:
 - `tests/fyr_parser_diagnostics.rs`
 - `tests/fyr_f3_package_diagnostics.rs`
 - `tests/fyr_f3_expression_diagnostics.rs`
+- `tests/fyr_f4_runtime_safety.rs`
+- `tests/fyr_f4_error_redaction.rs`

--- a/tests/fyr_f4_error_redaction.rs
+++ b/tests/fyr_f4_error_redaction.rs
@@ -1,0 +1,110 @@
+use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn run_phase1(script: &str) -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let seq = RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let run_dir = std::env::temp_dir().join(format!(
+        "phase1-fyr-f4-errors-{}-{nonce}-{seq}",
+        std::process::id()
+    ));
+
+    let _ = fs::remove_dir_all(&run_dir);
+    fs::create_dir_all(&run_dir).expect("create run dir");
+    let host_path_marker = run_dir.display().to_string();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .current_dir(&run_dir)
+        .env("PHASE1_NO_COLOR", "1")
+        .env("PHASE1_ASCII", "1")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_BLEEDING_EDGE", "1")
+        .env("PHASE1_MOBILE_MODE", "0")
+        .env("PHASE1_DEVICE_MODE", "desktop")
+        .env("PHASE1_ALLOW_HOST_TOOLS", "1")
+        .env_remove("PHASE1_THEME")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{script}").as_bytes())
+        .expect("write script");
+
+    let output = child.wait_with_output().expect("wait phase1");
+    let _ = fs::remove_dir_all(&run_dir);
+
+    let mut combined = String::new();
+    combined.push_str(&String::from_utf8_lossy(&output.stdout));
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success(), "phase1 failed:\n{combined}");
+    assert!(
+        !combined.contains(&host_path_marker),
+        "Fyr diagnostics leaked host run dir {host_path_marker}:\n{combined}"
+    );
+    combined
+}
+
+fn assert_redacted(output: &str) {
+    for forbidden in [
+        "/tmp/",
+        "phase1-fyr-f4-errors",
+        "CARGO_BIN_EXE_phase1",
+        "PHASE1_ALLOW_HOST_TOOLS",
+        "cargo ",
+        "rustc ",
+        "bash:",
+        "sh:",
+        "http://",
+        "https://",
+    ] {
+        assert!(
+            !output.contains(forbidden),
+            "diagnostic should not contain {forbidden:?}:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn fyr_check_error_is_target_scoped_and_redacted() {
+    let output = run_phase1(
+        "echo 'fn main() -> i32 { print(\"unterminated); return 0; }' > bad.fyr\nfyr check bad.fyr\nexit\n",
+    );
+
+    assert!(output.contains("fyr check: bad.fyr:"), "{output}");
+    assert!(output.contains("unterminated string literal"), "{output}");
+    assert_redacted(&output);
+}
+
+#[test]
+fn fyr_package_error_is_package_scoped_and_redacted() {
+    let output = run_phase1("fyr check ghost_package\nexit\n");
+
+    assert!(output.contains("fyr check: ghost_package:"), "{output}");
+    assert!(output.contains("missing package manifest"), "{output}");
+    assert_redacted(&output);
+}
+
+#[test]
+fn fyr_test_error_stays_inside_vfs_package_scope() {
+    let output = run_phase1(
+        "fyr init app\necho 'fn main() -> i32 { let bad = 10 / (5 - 5); return bad; }' > app/tests/bad.fyr\nfyr test app\nexit\n",
+    );
+
+    assert!(output.contains("app/tests/bad.fyr"), "{output}");
+    assert!(output.contains("division by zero"), "{output}");
+    assert_redacted(&output);
+}


### PR DESCRIPTION
## Summary

This PR continues the Fyr F4 safe-runtime push by adding target-scoped error-redaction evidence and documenting bounded-runtime/error behavior.

## Changes

- Updates `docs/fyr/SAFETY_MODEL.md` with:
  - current bounded-runtime behavior
  - current error-redaction behavior
  - expected target-scoped diagnostic shapes
  - forbidden host path/tool/network/environment leak categories
- Adds `tests/fyr_f4_error_redaction.rs` covering:
  - single-file check errors remain target-scoped and redacted
  - package errors remain package-scoped and redacted
  - package test errors remain inside the VFS package scope
- Updates `docs/fyr/ROADMAP.md` to record F4 error-redaction evidence.

## Why

F4 requires bounded runtime and redacted error evidence. This PR adds tests that exercise real Phase1/Fyr command flows and verify diagnostics do not expose host temp paths, host-tool environment markers, shell/compiler text, or network URLs.

## Validation

Not run locally through this connector. Added deterministic Phase1 integration tests and documentation updates.