### PR TITLE
Add Fyr black_arts workspace layout evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -55,9 +55,10 @@ docs/fyr/fixtures/staged-validation-ok.txt
 docs/fyr/fixtures/staged-approval-ok.txt
 docs/fyr/fixtures/staged-discard-ok.txt
 docs/fyr/fixtures/staged-claim-boundary-ok.txt
+docs/fyr/fixtures/staged-workspace-ok.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, validation results, explicit approval, discard records, and claim boundaries. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, validation results, explicit approval, discard records, claim boundaries, and staged workspace layout. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-workspace-ok.txt
+++ b/docs/fyr/fixtures/staged-workspace-ok.txt
@@ -1,0 +1,17 @@
+name: black-arts-workspace-fixture
+kind: staged-workspace-fixture
+workspace-root: .phase1/staged-candidates
+candidate-root: .phase1/staged-candidates/phase1-base1-candidate
+required-paths:
+  - plan.fyr
+  - candidate.toml
+  - changes.log
+  - validation.log
+  - approval.toml
+  - discard.log
+isolation-rules:
+  - candidate-only-writes
+  - live-system-untouched
+  - declared-workspace
+  - evidence-recorded
+claim: fixture-only

--- a/tests/fyr_black_arts_workspace_fixture.rs
+++ b/tests/fyr_black_arts_workspace_fixture.rs
@@ -1,0 +1,57 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_workspace_fixture_has_required_shape() {
+    let path = "docs/fyr/fixtures/staged-workspace-ok.txt";
+
+    for field in [
+        "name: black-arts-workspace-fixture",
+        "kind: staged-workspace-fixture",
+        "workspace-root: .phase1/staged-candidates",
+        "candidate-root: .phase1/staged-candidates/phase1-base1-candidate",
+        "required-paths:",
+        "plan.fyr",
+        "candidate.toml",
+        "changes.log",
+        "validation.log",
+        "approval.toml",
+        "discard.log",
+        "isolation-rules:",
+        "candidate-only-writes",
+        "live-system-untouched",
+        "declared-workspace",
+        "evidence-recorded",
+        "claim: fixture-only",
+    ] {
+        assert_contains(path, field);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_workspace_fixture() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-workspace-ok.txt",
+    );
+}
+
+#[test]
+fn workspace_fixture_preserves_candidate_only_boundary() {
+    let doc = read("docs/fyr/STAGED_CANDIDATES.md");
+    let fixture = read("docs/fyr/fixtures/staged-workspace-ok.txt");
+
+    assert!(doc.contains("candidate-only writes"));
+    assert!(doc.contains("declared workspace first"));
+    assert!(doc.contains("live system remains untouched until explicit promotion"));
+    assert!(fixture.contains("candidate-only-writes"));
+    assert!(fixture.contains("live-system-untouched"));
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate track by defining the first staged workspace layout fixture.

## Changes

- Adds `docs/fyr/fixtures/staged-workspace-ok.txt` with workspace and candidate path expectations.
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the workspace fixture.
- Adds `tests/fyr_black_arts_workspace_fixture.rs` covering:
  - workspace fixture shape
  - required staged candidate records
  - candidate-only write boundary
  - live-system untouched marker
  - declared workspace requirement

## Intent

This gives future `black_arts` candidate creation a defined place to operate: `.phase1/staged-candidates/...`, with plan, metadata, change, validation, approval, and discard records. It remains fixture-only and does not implement live mutation.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.