### PR TITLE
Add Fyr F6 text module fixture evidence

### DIFF
--- a/docs/fyr/ROADMAP.md
+++ b/docs/fyr/ROADMAP.md
@@ -22,6 +22,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 - F5 public-status fixture evidence now validates expected status-reader fields while keeping the reader command pending.
 - F6 standard-library fixture evidence now defines the planned module surface and required evidence categories without claiming implementation.
 - F6 `vfs` module fixture evidence now records the planned VFS helper surface and required evidence categories.
+- F6 `text` module fixture evidence now records deterministic text helper operations and required evidence categories.
 
 ## Roadmap
 

--- a/docs/fyr/STDLIB.md
+++ b/docs/fyr/STDLIB.md
@@ -13,7 +13,7 @@ The planned module names are:
 | Module | Purpose | Current state |
 | --- | --- | --- |
 | `vfs` | VFS read/write helpers scoped to Phase1-owned paths. | fixture |
-| `text` | Small string and text-processing helpers. | planned |
+| `text` | Small string and text-processing helpers. | fixture |
 | `json-lite` | Minimal deterministic JSON-like reading/writing. | planned |
 | `audit` | Structured validation and event-report helpers. | planned |
 | `process` | Metadata-only process information unless a separate guarded policy is implemented. | planned |
@@ -42,13 +42,14 @@ docs/fyr/fixtures/stdlib-modules-ok.txt
 
 It lists the planned module names and required evidence categories. It is not a module implementation.
 
-The first module-level fixture is:
+Module-level fixtures:
 
 ```text
 docs/fyr/fixtures/stdlib-vfs-ok.txt
+docs/fyr/fixtures/stdlib-text-ok.txt
 ```
 
-It records the planned `vfs` module operation surface and required evidence categories. It is not a module implementation.
+These record planned module operation surfaces and required evidence categories. They are not module implementations.
 
 ## Completion rule
 

--- a/docs/fyr/fixtures/stdlib-text-ok.txt
+++ b/docs/fyr/fixtures/stdlib-text-ok.txt
@@ -1,0 +1,15 @@
+name: fyr-stdlib-text
+kind: standard-library-module-fixture
+module: text
+purpose: deterministic text helpers
+allowed-operations:
+  - trim
+  - split-lines
+  - contains
+  - replace
+required-evidence:
+  - smoke-test
+  - failure-mode-test
+  - docs-example
+  - safety-note
+claim: fixture-only

--- a/tests/fyr_f6_text_module_fixture.rs
+++ b/tests/fyr_f6_text_module_fixture.rs
@@ -1,0 +1,61 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn fyr_f6_text_fixture_has_required_shape() {
+    let path = "docs/fyr/fixtures/stdlib-text-ok.txt";
+
+    for field in [
+        "name: fyr-stdlib-text",
+        "kind: standard-library-module-fixture",
+        "module: text",
+        "allowed-operations:",
+        "trim",
+        "split-lines",
+        "contains",
+        "replace",
+        "required-evidence:",
+        "smoke-test",
+        "failure-mode-test",
+        "docs-example",
+        "safety-note",
+        "claim: fixture-only",
+    ] {
+        assert_contains(path, field);
+    }
+}
+
+#[test]
+fn fyr_f6_stdlib_doc_links_text_fixture() {
+    assert_contains(
+        "docs/fyr/STDLIB.md",
+        "docs/fyr/fixtures/stdlib-text-ok.txt",
+    );
+}
+
+#[test]
+fn fyr_f6_stdlib_doc_keeps_text_module_non_claiming() {
+    let doc = read("docs/fyr/STDLIB.md");
+
+    assert!(doc.contains("`text`"), "stdlib doc should list text module");
+    assert!(
+        doc.contains("not implemented as a complete standard library yet"),
+        "stdlib doc should keep non-claim boundary"
+    );
+}
+
+#[test]
+fn fyr_roadmap_tracks_text_module_fixture_evidence() {
+    assert_contains(
+        "docs/fyr/ROADMAP.md",
+        "F6 `text` module fixture evidence",
+    );
+}


### PR DESCRIPTION
## Summary

This PR continues the Fyr F6 standard-library track by adding the per-module fixture for the planned `text` module.

## Changes

- Adds `docs/fyr/fixtures/stdlib-text-ok.txt` as the `text` module-level standard-library fixture.
- Updates `docs/fyr/STDLIB.md` to mark `text` as fixture-backed and link the module fixture.
- Adds `tests/fyr_f6_text_module_fixture.rs` covering:
  - `text` fixture shape
  - planned text helper operations
  - required evidence categories
  - fixture-only/non-complete boundary
  - roadmap evidence trail
- Updates `docs/fyr/ROADMAP.md` to record F6 `text` module fixture evidence.

## Why

F6 requires smoke and failure-mode evidence for each stable module before completion. This PR establishes the next per-module fixture without claiming implementation.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.