### PR TITLE
Add Fyr black_arts staged create example evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -52,6 +52,7 @@ The current staged candidate fixtures are:
 docs/fyr/fixtures/staged-candidate-ok.txt
 docs/fyr/fixtures/staged-plan-ok.txt
 docs/fyr/fixtures/staged-plan-example.txt
+docs/fyr/fixtures/staged-create-example.txt
 docs/fyr/fixtures/staged-change-log-ok.txt
 docs/fyr/fixtures/staged-validation-ok.txt
 docs/fyr/fixtures/staged-approval-ok.txt
@@ -63,7 +64,7 @@ docs/fyr/fixtures/staged-status-ok.txt
 docs/fyr/fixtures/staged-status-example.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, status output, and a status example. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create example output, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, status output, and a status example. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-create-example.txt
+++ b/docs/fyr/fixtures/staged-create-example.txt
@@ -1,0 +1,10 @@
+fyr staged create phase1-base1-candidate
+codename      : black_arts
+candidate     : phase1-base1-candidate
+source        : known-good
+workspace     : .phase1/staged-candidates/phase1-base1-candidate
+created       : candidate.toml, plan.fyr, changes.log, validation.log, approval.toml, discard.log
+write-scope   : candidate-only
+live-system   : untouched
+next          : fyr staged apply phase1-base1-candidate docs/fyr/fixtures/staged-plan-ok.txt
+claim-boundary: fixture-only

--- a/tests/fyr_black_arts_create_example.rs
+++ b/tests/fyr_black_arts_create_example.rs
@@ -1,0 +1,47 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_create_example_has_required_output_rows() {
+    let path = "docs/fyr/fixtures/staged-create-example.txt";
+
+    for row in [
+        "fyr staged create phase1-base1-candidate",
+        "codename      : black_arts",
+        "candidate     : phase1-base1-candidate",
+        "source        : known-good",
+        "workspace     : .phase1/staged-candidates/phase1-base1-candidate",
+        "created       : candidate.toml, plan.fyr, changes.log, validation.log, approval.toml, discard.log",
+        "write-scope   : candidate-only",
+        "live-system   : untouched",
+        "next          : fyr staged apply phase1-base1-candidate docs/fyr/fixtures/staged-plan-ok.txt",
+        "claim-boundary: fixture-only",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_create_example() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-create-example.txt",
+    );
+}
+
+#[test]
+fn create_example_preserves_candidate_workspace_boundary() {
+    let example = read("docs/fyr/fixtures/staged-create-example.txt");
+
+    assert!(example.contains("write-scope   : candidate-only"));
+    assert!(example.contains("live-system   : untouched"));
+    assert!(example.contains("workspace     : .phase1/staged-candidates/phase1-base1-candidate"));
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate track by adding a concrete create example for the future `fyr staged create` command.

## Changes

- Adds `docs/fyr/fixtures/staged-create-example.txt` with deterministic create output rows.
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the create example fixture.
- Adds `tests/fyr_black_arts_create_example.rs` covering:
  - exact create example rows
  - candidate workspace path
  - candidate-only write scope
  - live-system untouched marker
  - fixture-only claim boundary

## Intent

This defines the public shape of a future candidate creation report before implementation: source, workspace, created records, write scope, live-system boundary, next command, and claim boundary.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.