### PR TITLE
Add Fyr black_arts claim boundary evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -54,9 +54,10 @@ docs/fyr/fixtures/staged-plan-ok.txt
 docs/fyr/fixtures/staged-validation-ok.txt
 docs/fyr/fixtures/staged-approval-ok.txt
 docs/fyr/fixtures/staged-discard-ok.txt
+docs/fyr/fixtures/staged-claim-boundary-ok.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, validation results, explicit approval, and discard records. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, validation results, explicit approval, discard records, and claim boundaries. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-claim-boundary-ok.txt
+++ b/docs/fyr/fixtures/staged-claim-boundary-ok.txt
@@ -1,0 +1,16 @@
+name: black-arts-claim-boundary-fixture
+kind: staged-claim-boundary-fixture
+candidate: phase1-base1-candidate
+required-boundaries:
+  - not-production
+  - not-release-ready
+  - not-live-update
+  - not-auto-promote
+  - not-daily-driver
+report-fields:
+  - candidate-id
+  - evidence-link
+  - validation-state
+  - promotion-state
+  - claim-boundary
+claim: fixture-only

--- a/tests/fyr_black_arts_claim_boundary_fixture.rs
+++ b/tests/fyr_black_arts_claim_boundary_fixture.rs
@@ -1,0 +1,54 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_claim_boundary_fixture_has_required_shape() {
+    let path = "docs/fyr/fixtures/staged-claim-boundary-ok.txt";
+
+    for field in [
+        "name: black-arts-claim-boundary-fixture",
+        "kind: staged-claim-boundary-fixture",
+        "candidate: phase1-base1-candidate",
+        "required-boundaries:",
+        "not-production",
+        "not-release-ready",
+        "not-live-update",
+        "not-auto-promote",
+        "not-daily-driver",
+        "report-fields:",
+        "candidate-id",
+        "evidence-link",
+        "validation-state",
+        "promotion-state",
+        "claim-boundary",
+        "claim: fixture-only",
+    ] {
+        assert_contains(path, field);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_claim_boundary_fixture() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-claim-boundary-ok.txt",
+    );
+}
+
+#[test]
+fn staged_candidate_doc_preserves_claim_boundaries() {
+    let doc = read("docs/fyr/STAGED_CANDIDATES.md");
+
+    assert!(doc.contains("not a production updater"));
+    assert!(doc.contains("not a release candidate process"));
+    assert!(doc.contains("does not change the live system"));
+    assert!(doc.contains("does not promote candidates without validation evidence"));
+}


### PR DESCRIPTION
## Summary

This PR adds the final fixture in the first `black_arts` staged-candidate evidence set: a claim-boundary fixture.

## Changes

- Adds `docs/fyr/fixtures/staged-claim-boundary-ok.txt`.
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the new fixture.
- Adds `tests/fyr_black_arts_claim_boundary_fixture.rs` for fixture shape and documentation boundary checks.

## Intent

This keeps the staged-candidate track evidence-bound and fixture-only. It records what reports must include before future implementation work can proceed.

## Validation

Not run locally through this connector. Added deterministic documentation and fixture tests.