### PR TITLE
Add Fyr black_arts discard fixture evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -53,9 +53,10 @@ docs/fyr/fixtures/staged-candidate-ok.txt
 docs/fyr/fixtures/staged-plan-ok.txt
 docs/fyr/fixtures/staged-validation-ok.txt
 docs/fyr/fixtures/staged-approval-ok.txt
+docs/fyr/fixtures/staged-discard-ok.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, validation results, and explicit approval. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, validation results, explicit approval, and discard records. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-discard-ok.txt
+++ b/docs/fyr/fixtures/staged-discard-ok.txt
@@ -1,0 +1,16 @@
+name: black-arts-discard-fixture
+kind: staged-discard-fixture
+candidate: phase1-base1-candidate
+reason: failed-validation
+discard-mode: explicit-only
+required-records:
+  - candidate-id
+  - discard-reason
+  - deletion-log
+  - live-system-untouched
+  - evidence-link
+allowed-reasons:
+  - failed-validation
+  - stale-candidate
+  - operator-request
+claim: fixture-only

--- a/tests/fyr_black_arts_discard_fixture.rs
+++ b/tests/fyr_black_arts_discard_fixture.rs
@@ -1,0 +1,55 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_discard_fixture_has_required_shape() {
+    let path = "docs/fyr/fixtures/staged-discard-ok.txt";
+
+    for field in [
+        "name: black-arts-discard-fixture",
+        "kind: staged-discard-fixture",
+        "candidate: phase1-base1-candidate",
+        "reason: failed-validation",
+        "discard-mode: explicit-only",
+        "required-records:",
+        "candidate-id",
+        "discard-reason",
+        "deletion-log",
+        "live-system-untouched",
+        "evidence-link",
+        "allowed-reasons:",
+        "failed-validation",
+        "stale-candidate",
+        "operator-request",
+        "claim: fixture-only",
+    ] {
+        assert_contains(path, field);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_discard_fixture() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-discard-ok.txt",
+    );
+}
+
+#[test]
+fn discard_fixture_preserves_live_system_untouched_boundary() {
+    let doc = read("docs/fyr/STAGED_CANDIDATES.md");
+    let fixture = read("docs/fyr/fixtures/staged-discard-ok.txt");
+
+    assert!(doc.contains("live system remains untouched until explicit promotion"));
+    assert!(doc.contains("explicit rollback or discard path"));
+    assert!(fixture.contains("live-system-untouched"));
+    assert!(fixture.contains("discard-mode: explicit-only"));
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate design track by adding discard/banish fixture evidence for failed or stale candidates.

## Changes

- Adds `docs/fyr/fixtures/staged-discard-ok.txt` with discard metadata:
  - candidate
  - reason
  - explicit-only discard mode
  - required records
  - allowed reasons
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the discard fixture.
- Adds `tests/fyr_black_arts_discard_fixture.rs` covering:
  - discard fixture shape
  - explicit discard boundary
  - live-system untouched marker
  - rollback/discard path requirement

## Intent

This completes the first core fixture set for `black_arts`: staged candidates can be planned, validated, approval-gated, and discarded without touching the live system.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.