### PR TITLE
Add Fyr black_arts staged apply example evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -53,6 +53,7 @@ docs/fyr/fixtures/staged-candidate-ok.txt
 docs/fyr/fixtures/staged-plan-ok.txt
 docs/fyr/fixtures/staged-plan-example.txt
 docs/fyr/fixtures/staged-create-example.txt
+docs/fyr/fixtures/staged-apply-example.txt
 docs/fyr/fixtures/staged-change-log-ok.txt
 docs/fyr/fixtures/staged-validation-ok.txt
 docs/fyr/fixtures/staged-approval-ok.txt
@@ -64,7 +65,7 @@ docs/fyr/fixtures/staged-status-ok.txt
 docs/fyr/fixtures/staged-status-example.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create example output, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, status output, and a status example. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create/apply example output, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, status output, and a status example. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-apply-example.txt
+++ b/docs/fyr/fixtures/staged-apply-example.txt
@@ -1,0 +1,12 @@
+fyr staged apply phase1-base1-candidate docs/fyr/fixtures/staged-plan-ok.txt
+codename      : black_arts
+candidate     : phase1-base1-candidate
+plan          : docs/fyr/fixtures/staged-plan-ok.txt
+change-mode   : candidate-only
+applied       : config-update, feature-toggle, docs-update
+rejected      : live-system-write, undeclared-path, missing-evidence
+records       : changes.log, candidate.toml
+write-scope   : .phase1/staged-candidates/phase1-base1-candidate
+live-system   : untouched
+next          : fyr staged validate phase1-base1-candidate
+claim-boundary: fixture-only

--- a/tests/fyr_black_arts_apply_example.rs
+++ b/tests/fyr_black_arts_apply_example.rs
@@ -1,0 +1,49 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_apply_example_has_required_output_rows() {
+    let path = "docs/fyr/fixtures/staged-apply-example.txt";
+
+    for row in [
+        "fyr staged apply phase1-base1-candidate docs/fyr/fixtures/staged-plan-ok.txt",
+        "codename      : black_arts",
+        "candidate     : phase1-base1-candidate",
+        "plan          : docs/fyr/fixtures/staged-plan-ok.txt",
+        "change-mode   : candidate-only",
+        "applied       : config-update, feature-toggle, docs-update",
+        "rejected      : live-system-write, undeclared-path, missing-evidence",
+        "records       : changes.log, candidate.toml",
+        "write-scope   : .phase1/staged-candidates/phase1-base1-candidate",
+        "live-system   : untouched",
+        "next          : fyr staged validate phase1-base1-candidate",
+        "claim-boundary: fixture-only",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_apply_example() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-apply-example.txt",
+    );
+}
+
+#[test]
+fn apply_example_preserves_rejected_operation_visibility() {
+    let example = read("docs/fyr/fixtures/staged-apply-example.txt");
+
+    assert!(example.contains("change-mode   : candidate-only"));
+    assert!(example.contains("rejected      : live-system-write, undeclared-path, missing-evidence"));
+    assert!(example.contains("live-system   : untouched"));
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate track by adding a concrete apply example for the future `fyr staged apply` command.

## Changes

- Adds `docs/fyr/fixtures/staged-apply-example.txt` with deterministic apply output rows.
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the apply example fixture.
- Adds `tests/fyr_black_arts_apply_example.rs` covering:
  - exact apply example rows
  - candidate-only change mode
  - rejected-operation visibility
  - live-system untouched marker
  - fixture-only claim boundary

## Intent

This defines the public shape of a future apply/mutate report before implementation: candidate, plan, candidate-only mode, applied changes, rejected operations, records, write scope, next command, and claim boundary.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.