### PR TITLE
Add Fyr black_arts staged candidate design track

### DIFF
--- a/docs/fyr/ROADMAP.md
+++ b/docs/fyr/ROADMAP.md
@@ -23,6 +23,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 - F6 standard-library fixture evidence now defines the planned module surface and required evidence categories without claiming implementation.
 - F6 `vfs` module fixture evidence now records the planned VFS helper surface and required evidence categories.
 - F6 `text` module fixture evidence now records deterministic text helper operations and required evidence categories.
+- `black_arts` staged-candidate design evidence now defines guarded candidate creation, validation, promotion, and discard boundaries without claiming live-system updates.
 
 ## Roadmap
 
@@ -36,6 +37,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 | F5 — Phase1 self-workflows | Use Fyr to help Phase1 inspect, copy, construct, and validate itself. | `fyr self`, repository manifest readers, docs sync helpers, checkpoint helpers. | Active |
 | F6 — Standard library | Provide a small Phase1-owned standard library. | `vfs`, `text`, `json-lite`, `audit`, `process`, `package`, and `doc` modules. | Active |
 | F7 — Compiler path | Decide whether Fyr remains interpreted, lowers to Rust, or targets WASI-lite. | Compiler design note, WASI-lite strategy, packaging contract. | Planned |
+| X1 — black_arts staged candidates | Use guarded Fyr plans to create, validate, and promote candidate Phase1/Base1 trees. | Candidate lifecycle design, fixtures, tests, non-claim boundary, approval gate. | Design |
 
 ## 100% promotion gate
 

--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -1,0 +1,87 @@
+# Fyr staged candidate track
+
+Status: experimental design track  
+Codename: `black_arts`  
+Scope: staged Phase1/Base1 candidate workflows driven by Fyr plans  
+Non-claim: this is not a production updater, not a release candidate process, and not a hardened recovery system.
+
+This track defines how Fyr can eventually help Phase1 create candidate copies of Phase1/Base1, apply controlled configuration or feature plans to those candidates, validate them, and promote them only after evidence gates pass.
+
+## Goal
+
+The staged candidate track should eventually let Phase1 use Fyr to:
+
+1. create a candidate from known-good inputs;
+2. apply versioned configuration and feature changes to that candidate;
+3. run deterministic checks against the candidate;
+4. record evidence and non-claims;
+5. promote the candidate only after validation succeeds.
+
+## Proposed command surface
+
+These command names are placeholders until implementation lands:
+
+```text
+fyr staged status
+fyr staged plan
+fyr staged create <candidate>
+fyr staged apply <candidate> <plan.fyr>
+fyr staged validate <candidate>
+fyr staged promote <candidate>
+fyr staged discard <candidate>
+```
+
+The public skin can later expose these through the `black_arts` codename if the guarded behavior is implemented and tested first.
+
+## Candidate lifecycle
+
+| Stage | Plain meaning | Required evidence |
+| --- | --- | --- |
+| plan | Load a versioned plan. | Plan schema, target, scope, non-claims. |
+| create | Create a staged candidate tree. | Source reference, candidate ID, clean workspace. |
+| apply | Apply scoped changes to the candidate. | Change log, file list, rejected operations. |
+| validate | Validate the candidate. | Test output, doc checks, status checks. |
+| promote | Promote only after validation. | Operator approval, rollback path, evidence link. |
+| discard | Remove failed or stale candidate. | Deletion log, live-system untouched marker. |
+
+## Safety rules
+
+Required defaults:
+
+- candidate-only writes;
+- declared workspace first;
+- live system remains untouched until explicit promotion;
+- no hidden host command execution;
+- no network by default;
+- no promotion without validation;
+- deterministic evidence output;
+- explicit rollback or discard path;
+- visible non-claims in every report.
+
+## Promotion rule
+
+A candidate can be promoted only if all are true:
+
+1. the candidate was created from a known source;
+2. all changes are recorded;
+3. validation passes;
+4. the public status and non-claim boundary remain accurate;
+5. rollback or discard instructions exist;
+6. an operator explicitly approves promotion.
+
+## First evidence gate
+
+Before implementation, the repository needs fixtures and tests for:
+
+- plan shape;
+- candidate metadata shape;
+- validation result shape;
+- promotion approval shape;
+- discard result shape;
+- non-claim preservation.
+
+## Current wording
+
+Use this wording now:
+
+> `black_arts` is the codename for an experimental Fyr staged-candidate design track. It does not change the live system and does not promote candidates without validation evidence and explicit operator approval.

--- a/docs/fyr/fixtures/staged-candidate-ok.txt
+++ b/docs/fyr/fixtures/staged-candidate-ok.txt
@@ -1,0 +1,17 @@
+name: black-arts-candidate-fixture
+kind: staged-candidate-fixture
+candidate: phase1-base1-candidate
+source: known-good
+plan: plan.fyr
+status: fixture-only
+required-records:
+  - plan-shape
+  - candidate-metadata
+  - validation-result
+  - promotion-approval
+  - discard-result
+checks:
+  - deterministic
+  - candidate-only
+  - evidence-bound
+  - non-claim-aware

--- a/tests/fyr_black_arts_staged_candidates.rs
+++ b/tests/fyr_black_arts_staged_candidates.rs
@@ -1,0 +1,54 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn staged_candidate_doc_preserves_black_arts_boundary() {
+    let path = "docs/fyr/STAGED_CANDIDATES.md";
+
+    assert_contains(path, "Codename: `black_arts`");
+    assert_contains(path, "experimental design track");
+    assert_contains(path, "candidate-only writes");
+    assert_contains(path, "no promotion without validation");
+    assert_contains(path, "operator explicitly approves promotion");
+}
+
+#[test]
+fn staged_candidate_fixture_has_required_shape() {
+    let path = "docs/fyr/fixtures/staged-candidate-ok.txt";
+
+    for field in [
+        "name: black-arts-candidate-fixture",
+        "kind: staged-candidate-fixture",
+        "candidate: phase1-base1-candidate",
+        "source: known-good",
+        "status: fixture-only",
+        "plan-shape",
+        "candidate-metadata",
+        "validation-result",
+        "promotion-approval",
+        "discard-result",
+        "deterministic",
+        "candidate-only",
+        "evidence-bound",
+        "non-claim-aware",
+    ] {
+        assert_contains(path, field);
+    }
+}
+
+#[test]
+fn staged_candidate_track_is_not_claimed_as_live_update_system() {
+    let doc = read("docs/fyr/STAGED_CANDIDATES.md");
+
+    assert!(doc.contains("not a production updater"));
+    assert!(doc.contains("live system remains untouched until explicit promotion"));
+    assert!(doc.contains("does not change the live system"));
+}


### PR DESCRIPTION
## Summary

This PR adds the `black_arts` codename as a guarded Fyr staged-candidate design track for future Phase1/Base1 candidate workflows.

## Changes

- Adds `docs/fyr/STAGED_CANDIDATES.md` describing candidate-only staged workflows:
  - plan
  - create
  - apply
  - validate
  - promote
  - discard
- Adds `docs/fyr/fixtures/staged-candidate-ok.txt` as the first staged-candidate fixture.
- Adds `tests/fyr_black_arts_staged_candidates.rs` covering:
  - `black_arts` codename boundary
  - candidate-only safety defaults
  - validation-before-promotion rule
  - fixture shape
  - non-claim boundary
- Updates `docs/fyr/ROADMAP.md` with an X1 design-track row for `black_arts` staged candidates.

## Intent

This preserves the creative black_arts / staged-candidate direction while keeping the system safe and evidence-bound. It does not claim live-system mutation, autonomous promotion, production update infrastructure, hardening, or release-candidate readiness.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.