### PR TITLE
Add Fyr black_arts change log fixture evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -51,6 +51,7 @@ The current staged candidate fixtures are:
 ```text
 docs/fyr/fixtures/staged-candidate-ok.txt
 docs/fyr/fixtures/staged-plan-ok.txt
+docs/fyr/fixtures/staged-change-log-ok.txt
 docs/fyr/fixtures/staged-validation-ok.txt
 docs/fyr/fixtures/staged-approval-ok.txt
 docs/fyr/fixtures/staged-discard-ok.txt
@@ -58,7 +59,7 @@ docs/fyr/fixtures/staged-claim-boundary-ok.txt
 docs/fyr/fixtures/staged-workspace-ok.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, validation results, explicit approval, discard records, claim boundaries, and staged workspace layout. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, change logs, validation results, explicit approval, discard records, claim boundaries, and staged workspace layout. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-change-log-ok.txt
+++ b/docs/fyr/fixtures/staged-change-log-ok.txt
@@ -1,0 +1,19 @@
+name: black-arts-change-log-fixture
+kind: staged-change-log-fixture
+candidate: phase1-base1-candidate
+plan: staged-plan-ok.txt
+change-mode: candidate-only
+applied-changes:
+  - config-update
+  - feature-toggle
+  - docs-update
+rejected-operations:
+  - live-system-write
+  - undeclared-path
+  - missing-evidence
+required-records:
+  - file-list
+  - change-summary
+  - rejected-operations
+  - evidence-link
+claim: fixture-only

--- a/tests/fyr_black_arts_change_log_fixture.rs
+++ b/tests/fyr_black_arts_change_log_fixture.rs
@@ -1,0 +1,58 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_change_log_fixture_has_required_shape() {
+    let path = "docs/fyr/fixtures/staged-change-log-ok.txt";
+
+    for field in [
+        "name: black-arts-change-log-fixture",
+        "kind: staged-change-log-fixture",
+        "candidate: phase1-base1-candidate",
+        "plan: staged-plan-ok.txt",
+        "change-mode: candidate-only",
+        "applied-changes:",
+        "config-update",
+        "feature-toggle",
+        "docs-update",
+        "rejected-operations:",
+        "live-system-write",
+        "undeclared-path",
+        "missing-evidence",
+        "required-records:",
+        "file-list",
+        "change-summary",
+        "rejected-operations",
+        "evidence-link",
+        "claim: fixture-only",
+    ] {
+        assert_contains(path, field);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_change_log_fixture() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-change-log-ok.txt",
+    );
+}
+
+#[test]
+fn change_log_fixture_preserves_rejected_operation_visibility() {
+    let doc = read("docs/fyr/STAGED_CANDIDATES.md");
+    let fixture = read("docs/fyr/fixtures/staged-change-log-ok.txt");
+
+    assert!(doc.contains("rejected operations"));
+    assert!(doc.contains("candidate-only writes"));
+    assert!(fixture.contains("rejected-operations"));
+    assert!(fixture.contains("live-system-write"));
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate track by adding change-log fixture evidence for candidate-scoped apply operations.

## Changes

- Adds `docs/fyr/fixtures/staged-change-log-ok.txt` with:
  - candidate
  - plan
  - candidate-only change mode
  - applied changes
  - rejected operations
  - required records
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the change-log fixture.
- Adds `tests/fyr_black_arts_change_log_fixture.rs` covering:
  - change-log fixture shape
  - applied change records
  - rejected-operation visibility
  - candidate-only write boundary

## Intent

This ensures future `black_arts` apply/mutate operations must record what changed and what was rejected before validation or promotion can proceed.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.