### PR TITLE
Add Fyr F5 manifest fixture evidence

### DIFF
--- a/docs/fyr/ROADMAP.md
+++ b/docs/fyr/ROADMAP.md
@@ -16,6 +16,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 - F4 deterministic-output evidence now compares repeated `fyr build`, `fyr run`, and `fyr test` output slices so the safe runtime stays repeatable.
 - F4 VFS workflow evidence now covers `fyr new`, `fyr cat`, `fyr init`, `fyr check`, `fyr build`, `fyr test`, and `fyr run` working together without host-tool markers.
 - F5 inspection-workflow evidence now documents the `fyr self` surface and the planned repository manifest, documentation consistency, checkpoint metadata, status reader, and fixture validation helpers.
+- F5 manifest-fixture evidence now validates a project-shaped manifest fixture and checks that listed documentation paths exist.
 
 ## Roadmap
 

--- a/docs/fyr/SELF_WORKFLOWS.md
+++ b/docs/fyr/SELF_WORKFLOWS.md
@@ -14,6 +14,7 @@ Current Fyr inspection surface:
 - Fyr package/file workflows are VFS-first.
 - F3 parser diagnostics and F4 runtime-safety evidence are active.
 - Repository inspection workflows are still planned and must not be described as complete.
+- The first repository-manifest fixture lives at [`fixtures/repo-manifest-ok.txt`](fixtures/repo-manifest-ok.txt).
 
 ## F5 target workflows
 
@@ -24,6 +25,16 @@ F5 should add or document these workflows only after implementation and tests ex
 3. Checkpoint metadata helper.
 4. Public status reader or documented deferral.
 5. Fixture-based validation helper.
+
+## Repository manifest fixture
+
+The first fixture is intentionally small and static:
+
+```text
+docs/fyr/fixtures/repo-manifest-ok.txt
+```
+
+It records a project-shaped manifest with a name, root, kind, file list, and check list. It is test evidence for the future manifest reader; it is not yet a full reader command.
 
 ## Safety rules
 
@@ -70,7 +81,12 @@ Related docs:
 - [`SAFETY_MODEL.md`](SAFETY_MODEL.md)
 - [`../status/FYR_PHASE1_100_COMPLETION_GATES.md`](../status/FYR_PHASE1_100_COMPLETION_GATES.md)
 
+Related fixtures:
+
+- [`fixtures/repo-manifest-ok.txt`](fixtures/repo-manifest-ok.txt)
+
 Related tests:
 
 - `tests/fyr_authoring_commands.rs`
 - `tests/fyr_f5_self_workflows.rs`
+- `tests/fyr_f5_manifest_fixtures.rs`

--- a/docs/fyr/fixtures/repo-manifest-ok.txt
+++ b/docs/fyr/fixtures/repo-manifest-ok.txt
@@ -1,0 +1,11 @@
+name: phase1-fixture
+root: /phase1
+kind: fixture
+files:
+  - docs/fyr/SELF_WORKFLOWS.md
+  - docs/fyr/ROADMAP.md
+  - docs/fyr/SAFETY_MODEL.md
+checks:
+  - deterministic
+  - vfs-first
+  - bounded

--- a/tests/fyr_f5_manifest_fixtures.rs
+++ b/tests/fyr_f5_manifest_fixtures.rs
@@ -1,0 +1,50 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn fyr_f5_repo_manifest_fixture_has_required_shape() {
+    let path = "docs/fyr/fixtures/repo-manifest-ok.txt";
+
+    for field in [
+        "name: phase1-fixture",
+        "root: /phase1",
+        "kind: fixture",
+        "files:",
+        "checks:",
+        "deterministic",
+        "vfs-first",
+        "bounded",
+    ] {
+        assert_contains(path, field);
+    }
+}
+
+#[test]
+fn fyr_f5_repo_manifest_fixture_points_to_existing_docs() {
+    let fixture = read("docs/fyr/fixtures/repo-manifest-ok.txt");
+
+    for path in [
+        "docs/fyr/SELF_WORKFLOWS.md",
+        "docs/fyr/ROADMAP.md",
+        "docs/fyr/SAFETY_MODEL.md",
+    ] {
+        assert!(fixture.contains(path), "fixture should list {path}");
+        assert!(fs::metadata(path).is_ok(), "listed path should exist: {path}");
+    }
+}
+
+#[test]
+fn fyr_f5_self_workflows_doc_links_manifest_fixture() {
+    assert_contains(
+        "docs/fyr/SELF_WORKFLOWS.md",
+        "docs/fyr/fixtures/repo-manifest-ok.txt",
+    );
+}


### PR DESCRIPTION
## Summary

This PR continues the Fyr F5 inspection workflow push by adding the first repository-manifest fixture and regression checks for its shape and referenced documentation paths.

## Changes

- Adds `docs/fyr/fixtures/repo-manifest-ok.txt` as a small project-shaped manifest fixture.
- Adds `tests/fyr_f5_manifest_fixtures.rs` covering:
  - required fixture fields
  - deterministic/vfs-first/bounded check markers
  - referenced documentation paths exist
  - `SELF_WORKFLOWS.md` links the fixture
- Updates `docs/fyr/SELF_WORKFLOWS.md` to describe the fixture as evidence for a future reader, not a completed command.
- Updates `docs/fyr/ROADMAP.md` to record F5 manifest-fixture evidence.

## Why

F5 requires deterministic fixture data before adding repository inspection helpers. This PR creates the first stable fixture and tests it without claiming the manifest reader is implemented yet.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.