### PR TITLE
Add Fyr F6 vfs module fixture evidence

### DIFF
--- a/docs/fyr/ROADMAP.md
+++ b/docs/fyr/ROADMAP.md
@@ -21,6 +21,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 - F5 checkpoint-metadata fixture evidence now validates checkpoint-shaped fixture metadata and linked artifacts.
 - F5 public-status fixture evidence now validates expected status-reader fields while keeping the reader command pending.
 - F6 standard-library fixture evidence now defines the planned module surface and required evidence categories without claiming implementation.
+- F6 `vfs` module fixture evidence now records the planned VFS helper surface and required evidence categories.
 
 ## Roadmap
 

--- a/docs/fyr/STDLIB.md
+++ b/docs/fyr/STDLIB.md
@@ -12,7 +12,7 @@ The planned module names are:
 
 | Module | Purpose | Current state |
 | --- | --- | --- |
-| `vfs` | VFS read/write helpers scoped to Phase1-owned paths. | planned |
+| `vfs` | VFS read/write helpers scoped to Phase1-owned paths. | fixture |
 | `text` | Small string and text-processing helpers. | planned |
 | `json-lite` | Minimal deterministic JSON-like reading/writing. | planned |
 | `audit` | Structured validation and event-report helpers. | planned |
@@ -41,6 +41,14 @@ docs/fyr/fixtures/stdlib-modules-ok.txt
 ```
 
 It lists the planned module names and required evidence categories. It is not a module implementation.
+
+The first module-level fixture is:
+
+```text
+docs/fyr/fixtures/stdlib-vfs-ok.txt
+```
+
+It records the planned `vfs` module operation surface and required evidence categories. It is not a module implementation.
 
 ## Completion rule
 

--- a/docs/fyr/fixtures/stdlib-vfs-ok.txt
+++ b/docs/fyr/fixtures/stdlib-vfs-ok.txt
@@ -1,0 +1,14 @@
+name: fyr-stdlib-vfs
+kind: standard-library-module-fixture
+module: vfs
+purpose: Phase1 VFS read-write helpers
+allowed-operations:
+  - read-vfs-file
+  - write-vfs-file
+  - list-vfs-directory
+required-evidence:
+  - smoke-test
+  - failure-mode-test
+  - docs-example
+  - safety-note
+claim: fixture-only

--- a/tests/fyr_f6_vfs_module_fixture.rs
+++ b/tests/fyr_f6_vfs_module_fixture.rs
@@ -1,0 +1,60 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn fyr_f6_vfs_fixture_has_required_shape() {
+    let path = "docs/fyr/fixtures/stdlib-vfs-ok.txt";
+
+    for field in [
+        "name: fyr-stdlib-vfs",
+        "kind: standard-library-module-fixture",
+        "module: vfs",
+        "allowed-operations:",
+        "read-vfs-file",
+        "write-vfs-file",
+        "list-vfs-directory",
+        "required-evidence:",
+        "smoke-test",
+        "failure-mode-test",
+        "docs-example",
+        "safety-note",
+        "claim: fixture-only",
+    ] {
+        assert_contains(path, field);
+    }
+}
+
+#[test]
+fn fyr_f6_stdlib_doc_links_vfs_fixture() {
+    assert_contains(
+        "docs/fyr/STDLIB.md",
+        "docs/fyr/fixtures/stdlib-vfs-ok.txt",
+    );
+}
+
+#[test]
+fn fyr_f6_stdlib_doc_keeps_vfs_module_non_claiming() {
+    let doc = read("docs/fyr/STDLIB.md");
+
+    assert!(doc.contains("`vfs`"), "stdlib doc should list vfs module");
+    assert!(
+        doc.contains("not implemented as a complete standard library yet"),
+        "stdlib doc should keep non-claim boundary"
+    );
+}
+
+#[test]
+fn fyr_roadmap_tracks_vfs_module_fixture_evidence() {
+    assert_contains(
+        "docs/fyr/ROADMAP.md",
+        "F6 `vfs` module fixture evidence",
+    );
+}


### PR DESCRIPTION
## Summary

This PR continues the Fyr F6 standard-library track by adding the first per-module fixture for the planned `vfs` module.

## Changes

- Adds `docs/fyr/fixtures/stdlib-vfs-ok.txt` as the first module-level standard-library fixture.
- Updates `docs/fyr/STDLIB.md` to mark `vfs` as fixture-backed and link the module fixture.
- Adds `tests/fyr_f6_vfs_module_fixture.rs` covering:
  - `vfs` fixture shape
  - planned VFS operations
  - required evidence categories
  - fixture-only/non-complete boundary
  - roadmap evidence trail
- Updates `docs/fyr/ROADMAP.md` to record F6 `vfs` module fixture evidence.

## Why

F6 requires smoke and failure-mode evidence for each stable module before completion. This PR establishes the first per-module fixture without claiming implementation.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.