### PR TITLE
Add Fyr black_arts staged status fixture evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -58,9 +58,10 @@ docs/fyr/fixtures/staged-discard-ok.txt
 docs/fyr/fixtures/staged-claim-boundary-ok.txt
 docs/fyr/fixtures/staged-workspace-ok.txt
 docs/fyr/fixtures/staged-command-contract-ok.txt
+docs/fyr/fixtures/staged-status-ok.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, and command contract. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, and status output. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-status-ok.txt
+++ b/docs/fyr/fixtures/staged-status-ok.txt
@@ -1,0 +1,21 @@
+name: black-arts-status-fixture
+kind: staged-status-fixture
+command: fyr staged status
+candidate-count: 1
+candidates:
+  - phase1-base1-candidate
+required-fields:
+  - workspace-root
+  - candidate-id
+  - validation-state
+  - promotion-state
+  - claim-boundary
+  - evidence-link
+states:
+  - planned
+  - created
+  - changed
+  - validated
+  - approved
+  - discarded
+claim: fixture-only

--- a/tests/fyr_black_arts_status_fixture.rs
+++ b/tests/fyr_black_arts_status_fixture.rs
@@ -1,0 +1,59 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_status_fixture_has_required_shape() {
+    let path = "docs/fyr/fixtures/staged-status-ok.txt";
+
+    for field in [
+        "name: black-arts-status-fixture",
+        "kind: staged-status-fixture",
+        "command: fyr staged status",
+        "candidate-count: 1",
+        "phase1-base1-candidate",
+        "required-fields:",
+        "workspace-root",
+        "candidate-id",
+        "validation-state",
+        "promotion-state",
+        "claim-boundary",
+        "evidence-link",
+        "states:",
+        "planned",
+        "created",
+        "changed",
+        "validated",
+        "approved",
+        "discarded",
+        "claim: fixture-only",
+    ] {
+        assert_contains(path, field);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_status_fixture() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-status-ok.txt",
+    );
+}
+
+#[test]
+fn status_fixture_preserves_status_contract_boundaries() {
+    let doc = read("docs/fyr/STAGED_CANDIDATES.md");
+    let fixture = read("docs/fyr/fixtures/staged-status-ok.txt");
+
+    assert!(doc.contains("fyr staged status"));
+    assert!(doc.contains("visible non-claims in every report"));
+    assert!(fixture.contains("claim-boundary"));
+    assert!(fixture.contains("evidence-link"));
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate track by adding a status-output fixture for the future `fyr staged status` command.

## Changes

- Adds `docs/fyr/fixtures/staged-status-ok.txt` with:
  - command name
  - candidate count
  - candidate list
  - required status fields
  - staged lifecycle states
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the status fixture.
- Adds `tests/fyr_black_arts_status_fixture.rs` covering:
  - status fixture shape
  - documented status command
  - claim-boundary field
  - evidence-link field

## Intent

This defines what `fyr staged status` should eventually report before implementation: workspace/candidate identity, validation state, promotion state, claim boundary, and evidence link.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.