### PR TITLE
Add Fyr black_arts staged promote example evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -57,6 +57,7 @@ docs/fyr/fixtures/staged-apply-example.txt
 docs/fyr/fixtures/staged-change-log-ok.txt
 docs/fyr/fixtures/staged-validation-ok.txt
 docs/fyr/fixtures/staged-validate-example.txt
+docs/fyr/fixtures/staged-promote-example.txt
 docs/fyr/fixtures/staged-approval-ok.txt
 docs/fyr/fixtures/staged-discard-ok.txt
 docs/fyr/fixtures/staged-claim-boundary-ok.txt
@@ -66,7 +67,7 @@ docs/fyr/fixtures/staged-status-ok.txt
 docs/fyr/fixtures/staged-status-example.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create/apply/validate example output, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, status output, and a status example. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create/apply/validate/promote example output, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, status output, and a status example. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-promote-example.txt
+++ b/docs/fyr/fixtures/staged-promote-example.txt
@@ -1,0 +1,11 @@
+fyr staged promote phase1-base1-candidate
+codename      : black_arts
+candidate     : phase1-base1-candidate
+validation    : passed
+approval      : approved-by-operator
+promotion     : explicit-only
+rollback      : docs/fyr/fixtures/staged-approval-ok.txt
+evidence      : docs/fyr/fixtures/staged-validation-ok.txt
+claim-boundary: fixture-only
+live-system   : untouched-before-promotion
+result        : promotion-record-ready

--- a/tests/fyr_black_arts_promote_example.rs
+++ b/tests/fyr_black_arts_promote_example.rs
@@ -1,0 +1,50 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_promote_example_has_required_output_rows() {
+    let path = "docs/fyr/fixtures/staged-promote-example.txt";
+
+    for row in [
+        "fyr staged promote phase1-base1-candidate",
+        "codename      : black_arts",
+        "candidate     : phase1-base1-candidate",
+        "validation    : passed",
+        "approval      : approved-by-operator",
+        "promotion     : explicit-only",
+        "rollback      : docs/fyr/fixtures/staged-approval-ok.txt",
+        "evidence      : docs/fyr/fixtures/staged-validation-ok.txt",
+        "claim-boundary: fixture-only",
+        "live-system   : untouched-before-promotion",
+        "result        : promotion-record-ready",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_promote_example() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-promote-example.txt",
+    );
+}
+
+#[test]
+fn promote_example_preserves_explicit_approval_boundary() {
+    let example = read("docs/fyr/fixtures/staged-promote-example.txt");
+
+    assert!(example.contains("validation    : passed"));
+    assert!(example.contains("approval      : approved-by-operator"));
+    assert!(example.contains("promotion     : explicit-only"));
+    assert!(example.contains("rollback      : docs/fyr/fixtures/staged-approval-ok.txt"));
+    assert!(example.contains("evidence      : docs/fyr/fixtures/staged-validation-ok.txt"));
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate track by adding a concrete promote example for the future `fyr staged promote` command.

## Changes

- Adds `docs/fyr/fixtures/staged-promote-example.txt` with deterministic promote output rows.
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the promote example fixture.
- Adds `tests/fyr_black_arts_promote_example.rs` covering:
  - exact promote example rows
  - validation and approval requirements
  - explicit-only promotion mode
  - rollback/evidence links
  - fixture-only claim boundary

## Intent

This defines the public shape of a future promotion record before implementation: validation, operator approval, explicit promotion, rollback, evidence, live-system boundary, result, and claim boundary.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.