### PR TITLE
Add Fyr black_arts staged plan example evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -51,6 +51,7 @@ The current staged candidate fixtures are:
 ```text
 docs/fyr/fixtures/staged-candidate-ok.txt
 docs/fyr/fixtures/staged-plan-ok.txt
+docs/fyr/fixtures/staged-plan-example.txt
 docs/fyr/fixtures/staged-change-log-ok.txt
 docs/fyr/fixtures/staged-validation-ok.txt
 docs/fyr/fixtures/staged-approval-ok.txt
@@ -62,7 +63,7 @@ docs/fyr/fixtures/staged-status-ok.txt
 docs/fyr/fixtures/staged-status-example.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, status output, and a status example. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, status output, and a status example. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-plan-example.txt
+++ b/docs/fyr/fixtures/staged-plan-example.txt
@@ -1,0 +1,12 @@
+fyr staged plan
+codename      : black_arts
+plan          : docs/fyr/fixtures/staged-plan-ok.txt
+version       : 0.1.0
+source        : known-good
+candidate     : phase1-base1-candidate
+scope         : candidate-only
+changes       : config-update, feature-toggle, docs-update
+validation    : tests, docs, status
+promotion     : operator-approval, rollback-path, evidence-link
+discard       : stale-candidate, failed-validation
+claim-boundary: fixture-only

--- a/tests/fyr_black_arts_plan_example.rs
+++ b/tests/fyr_black_arts_plan_example.rs
@@ -1,0 +1,49 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_plan_example_has_required_output_rows() {
+    let path = "docs/fyr/fixtures/staged-plan-example.txt";
+
+    for row in [
+        "fyr staged plan",
+        "codename      : black_arts",
+        "plan          : docs/fyr/fixtures/staged-plan-ok.txt",
+        "version       : 0.1.0",
+        "source        : known-good",
+        "candidate     : phase1-base1-candidate",
+        "scope         : candidate-only",
+        "changes       : config-update, feature-toggle, docs-update",
+        "validation    : tests, docs, status",
+        "promotion     : operator-approval, rollback-path, evidence-link",
+        "discard       : stale-candidate, failed-validation",
+        "claim-boundary: fixture-only",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_plan_example() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-plan-example.txt",
+    );
+}
+
+#[test]
+fn plan_example_preserves_candidate_only_scope() {
+    let example = read("docs/fyr/fixtures/staged-plan-example.txt");
+
+    assert!(example.contains("scope         : candidate-only"));
+    assert!(example.contains("promotion     : operator-approval, rollback-path, evidence-link"));
+    assert!(example.contains("claim-boundary: fixture-only"));
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate track by adding a concrete plan example for the future `fyr staged plan` command.

## Changes

- Adds `docs/fyr/fixtures/staged-plan-example.txt` with deterministic plan output rows.
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the plan example fixture.
- Adds `tests/fyr_black_arts_plan_example.rs` covering:
  - exact plan example rows
  - candidate-only scope
  - promotion requirements
  - fixture-only claim boundary

## Intent

This defines the public shape of a future plan report before implementation: source, candidate, scope, changes, validation, promotion, discard, and claim boundary.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.