### PR TITLE
Add Fyr F4 VFS workflow evidence

### DIFF
--- a/docs/fyr/ROADMAP.md
+++ b/docs/fyr/ROADMAP.md
@@ -14,6 +14,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 - F4 runtime-safety evidence now checks that `fyr build`, `fyr run`, and `fyr test` stay VFS-oriented and report no host-tool markers even when host tools are enabled for the wider Phase1 process.
 - F4 error-redaction evidence now checks that check/package/test diagnostics stay target-scoped and avoid host temp paths, host-tool environment markers, shell/compiler text, and network URLs.
 - F4 deterministic-output evidence now compares repeated `fyr build`, `fyr run`, and `fyr test` output slices so the safe runtime stays repeatable.
+- F4 VFS workflow evidence now covers `fyr new`, `fyr cat`, `fyr init`, `fyr check`, `fyr build`, `fyr test`, and `fyr run` working together without host-tool markers.
 
 ## Roadmap
 

--- a/docs/fyr/SAFETY_MODEL.md
+++ b/docs/fyr/SAFETY_MODEL.md
@@ -89,6 +89,16 @@ Current evidence compares the Fyr-relevant output slices from repeated runs of:
 
 The comparison ignores Phase1 boot/prompt noise and focuses on Fyr command lines such as package, source, AST, backend, host, status, test, passed, and failed rows.
 
+## Current VFS workflow behavior
+
+Current evidence exercises Fyr file and package workflows end-to-end inside the Phase1 VFS:
+
+- `fyr new` creates a `.fyr` source file;
+- `fyr cat` reads the created VFS source file;
+- `fyr new` refuses to overwrite an existing VFS source file;
+- `fyr init` creates a package manifest, source file, and smoke test in the VFS;
+- `fyr check`, `fyr build`, `fyr test`, and `fyr run` operate on those VFS files without host-tool markers.
+
 ## F4 promotion requirements
 
 F4 may move from planned to active/completed only after the repository includes evidence for:
@@ -128,3 +138,4 @@ Related tests:
 - `tests/fyr_f4_runtime_safety.rs`
 - `tests/fyr_f4_error_redaction.rs`
 - `tests/fyr_f4_deterministic_output.rs`
+- `tests/fyr_f4_vfs_workflows.rs`

--- a/tests/fyr_f4_vfs_workflows.rs
+++ b/tests/fyr_f4_vfs_workflows.rs
@@ -1,0 +1,110 @@
+use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn run_phase1(script: &str) -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let seq = RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let run_dir = std::env::temp_dir().join(format!(
+        "phase1-fyr-f4-vfs-{}-{nonce}-{seq}",
+        std::process::id()
+    ));
+
+    let _ = fs::remove_dir_all(&run_dir);
+    fs::create_dir_all(&run_dir).expect("create run dir");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .current_dir(&run_dir)
+        .env("PHASE1_NO_COLOR", "1")
+        .env("PHASE1_ASCII", "1")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_BLEEDING_EDGE", "1")
+        .env("PHASE1_MOBILE_MODE", "0")
+        .env("PHASE1_DEVICE_MODE", "desktop")
+        .env("PHASE1_ALLOW_HOST_TOOLS", "1")
+        .env_remove("PHASE1_THEME")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{script}").as_bytes())
+        .expect("write script");
+
+    let output = child.wait_with_output().expect("wait phase1");
+    let _ = fs::remove_dir_all(&run_dir);
+
+    let mut combined = String::new();
+    combined.push_str(&String::from_utf8_lossy(&output.stdout));
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success(), "phase1 failed:\n{combined}");
+    combined
+}
+
+fn assert_no_host_markers(output: &str) {
+    for forbidden in [
+        "cargo ",
+        "rustc ",
+        "bash:",
+        "sh:",
+        "http://",
+        "https://",
+        "download",
+        "network",
+    ] {
+        assert!(
+            !output.to_lowercase().contains(&forbidden.to_lowercase()),
+            "unexpected host marker {forbidden:?}:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn fyr_new_cat_check_run_stays_inside_vfs() {
+    let output = run_phase1("fyr new hello\nfyr cat hello.fyr\nfyr check hello.fyr\nfyr run hello.fyr\nexit\n");
+
+    assert!(output.contains("fyr new: created hello.fyr"), "{output}");
+    assert!(output.contains("fn main() -> i32"), "{output}");
+    assert!(output.contains("fyr check: ok hello.fyr"), "{output}");
+    assert!(output.contains("Hello, hacker!"), "{output}");
+    assert_no_host_markers(&output);
+}
+
+#[test]
+fn fyr_init_creates_vfs_package_that_checks_builds_tests_and_runs() {
+    let output = run_phase1("fyr init app\nfyr check app\nfyr build app\nfyr test app\nfyr run app/src/main.fyr\nexit\n");
+
+    assert!(output.contains("fyr init: created package app"), "{output}");
+    assert!(output.contains("manifest: app/fyr.toml"), "{output}");
+    assert!(output.contains("main    : app/src/main.fyr"), "{output}");
+    assert!(output.contains("tests   : app/tests/smoke.fyr"), "{output}");
+    assert!(output.contains("fyr check: ok app/src/main.fyr"), "{output}");
+    assert!(output.contains("package : app"), "{output}");
+    assert!(output.contains("backend : seed/interpreted"), "{output}");
+    assert!(output.contains("host    : none"), "{output}");
+    assert!(output.contains("test    : app/tests/smoke.fyr ok"), "{output}");
+    assert!(output.contains("Hello from Fyr package"), "{output}");
+    assert_no_host_markers(&output);
+}
+
+#[test]
+fn fyr_new_refuses_to_overwrite_existing_vfs_file() {
+    let output = run_phase1("fyr new hello\nfyr new hello\nfyr cat hello.fyr\nexit\n");
+
+    assert!(output.contains("fyr new: created hello.fyr"), "{output}");
+    assert!(output.contains("fyr new: hello.fyr already exists"), "{output}");
+    assert!(output.contains("Hello, hacker!"), "{output}");
+    assert_no_host_markers(&output);
+}


### PR DESCRIPTION
## Summary

This PR continues the Fyr F4 safe-runtime push by adding live VFS workflow evidence for Fyr file and package operations.

## Changes

- Adds `tests/fyr_f4_vfs_workflows.rs` covering:
  - `fyr new` creates a `.fyr` source file in the Phase1 VFS
  - `fyr cat` reads that VFS source file
  - `fyr new` refuses to overwrite an existing VFS source file
  - `fyr init` creates package manifest/source/test files in the VFS
  - `fyr check`, `fyr build`, `fyr test`, and `fyr run` operate on those VFS files without host-tool markers
- Updates `docs/fyr/SAFETY_MODEL.md` with current VFS workflow behavior.
- Updates `docs/fyr/ROADMAP.md` to record F4 VFS workflow evidence.

## Why

F4 requires VFS read/write happy-path evidence. This PR turns that requirement into live Phase1/Fyr integration tests instead of documentation-only claims.

## Validation

Not run locally through this connector. Added deterministic Phase1 integration tests and documentation updates.