### PR TITLE
Add Fyr black_arts approval fixture evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -52,9 +52,10 @@ The current staged candidate fixtures are:
 docs/fyr/fixtures/staged-candidate-ok.txt
 docs/fyr/fixtures/staged-plan-ok.txt
 docs/fyr/fixtures/staged-validation-ok.txt
+docs/fyr/fixtures/staged-approval-ok.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, and validation results. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, validation results, and explicit approval. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-approval-ok.txt
+++ b/docs/fyr/fixtures/staged-approval-ok.txt
@@ -1,0 +1,17 @@
+name: black-arts-approval-fixture
+kind: staged-approval-fixture
+candidate: phase1-base1-candidate
+validation: staged-validation-ok.txt
+approval-state: approved-by-operator
+promotion-mode: explicit-only
+required-approval:
+  - operator
+  - evidence-link
+  - rollback-path
+  - status-boundary-check
+promotion-blockers:
+  - missing-validation
+  - missing-approval
+  - missing-rollback
+  - failed-status-boundary
+claim: fixture-only

--- a/tests/fyr_black_arts_approval_fixture.rs
+++ b/tests/fyr_black_arts_approval_fixture.rs
@@ -1,0 +1,56 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_approval_fixture_has_required_shape() {
+    let path = "docs/fyr/fixtures/staged-approval-ok.txt";
+
+    for field in [
+        "name: black-arts-approval-fixture",
+        "kind: staged-approval-fixture",
+        "candidate: phase1-base1-candidate",
+        "validation: staged-validation-ok.txt",
+        "approval-state: approved-by-operator",
+        "promotion-mode: explicit-only",
+        "required-approval:",
+        "operator",
+        "evidence-link",
+        "rollback-path",
+        "status-boundary-check",
+        "promotion-blockers:",
+        "missing-validation",
+        "missing-approval",
+        "missing-rollback",
+        "failed-status-boundary",
+        "claim: fixture-only",
+    ] {
+        assert_contains(path, field);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_approval_fixture() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-approval-ok.txt",
+    );
+}
+
+#[test]
+fn approval_fixture_preserves_explicit_promotion_boundary() {
+    let doc = read("docs/fyr/STAGED_CANDIDATES.md");
+    let fixture = read("docs/fyr/fixtures/staged-approval-ok.txt");
+
+    assert!(doc.contains("operator explicitly approves promotion"));
+    assert!(doc.contains("Promote only after validation"));
+    assert!(fixture.contains("promotion-mode: explicit-only"));
+    assert!(fixture.contains("missing-approval"));
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate design track by adding explicit promotion-approval fixture evidence.

## Changes

- Adds `docs/fyr/fixtures/staged-approval-ok.txt` with approval metadata:
  - candidate
  - validation reference
  - approval state
  - explicit-only promotion mode
  - required approval fields
  - promotion blockers
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the approval fixture.
- Adds `tests/fyr_black_arts_approval_fixture.rs` covering:
  - approval fixture shape
  - operator approval requirement
  - rollback/evidence/status-boundary requirements
  - explicit promotion boundary

## Intent

This reinforces the key `black_arts` boundary: validation does not equal promotion. Promotion remains explicit, approval-gated, rollback-aware, and evidence-linked.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.