### PR TITLE
Add Fyr black_arts staged status example evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -59,9 +59,10 @@ docs/fyr/fixtures/staged-claim-boundary-ok.txt
 docs/fyr/fixtures/staged-workspace-ok.txt
 docs/fyr/fixtures/staged-command-contract-ok.txt
 docs/fyr/fixtures/staged-status-ok.txt
+docs/fyr/fixtures/staged-status-example.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, and status output. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, status output, and a status example. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-status-example.txt
+++ b/docs/fyr/fixtures/staged-status-example.txt
@@ -1,0 +1,13 @@
+fyr staged status
+codename      : black_arts
+workspace     : .phase1/staged-candidates
+candidates    : 1
+
+candidate     : phase1-base1-candidate
+state         : validated
+validation    : passed
+promotion     : blocked-until-approval
+claim-boundary: fixture-only
+evidence      : docs/fyr/fixtures/staged-validation-ok.txt
+
+non-claims    : not-production, not-release-ready, not-live-update

--- a/tests/fyr_black_arts_status_example.rs
+++ b/tests/fyr_black_arts_status_example.rs
@@ -1,0 +1,48 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_status_example_has_required_output_rows() {
+    let path = "docs/fyr/fixtures/staged-status-example.txt";
+
+    for row in [
+        "fyr staged status",
+        "codename      : black_arts",
+        "workspace     : .phase1/staged-candidates",
+        "candidates    : 1",
+        "candidate     : phase1-base1-candidate",
+        "state         : validated",
+        "validation    : passed",
+        "promotion     : blocked-until-approval",
+        "claim-boundary: fixture-only",
+        "evidence      : docs/fyr/fixtures/staged-validation-ok.txt",
+        "non-claims    : not-production, not-release-ready, not-live-update",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_status_example() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-status-example.txt",
+    );
+}
+
+#[test]
+fn status_example_preserves_promotion_block() {
+    let example = read("docs/fyr/fixtures/staged-status-example.txt");
+
+    assert!(example.contains("validation    : passed"));
+    assert!(example.contains("promotion     : blocked-until-approval"));
+    assert!(example.contains("claim-boundary: fixture-only"));
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate track by adding a concrete status example for the future `fyr staged status` command.

## Changes

- Adds `docs/fyr/fixtures/staged-status-example.txt` with deterministic status output rows.
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the status example fixture.
- Adds `tests/fyr_black_arts_status_example.rs` covering:
  - exact status example rows
  - promotion remains blocked after validation
  - fixture-only claim boundary

## Intent

This defines the public shape of a future status report before implementation: candidate identity, validation state, blocked promotion state, claim boundary, evidence link, and non-claim summary.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.