### PR TITLE
Add Fyr F6 standard library fixture evidence

### DIFF
--- a/docs/fyr/ROADMAP.md
+++ b/docs/fyr/ROADMAP.md
@@ -20,6 +20,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 - F5 documentation-consistency fixture evidence now validates aligned Fyr docs and required shared phrases.
 - F5 checkpoint-metadata fixture evidence now validates checkpoint-shaped fixture metadata and linked artifacts.
 - F5 public-status fixture evidence now validates expected status-reader fields while keeping the reader command pending.
+- F6 standard-library fixture evidence now defines the planned module surface and required evidence categories without claiming implementation.
 
 ## Roadmap
 
@@ -31,7 +32,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 | F3 — Core syntax | Define stable parser behavior inspired by C, Rust, and Python. | Lexer, parser, function blocks, variables, return values, comments, diagnostics. | Active |
 | F4 — Safe runtime | Execute useful scripts without exposing the host. | VFS reads/writes, command metadata, bounded runtime, redacted errors, deterministic tests. | Active |
 | F5 — Phase1 self-workflows | Use Fyr to help Phase1 inspect, copy, construct, and validate itself. | `fyr self`, repository manifest readers, docs sync helpers, checkpoint helpers. | Active |
-| F6 — Standard library | Provide a small Phase1-owned standard library. | `vfs`, `text`, `json-lite`, `audit`, `process`, `package`, and `doc` modules. | Planned |
+| F6 — Standard library | Provide a small Phase1-owned standard library. | `vfs`, `text`, `json-lite`, `audit`, `process`, `package`, and `doc` modules. | Active |
 | F7 — Compiler path | Decide whether Fyr remains interpreted, lowers to Rust, or targets WASI-lite. | Compiler design note, WASI-lite strategy, packaging contract. | Planned |
 
 ## 100% promotion gate

--- a/docs/fyr/STDLIB.md
+++ b/docs/fyr/STDLIB.md
@@ -1,0 +1,56 @@
+# Fyr standard library contract
+
+Status: active F6 planning and fixture document  
+Scope: future Phase1-owned Fyr standard library module surface  
+Non-claim: these modules are not implemented as a complete standard library yet.
+
+F6 defines the small Phase1-owned standard library surface Fyr should grow into after F3-F5 are stable enough to support it.
+
+## Current module contract
+
+The planned module names are:
+
+| Module | Purpose | Current state |
+| --- | --- | --- |
+| `vfs` | VFS read/write helpers scoped to Phase1-owned paths. | planned |
+| `text` | Small string and text-processing helpers. | planned |
+| `json-lite` | Minimal deterministic JSON-like reading/writing. | planned |
+| `audit` | Structured validation and event-report helpers. | planned |
+| `process` | Metadata-only process information unless a separate guarded policy is implemented. | planned |
+| `package` | Fyr package manifest and layout helpers. | planned |
+| `doc` | Documentation consistency and link-helper surface. | planned |
+
+## Safety rules
+
+F6 modules must:
+
+- stay VFS-first;
+- keep output deterministic;
+- avoid host shell access by default;
+- avoid network access by default;
+- avoid host compiler access by default;
+- include smoke tests and failure-mode tests before any module is called complete;
+- keep public docs aligned with implemented behavior.
+
+## Fixture evidence
+
+The first F6 fixture is:
+
+```text
+docs/fyr/fixtures/stdlib-modules-ok.txt
+```
+
+It lists the planned module names and required evidence categories. It is not a module implementation.
+
+## Completion rule
+
+F6 can move from planned to active when module contracts, fixtures, and first module tests exist.
+
+F6 can be marked complete only when every planned module has:
+
+- implementation evidence;
+- smoke tests;
+- failure-mode tests;
+- documentation examples;
+- safety-boundary notes;
+- language-book and roadmap alignment.

--- a/docs/fyr/fixtures/stdlib-modules-ok.txt
+++ b/docs/fyr/fixtures/stdlib-modules-ok.txt
@@ -1,0 +1,16 @@
+name: fyr-stdlib-modules
+kind: standard-library-fixture
+modules:
+  - vfs
+  - text
+  - json-lite
+  - audit
+  - process
+  - package
+  - doc
+required-evidence:
+  - smoke-tests
+  - failure-mode-tests
+  - docs-examples
+  - safety-notes
+claim: fixture-only

--- a/tests/fyr_f6_stdlib_fixtures.rs
+++ b/tests/fyr_f6_stdlib_fixtures.rs
@@ -1,0 +1,64 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn fyr_f6_stdlib_contract_lists_planned_modules() {
+    let path = "docs/fyr/STDLIB.md";
+
+    for module in ["`vfs`", "`text`", "`json-lite`", "`audit`", "`package`", "`doc`"] {
+        assert_contains(path, module);
+    }
+
+    assert_contains(path, "not implemented as a complete standard library yet");
+    assert_contains(path, "smoke tests");
+    assert_contains(path, "failure-mode tests");
+}
+
+#[test]
+fn fyr_f6_stdlib_fixture_has_required_shape() {
+    let path = "docs/fyr/fixtures/stdlib-modules-ok.txt";
+
+    for field in [
+        "name: fyr-stdlib-modules",
+        "kind: standard-library-fixture",
+        "modules:",
+        "vfs",
+        "text",
+        "json-lite",
+        "audit",
+        "package",
+        "doc",
+        "required-evidence:",
+        "smoke-tests",
+        "failure-mode-tests",
+        "docs-examples",
+        "safety-notes",
+        "claim: fixture-only",
+    ] {
+        assert_contains(path, field);
+    }
+}
+
+#[test]
+fn fyr_f6_stdlib_contract_links_fixture() {
+    assert_contains(
+        "docs/fyr/STDLIB.md",
+        "docs/fyr/fixtures/stdlib-modules-ok.txt",
+    );
+}
+
+#[test]
+fn fyr_roadmap_tracks_f6_stdlib_fixture_evidence() {
+    assert_contains(
+        "docs/fyr/ROADMAP.md",
+        "F6 standard-library fixture evidence",
+    );
+}


### PR DESCRIPTION
## Summary

This PR starts the Fyr F6 standard-library track with a module-surface contract, a fixture, and regression checks while keeping implementation claims out of scope.

## Changes

- Adds `docs/fyr/STDLIB.md` documenting the planned module surface:
  - `vfs`
  - `text`
  - `json-lite`
  - `audit`
  - `process`
  - `package`
  - `doc`
- Adds `docs/fyr/fixtures/stdlib-modules-ok.txt` as the first standard-library module fixture.
- Adds `tests/fyr_f6_stdlib_fixtures.rs` covering:
  - planned module names
  - fixture shape
  - fixture-only/non-complete boundary
  - roadmap evidence trail
- Updates `docs/fyr/ROADMAP.md` to mark F6 active with fixture evidence, without claiming implementation.

## Why

F6 requires smoke/failure-mode evidence for each stable module before completion. This PR creates the first module-surface contract and fixture so implementation can proceed against stable names and evidence categories.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.