### PR TITLE
Add Fyr black_arts validation fixture evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -51,9 +51,10 @@ The current staged candidate fixtures are:
 ```text
 docs/fyr/fixtures/staged-candidate-ok.txt
 docs/fyr/fixtures/staged-plan-ok.txt
+docs/fyr/fixtures/staged-validation-ok.txt
 ```
 
-These fixtures define expected shapes for candidate metadata and plan metadata. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, and validation results. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-validation-ok.txt
+++ b/docs/fyr/fixtures/staged-validation-ok.txt
@@ -1,0 +1,16 @@
+name: black-arts-validation-fixture
+kind: staged-validation-fixture
+candidate: phase1-base1-candidate
+plan: staged-plan-ok.txt
+result: passed
+required-checks:
+  - tests
+  - docs
+  - status
+  - non-claims
+promotion-state: blocked-until-approval
+evidence:
+  - validation-log
+  - checked-files
+  - status-summary
+claim: fixture-only

--- a/tests/fyr_black_arts_validation_fixture.rs
+++ b/tests/fyr_black_arts_validation_fixture.rs
@@ -1,0 +1,53 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_validation_fixture_has_required_shape() {
+    let path = "docs/fyr/fixtures/staged-validation-ok.txt";
+
+    for field in [
+        "name: black-arts-validation-fixture",
+        "kind: staged-validation-fixture",
+        "candidate: phase1-base1-candidate",
+        "plan: staged-plan-ok.txt",
+        "result: passed",
+        "required-checks:",
+        "tests",
+        "docs",
+        "status",
+        "non-claims",
+        "promotion-state: blocked-until-approval",
+        "validation-log",
+        "checked-files",
+        "status-summary",
+        "claim: fixture-only",
+    ] {
+        assert_contains(path, field);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_validation_fixture() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-validation-ok.txt",
+    );
+}
+
+#[test]
+fn validation_fixture_keeps_promotion_blocked_until_approval() {
+    let doc = read("docs/fyr/STAGED_CANDIDATES.md");
+    let fixture = read("docs/fyr/fixtures/staged-validation-ok.txt");
+
+    assert!(doc.contains("no promotion without validation"));
+    assert!(doc.contains("operator explicitly approves promotion"));
+    assert!(fixture.contains("promotion-state: blocked-until-approval"));
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate design track by adding validation-result fixture evidence.

## Changes

- Adds `docs/fyr/fixtures/staged-validation-ok.txt` with validation-result metadata:
  - candidate
  - plan
  - result
  - required checks
  - promotion state
  - evidence items
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the validation fixture.
- Adds `tests/fyr_black_arts_validation_fixture.rs` covering:
  - validation fixture shape
  - required checks
  - promotion remains blocked until approval
  - validation-before-promotion boundary

## Intent

This moves the `black_arts` staged-candidate track one gate forward: a candidate can have validation evidence, but promotion remains blocked until explicit approval and rollback/evidence requirements exist.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.