### PR TITLE
Add Fyr black_arts staged validate example evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -56,6 +56,7 @@ docs/fyr/fixtures/staged-create-example.txt
 docs/fyr/fixtures/staged-apply-example.txt
 docs/fyr/fixtures/staged-change-log-ok.txt
 docs/fyr/fixtures/staged-validation-ok.txt
+docs/fyr/fixtures/staged-validate-example.txt
 docs/fyr/fixtures/staged-approval-ok.txt
 docs/fyr/fixtures/staged-discard-ok.txt
 docs/fyr/fixtures/staged-claim-boundary-ok.txt
@@ -65,7 +66,7 @@ docs/fyr/fixtures/staged-status-ok.txt
 docs/fyr/fixtures/staged-status-example.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create/apply example output, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, status output, and a status example. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create/apply/validate example output, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, status output, and a status example. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-validate-example.txt
+++ b/docs/fyr/fixtures/staged-validate-example.txt
@@ -1,0 +1,11 @@
+fyr staged validate phase1-base1-candidate
+codename      : black_arts
+candidate     : phase1-base1-candidate
+checks        : tests, docs, status, non-claims
+result        : passed
+evidence      : docs/fyr/fixtures/staged-validation-ok.txt
+promotion     : blocked-until-approval
+approval      : required
+rollback      : required
+claim-boundary: fixture-only
+next          : fyr staged promote phase1-base1-candidate

--- a/tests/fyr_black_arts_validate_example.rs
+++ b/tests/fyr_black_arts_validate_example.rs
@@ -1,0 +1,49 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_validate_example_has_required_output_rows() {
+    let path = "docs/fyr/fixtures/staged-validate-example.txt";
+
+    for row in [
+        "fyr staged validate phase1-base1-candidate",
+        "codename      : black_arts",
+        "candidate     : phase1-base1-candidate",
+        "checks        : tests, docs, status, non-claims",
+        "result        : passed",
+        "evidence      : docs/fyr/fixtures/staged-validation-ok.txt",
+        "promotion     : blocked-until-approval",
+        "approval      : required",
+        "rollback      : required",
+        "claim-boundary: fixture-only",
+        "next          : fyr staged promote phase1-base1-candidate",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_validate_example() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-validate-example.txt",
+    );
+}
+
+#[test]
+fn validate_example_keeps_promotion_blocked() {
+    let example = read("docs/fyr/fixtures/staged-validate-example.txt");
+
+    assert!(example.contains("result        : passed"));
+    assert!(example.contains("promotion     : blocked-until-approval"));
+    assert!(example.contains("approval      : required"));
+    assert!(example.contains("rollback      : required"));
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate track by adding a concrete validate example for the future `fyr staged validate` command.

## Changes

- Adds `docs/fyr/fixtures/staged-validate-example.txt` with deterministic validate output rows.
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the validate example fixture.
- Adds `tests/fyr_black_arts_validate_example.rs` covering:
  - exact validate example rows
  - validation result reporting
  - promotion remains blocked until approval
  - rollback requirement
  - fixture-only claim boundary

## Intent

This defines the public shape of a future validation report before implementation: checks, result, evidence, blocked promotion state, approval requirement, rollback requirement, next command, and claim boundary.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.