### PR TITLE
Add Fyr F5 public status fixture evidence

### DIFF
--- a/docs/fyr/ROADMAP.md
+++ b/docs/fyr/ROADMAP.md
@@ -19,6 +19,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 - F5 manifest-fixture evidence now validates a project-shaped manifest fixture and checks that listed documentation paths exist.
 - F5 documentation-consistency fixture evidence now validates aligned Fyr docs and required shared phrases.
 - F5 checkpoint-metadata fixture evidence now validates checkpoint-shaped fixture metadata and linked artifacts.
+- F5 public-status fixture evidence now validates expected status-reader fields while keeping the reader command pending.
 
 ## Roadmap
 

--- a/docs/fyr/SELF_WORKFLOWS.md
+++ b/docs/fyr/SELF_WORKFLOWS.md
@@ -17,6 +17,7 @@ Current Fyr inspection surface:
 - The first repository-manifest fixture lives at [`fixtures/repo-manifest-ok.txt`](fixtures/repo-manifest-ok.txt).
 - The first documentation-consistency fixture lives at `docs/fyr/fixtures/doc-consistency-ok.txt`.
 - The first checkpoint-metadata fixture lives at `docs/fyr/fixtures/checkpoint-metadata-ok.txt`.
+- The first public-status fixture lives at `docs/fyr/fixtures/public-status-ok.txt`.
 
 ## F5 target workflows
 
@@ -57,6 +58,16 @@ docs/fyr/fixtures/checkpoint-metadata-ok.txt
 ```
 
 It records checkpoint-shaped metadata with a fixture-only result and a not-complete claim. It is test evidence for a future checkpoint metadata helper; it is not yet a full helper command.
+
+## Public status fixture
+
+The first public status fixture is intentionally small and static:
+
+```text
+docs/fyr/fixtures/public-status-ok.txt
+```
+
+It records the fields expected from a future public status reader. It is fixture evidence for a future reader or documented deferral; it is not yet a full reader command.
 
 ## Safety rules
 
@@ -104,6 +115,7 @@ Related fixtures:
 - [`fixtures/repo-manifest-ok.txt`](fixtures/repo-manifest-ok.txt)
 - `docs/fyr/fixtures/doc-consistency-ok.txt`
 - `docs/fyr/fixtures/checkpoint-metadata-ok.txt`
+- `docs/fyr/fixtures/public-status-ok.txt`
 
 Related tests:
 
@@ -112,3 +124,4 @@ Related tests:
 - `tests/fyr_f5_manifest_fixtures.rs`
 - `tests/fyr_f5_doc_consistency_fixtures.rs`
 - `tests/fyr_f5_checkpoint_fixtures.rs`
+- `tests/fyr_f5_public_status_fixtures.rs`

--- a/docs/fyr/fixtures/public-status-ok.txt
+++ b/docs/fyr/fixtures/public-status-ok.txt
@@ -1,0 +1,15 @@
+name: fyr-public-status-fixture
+kind: public-status
+status-kind: estimated-roadmap-progress
+project: Fyr native language
+claim: fixture-only
+required-fields:
+  - repository
+  - branch
+  - project
+  - estimated-completion
+  - next-milestone
+checks:
+  - deterministic
+  - evidence-bound
+  - non-claim-aware

--- a/tests/fyr_f5_public_status_fixtures.rs
+++ b/tests/fyr_f5_public_status_fixtures.rs
@@ -1,0 +1,54 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn fyr_f5_public_status_fixture_has_required_shape() {
+    let path = "docs/fyr/fixtures/public-status-ok.txt";
+
+    for field in [
+        "name: fyr-public-status-fixture",
+        "kind: public-status",
+        "status-kind: estimated-roadmap-progress",
+        "project: Fyr native language",
+        "claim: fixture-only",
+        "required-fields:",
+        "repository",
+        "branch",
+        "project",
+        "estimated-completion",
+        "next-milestone",
+        "checks:",
+        "deterministic",
+        "evidence-bound",
+        "non-claim-aware",
+    ] {
+        assert_contains(path, field);
+    }
+}
+
+#[test]
+fn fyr_self_workflows_doc_links_public_status_fixture() {
+    assert_contains(
+        "docs/fyr/SELF_WORKFLOWS.md",
+        "docs/fyr/fixtures/public-status-ok.txt",
+    );
+}
+
+#[test]
+fn fyr_public_status_reader_remains_documented_as_pending() {
+    let doc = read("docs/fyr/SELF_WORKFLOWS.md");
+
+    assert!(doc.contains("Public status reader"), "doc should name public status reader");
+    assert!(
+        doc.contains("not yet a full reader command") || doc.contains("documented deferral"),
+        "doc should avoid claiming completed public status reader"
+    );
+}


### PR DESCRIPTION
## Summary

This PR completes the current F5 fixture set by adding public-status fixture evidence and keeping the future reader command explicitly pending.

## Changes

- Adds `docs/fyr/fixtures/public-status-ok.txt` as a small public-status fixture.
- Adds `tests/fyr_f5_public_status_fixtures.rs` covering:
  - required public-status fixture fields
  - evidence-bound/non-claim-aware markers
  - `SELF_WORKFLOWS.md` links the fixture
  - the public status reader remains documented as pending
- Updates `docs/fyr/SELF_WORKFLOWS.md` to describe the fixture as evidence for a future reader or documented deferral, not a completed command.
- Updates `docs/fyr/ROADMAP.md` to record F5 public-status fixture evidence.

## Why

F5 includes a public status reader or documented deferral. This PR adds deterministic fixture evidence for the expected fields while keeping the actual reader command out of scope until implemented and tested.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.