### PR TITLE
Add Fyr black_arts staged command contract evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -57,9 +57,10 @@ docs/fyr/fixtures/staged-approval-ok.txt
 docs/fyr/fixtures/staged-discard-ok.txt
 docs/fyr/fixtures/staged-claim-boundary-ok.txt
 docs/fyr/fixtures/staged-workspace-ok.txt
+docs/fyr/fixtures/staged-command-contract-ok.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, change logs, validation results, explicit approval, discard records, claim boundaries, and staged workspace layout. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, and command contract. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-command-contract-ok.txt
+++ b/docs/fyr/fixtures/staged-command-contract-ok.txt
@@ -1,0 +1,20 @@
+name: black-arts-command-contract-fixture
+kind: staged-command-contract-fixture
+codename: black_arts
+canonical-surface: fyr staged
+commands:
+  - status
+  - plan
+  - create
+  - apply
+  - validate
+  - promote
+  - discard
+required-guards:
+  - candidate-only
+  - declared-workspace
+  - validation-before-promote
+  - operator-approval
+  - evidence-recorded
+  - claim-boundary
+claim: fixture-only

--- a/tests/fyr_black_arts_command_contract.rs
+++ b/tests/fyr_black_arts_command_contract.rs
@@ -1,0 +1,65 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_command_contract_fixture_has_required_shape() {
+    let path = "docs/fyr/fixtures/staged-command-contract-ok.txt";
+
+    for field in [
+        "name: black-arts-command-contract-fixture",
+        "kind: staged-command-contract-fixture",
+        "codename: black_arts",
+        "canonical-surface: fyr staged",
+        "commands:",
+        "status",
+        "plan",
+        "create",
+        "apply",
+        "validate",
+        "promote",
+        "discard",
+        "required-guards:",
+        "candidate-only",
+        "declared-workspace",
+        "validation-before-promote",
+        "operator-approval",
+        "evidence-recorded",
+        "claim-boundary",
+        "claim: fixture-only",
+    ] {
+        assert_contains(path, field);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_command_contract_fixture() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-command-contract-ok.txt",
+    );
+}
+
+#[test]
+fn command_contract_matches_documented_surface() {
+    let doc = read("docs/fyr/STAGED_CANDIDATES.md");
+
+    for command in [
+        "fyr staged status",
+        "fyr staged plan",
+        "fyr staged create <candidate>",
+        "fyr staged apply <candidate> <plan.fyr>",
+        "fyr staged validate <candidate>",
+        "fyr staged promote <candidate>",
+        "fyr staged discard <candidate>",
+    ] {
+        assert!(doc.contains(command), "staged candidate doc should include {command}");
+    }
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate track by adding a command-contract fixture for the future staged command surface.

## Changes

- Adds `docs/fyr/fixtures/staged-command-contract-ok.txt` with:
  - `black_arts` codename
  - canonical `fyr staged` surface
  - planned staged commands
  - required guards
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the command-contract fixture.
- Adds `tests/fyr_black_arts_command_contract.rs` covering:
  - command-contract fixture shape
  - documented staged command surface
  - required guard list
  - fixture-only boundary

## Intent

This makes the future `black_arts` command surface explicit before implementation: status, plan, create, apply, validate, promote, and discard all remain guarded by candidate-only scope, declared workspace, validation-before-promotion, explicit approval, evidence records, and claim-boundary checks.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.