### PR TITLE
Add Fyr F5 checkpoint metadata fixture evidence

### DIFF
--- a/docs/fyr/ROADMAP.md
+++ b/docs/fyr/ROADMAP.md
@@ -18,6 +18,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 - F5 inspection-workflow evidence now documents the `fyr self` surface and the planned repository manifest, documentation consistency, checkpoint metadata, status reader, and fixture validation helpers.
 - F5 manifest-fixture evidence now validates a project-shaped manifest fixture and checks that listed documentation paths exist.
 - F5 documentation-consistency fixture evidence now validates aligned Fyr docs and required shared phrases.
+- F5 checkpoint-metadata fixture evidence now validates checkpoint-shaped fixture metadata and linked artifacts.
 
 ## Roadmap
 

--- a/docs/fyr/SELF_WORKFLOWS.md
+++ b/docs/fyr/SELF_WORKFLOWS.md
@@ -16,6 +16,7 @@ Current Fyr inspection surface:
 - Repository inspection workflows are still planned and must not be described as complete.
 - The first repository-manifest fixture lives at [`fixtures/repo-manifest-ok.txt`](fixtures/repo-manifest-ok.txt).
 - The first documentation-consistency fixture lives at `docs/fyr/fixtures/doc-consistency-ok.txt`.
+- The first checkpoint-metadata fixture lives at `docs/fyr/fixtures/checkpoint-metadata-ok.txt`.
 
 ## F5 target workflows
 
@@ -46,6 +47,16 @@ docs/fyr/fixtures/doc-consistency-ok.txt
 ```
 
 It records the Fyr docs that should stay aligned plus required shared phrases. It is test evidence for a future documentation consistency helper; it is not yet a full helper command.
+
+## Checkpoint metadata fixture
+
+The first checkpoint metadata fixture is intentionally small and static:
+
+```text
+docs/fyr/fixtures/checkpoint-metadata-ok.txt
+```
+
+It records checkpoint-shaped metadata with a fixture-only result and a not-complete claim. It is test evidence for a future checkpoint metadata helper; it is not yet a full helper command.
 
 ## Safety rules
 
@@ -92,6 +103,7 @@ Related fixtures:
 
 - [`fixtures/repo-manifest-ok.txt`](fixtures/repo-manifest-ok.txt)
 - `docs/fyr/fixtures/doc-consistency-ok.txt`
+- `docs/fyr/fixtures/checkpoint-metadata-ok.txt`
 
 Related tests:
 
@@ -99,3 +111,4 @@ Related tests:
 - `tests/fyr_f5_self_workflows.rs`
 - `tests/fyr_f5_manifest_fixtures.rs`
 - `tests/fyr_f5_doc_consistency_fixtures.rs`
+- `tests/fyr_f5_checkpoint_fixtures.rs`

--- a/docs/fyr/fixtures/checkpoint-metadata-ok.txt
+++ b/docs/fyr/fixtures/checkpoint-metadata-ok.txt
@@ -1,0 +1,12 @@
+name: fyr-checkpoint-fixture
+kind: checkpoint-metadata
+checkpoint: F5-fixture-001
+claim: not-complete
+result: fixture-only
+artifacts:
+  - docs/fyr/SELF_WORKFLOWS.md
+  - docs/fyr/ROADMAP.md
+checks:
+  - deterministic
+  - scoped
+  - reviewable

--- a/tests/fyr_f5_checkpoint_fixtures.rs
+++ b/tests/fyr_f5_checkpoint_fixtures.rs
@@ -1,0 +1,48 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn fyr_f5_checkpoint_fixture_has_required_shape() {
+    let path = "docs/fyr/fixtures/checkpoint-metadata-ok.txt";
+
+    for field in [
+        "name: fyr-checkpoint-fixture",
+        "kind: checkpoint-metadata",
+        "checkpoint: F5-fixture-001",
+        "claim: not-complete",
+        "result: fixture-only",
+        "artifacts:",
+        "checks:",
+        "deterministic",
+        "scoped",
+        "reviewable",
+    ] {
+        assert_contains(path, field);
+    }
+}
+
+#[test]
+fn fyr_f5_checkpoint_fixture_points_to_existing_artifacts() {
+    let fixture = read("docs/fyr/fixtures/checkpoint-metadata-ok.txt");
+
+    for path in ["docs/fyr/SELF_WORKFLOWS.md", "docs/fyr/ROADMAP.md"] {
+        assert!(fixture.contains(path), "fixture should list {path}");
+        assert!(fs::metadata(path).is_ok(), "listed path should exist: {path}");
+    }
+}
+
+#[test]
+fn fyr_self_workflows_doc_links_checkpoint_fixture() {
+    assert_contains(
+        "docs/fyr/SELF_WORKFLOWS.md",
+        "docs/fyr/fixtures/checkpoint-metadata-ok.txt",
+    );
+}


### PR DESCRIPTION
## Summary

This PR continues the Fyr F5 inspection workflow push by adding checkpoint-metadata fixture evidence and regression checks for linked checkpoint-shaped artifacts.

## Changes

- Adds `docs/fyr/fixtures/checkpoint-metadata-ok.txt` as a small checkpoint metadata fixture.
- Adds `tests/fyr_f5_checkpoint_fixtures.rs` covering:
  - required checkpoint fixture fields
  - fixture-only/not-complete claim boundary
  - linked artifacts exist
  - `SELF_WORKFLOWS.md` links the fixture
- Updates `docs/fyr/SELF_WORKFLOWS.md` to describe the fixture as evidence for a future helper, not a completed command.
- Updates `docs/fyr/ROADMAP.md` to record F5 checkpoint-metadata fixture evidence.

## Why

F5 requires checkpoint metadata fixture evidence before adding checkpoint inspection helpers. This PR creates the first stable checkpoint-shaped fixture and tests it without claiming the helper is implemented yet.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.