### PR TITLE
Add Fyr black_arts staged plan fixture evidence

### DIFF
--- a/docs/fyr/ROADMAP.md
+++ b/docs/fyr/ROADMAP.md
@@ -24,6 +24,7 @@ Fyr is the Phase1-native language path for VFS automation, self-construction, an
 - F6 `vfs` module fixture evidence now records the planned VFS helper surface and required evidence categories.
 - F6 `text` module fixture evidence now records deterministic text helper operations and required evidence categories.
 - `black_arts` staged-candidate design evidence now defines guarded candidate creation, validation, promotion, and discard boundaries without claiming live-system updates.
+- `black_arts` staged-plan fixture evidence now defines candidate-only plan metadata, validation, promotion, rollback, and discard gates.
 
 ## Roadmap
 

--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -44,6 +44,17 @@ The public skin can later expose these through the `black_arts` codename if the 
 | promote | Promote only after validation. | Operator approval, rollback path, evidence link. |
 | discard | Remove failed or stale candidate. | Deletion log, live-system untouched marker. |
 
+## Fixtures
+
+The current staged candidate fixtures are:
+
+```text
+docs/fyr/fixtures/staged-candidate-ok.txt
+docs/fyr/fixtures/staged-plan-ok.txt
+```
+
+These fixtures define expected shapes for candidate metadata and plan metadata. They are not implementations.
+
 ## Safety rules
 
 Required defaults:

--- a/docs/fyr/fixtures/staged-plan-ok.txt
+++ b/docs/fyr/fixtures/staged-plan-ok.txt
@@ -1,0 +1,22 @@
+name: black-arts-plan-fixture
+kind: staged-plan-fixture
+plan-version: 0.1.0
+source: known-good
+candidate: phase1-base1-candidate
+scope: candidate-only
+changes:
+  - config-update
+  - feature-toggle
+  - docs-update
+validation:
+  - tests
+  - docs
+  - status
+promotion:
+  - operator-approval
+  - rollback-path
+  - evidence-link
+discard:
+  - stale-candidate
+  - failed-validation
+claim: fixture-only

--- a/tests/fyr_black_arts_plan_fixture.rs
+++ b/tests/fyr_black_arts_plan_fixture.rs
@@ -1,0 +1,53 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_plan_fixture_has_required_shape() {
+    let path = "docs/fyr/fixtures/staged-plan-ok.txt";
+
+    for field in [
+        "name: black-arts-plan-fixture",
+        "kind: staged-plan-fixture",
+        "plan-version: 0.1.0",
+        "source: known-good",
+        "candidate: phase1-base1-candidate",
+        "scope: candidate-only",
+        "changes:",
+        "validation:",
+        "promotion:",
+        "discard:",
+        "operator-approval",
+        "rollback-path",
+        "evidence-link",
+        "claim: fixture-only",
+    ] {
+        assert_contains(path, field);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_plan_fixture() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-plan-ok.txt",
+    );
+}
+
+#[test]
+fn black_arts_plan_keeps_promotion_guarded() {
+    let doc = read("docs/fyr/STAGED_CANDIDATES.md");
+    let fixture = read("docs/fyr/fixtures/staged-plan-ok.txt");
+
+    assert!(doc.contains("no promotion without validation"));
+    assert!(doc.contains("operator explicitly approves promotion"));
+    assert!(fixture.contains("operator-approval"));
+    assert!(fixture.contains("rollback-path"));
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate design track by adding the first staged-plan fixture and checks for the guarded plan shape.

## Changes

- Adds `docs/fyr/fixtures/staged-plan-ok.txt` with candidate-only plan metadata:
  - source
  - candidate
  - scope
  - changes
  - validation
  - promotion
  - discard
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the staged candidate and staged plan fixtures.
- Adds `tests/fyr_black_arts_plan_fixture.rs` covering:
  - required plan fixture fields
  - candidate-only scope
  - validation-before-promotion boundary
  - operator approval / rollback / evidence-link requirements
- Updates `docs/fyr/ROADMAP.md` to record staged-plan fixture evidence.

## Intent

This keeps `black_arts` moving toward safe mutation/mutate capabilities while preserving the key boundary: no live-system change, no promotion without validation evidence, and explicit operator approval.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.