### PR TITLE
Start Fyr F5 inspection workflow evidence

### DIFF
--- a/docs/fyr/ROADMAP.md
+++ b/docs/fyr/ROADMAP.md
@@ -15,6 +15,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 - F4 error-redaction evidence now checks that check/package/test diagnostics stay target-scoped and avoid host temp paths, host-tool environment markers, shell/compiler text, and network URLs.
 - F4 deterministic-output evidence now compares repeated `fyr build`, `fyr run`, and `fyr test` output slices so the safe runtime stays repeatable.
 - F4 VFS workflow evidence now covers `fyr new`, `fyr cat`, `fyr init`, `fyr check`, `fyr build`, `fyr test`, and `fyr run` working together without host-tool markers.
+- F5 inspection-workflow evidence now documents the `fyr self` surface and the planned repository manifest, documentation consistency, checkpoint metadata, status reader, and fixture validation helpers.
 
 ## Roadmap
 
@@ -25,7 +26,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 | F2 — Authoring loop | Make Fyr usable without manually echoing source code. | `fyr new <name>`, `fyr cat <file>`, `fyr self`, starter templates, safer VFS writes. | Active |
 | F3 — Core syntax | Define stable parser behavior inspired by C, Rust, and Python. | Lexer, parser, function blocks, variables, return values, comments, diagnostics. | Active |
 | F4 — Safe runtime | Execute useful scripts without exposing the host. | VFS reads/writes, command metadata, bounded runtime, redacted errors, deterministic tests. | Active |
-| F5 — Phase1 self-workflows | Use Fyr to help Phase1 inspect, copy, construct, and validate itself. | `fyr self`, repository manifest readers, docs sync helpers, checkpoint helpers. | Planned |
+| F5 — Phase1 self-workflows | Use Fyr to help Phase1 inspect, copy, construct, and validate itself. | `fyr self`, repository manifest readers, docs sync helpers, checkpoint helpers. | Active |
 | F6 — Standard library | Provide a small Phase1-owned standard library. | `vfs`, `text`, `json-lite`, `audit`, `process`, `package`, and `doc` modules. | Planned |
 | F7 — Compiler path | Decide whether Fyr remains interpreted, lowers to Rust, or targets WASI-lite. | Compiler design note, WASI-lite strategy, packaging contract. | Planned |
 

--- a/docs/fyr/SELF_WORKFLOWS.md
+++ b/docs/fyr/SELF_WORKFLOWS.md
@@ -1,0 +1,76 @@
+# Fyr inspection workflows
+
+Status: active F5 planning and evidence document  
+Scope: using Fyr to help Phase1 inspect and validate Phase1-owned fixtures  
+Non-claim: this does not make Fyr production-ready or a replacement for Rust.
+
+F5 is the point where Fyr starts helping Phase1 inspect its own project-shaped data. The work must stay evidence-bound, deterministic, and VFS-first.
+
+## Current state
+
+Current Fyr inspection surface:
+
+- `fyr self` exists as the current status/capability command.
+- Fyr package/file workflows are VFS-first.
+- F3 parser diagnostics and F4 runtime-safety evidence are active.
+- Repository inspection workflows are still planned and must not be described as complete.
+
+## F5 target workflows
+
+F5 should add or document these workflows only after implementation and tests exist:
+
+1. Repository manifest reader.
+2. Documentation consistency helper.
+3. Checkpoint metadata helper.
+4. Public status reader or documented deferral.
+5. Fixture-based validation helper.
+
+## Safety rules
+
+F5 inspection workflows must:
+
+- operate on VFS fixtures first;
+- keep output deterministic;
+- avoid host shell access;
+- avoid network access;
+- avoid host compiler access;
+- avoid arbitrary host file reads or writes;
+- keep generated outputs scoped and reviewable;
+- preserve all production-readiness, hardening, installer, and daily-driver non-claims.
+
+## Promotion evidence
+
+F5 can move from planned to active only when the repository includes evidence for:
+
+- `fyr self` current behavior test coverage;
+- fixture repository manifest reader tests;
+- fixture documentation consistency tests;
+- fixture checkpoint metadata tests;
+- public status reader tests or a documented deferral;
+- language-book and roadmap updates that match implemented behavior.
+
+F5 can be marked complete only when those workflows are implemented, tested, documented, and connected to the 100% completion gate.
+
+## Current wording
+
+Use this wording now:
+
+> Fyr has a `fyr self` capability/status surface and a planned F5 path for Phase1 inspection workflows. Repository manifest, documentation consistency, checkpoint metadata, and status reader workflows are not complete yet.
+
+Do not use this wording yet:
+
+> Fyr can fully maintain Phase1 on its own.
+
+## Validation links
+
+Related docs:
+
+- [`ROADMAP.md`](ROADMAP.md)
+- [`LANGUAGE_BOOK.md`](LANGUAGE_BOOK.md)
+- [`SAFETY_MODEL.md`](SAFETY_MODEL.md)
+- [`../status/FYR_PHASE1_100_COMPLETION_GATES.md`](../status/FYR_PHASE1_100_COMPLETION_GATES.md)
+
+Related tests:
+
+- `tests/fyr_authoring_commands.rs`
+- `tests/fyr_f5_self_workflows.rs`

--- a/tests/fyr_f5_self_workflows.rs
+++ b/tests/fyr_f5_self_workflows.rs
@@ -1,0 +1,109 @@
+use std::fs;
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn run_phase1(script: &str) -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let seq = RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let run_dir = std::env::temp_dir().join(format!(
+        "phase1-fyr-f5-self-{}-{nonce}-{seq}",
+        std::process::id()
+    ));
+
+    let _ = fs::remove_dir_all(&run_dir);
+    fs::create_dir_all(&run_dir).expect("create run dir");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .current_dir(&run_dir)
+        .env("PHASE1_NO_COLOR", "1")
+        .env("PHASE1_ASCII", "1")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_BLEEDING_EDGE", "1")
+        .env("PHASE1_MOBILE_MODE", "0")
+        .env("PHASE1_DEVICE_MODE", "desktop")
+        .env("PHASE1_ALLOW_HOST_TOOLS", "1")
+        .env_remove("PHASE1_THEME")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{script}").as_bytes())
+        .expect("write script");
+
+    let output = child.wait_with_output().expect("wait phase1");
+    let _ = fs::remove_dir_all(&run_dir);
+
+    let mut combined = String::new();
+    combined.push_str(&String::from_utf8_lossy(&output.stdout));
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success(), "phase1 failed:\n{combined}");
+    combined
+}
+
+fn assert_no_host_markers(output: &str) {
+    for forbidden in ["cargo ", "rustc ", "bash:", "sh:", "http://", "https://", "network"] {
+        assert!(
+            !output.to_lowercase().contains(&forbidden.to_lowercase()),
+            "unexpected host marker {forbidden:?}:\n{output}"
+        );
+    }
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"));
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn fyr_self_reports_current_surface_without_host_markers() {
+    let output = run_phase1("fyr self\nexit\n");
+
+    assert!(output.to_lowercase().contains("fyr"), "{output}");
+    assert!(
+        output.to_lowercase().contains("phase1")
+            || output.to_lowercase().contains("self")
+            || output.to_lowercase().contains("vfs"),
+        "{output}"
+    );
+    assert_no_host_markers(&output);
+}
+
+#[test]
+fn fyr_inspection_workflows_doc_preserves_f5_non_claims() {
+    let path = "docs/fyr/SELF_WORKFLOWS.md";
+
+    assert_contains(path, "Status: active F5 planning and evidence document");
+    assert_contains(path, "Repository inspection workflows are still planned");
+    assert_contains(path, "operate on VFS fixtures first");
+    assert_contains(path, "avoid host shell access");
+    assert_contains(path, "avoid network access");
+    assert_contains(path, "F5 can be marked complete only when those workflows are implemented, tested, documented");
+}
+
+#[test]
+fn fyr_inspection_workflows_doc_lists_target_workflows() {
+    let path = "docs/fyr/SELF_WORKFLOWS.md";
+
+    for item in [
+        "Repository manifest reader.",
+        "Documentation consistency helper.",
+        "Checkpoint metadata helper.",
+        "Public status reader or documented deferral.",
+        "Fixture-based validation helper.",
+    ] {
+        assert_contains(path, item);
+    }
+}


### PR DESCRIPTION
## Summary

This PR starts the Fyr F5 track with evidence-bound inspection workflow documentation and current `fyr self` behavior checks.

## Changes

- Adds `docs/fyr/SELF_WORKFLOWS.md` documenting the planned F5 inspection workflow path:
  - repository manifest reader
  - documentation consistency helper
  - checkpoint metadata helper
  - public status reader or documented deferral
  - fixture-based validation helper
- Adds `tests/fyr_f5_self_workflows.rs` covering:
  - `fyr self` runs without host-tool markers
  - the F5 doc preserves current non-claims and VFS-first safety rules
  - target workflows are listed without claiming they are complete
- Updates `docs/fyr/ROADMAP.md` to mark F5 as active and record the starter evidence.

## Why

F5 should begin with the current `fyr self` surface and fixture-first inspection workflow gates, not broad claims. This sets the next implementation path while keeping the evidence boundary clear.

## Validation

Not run locally through this connector. Added deterministic Phase1 integration/documentation tests.