### PR TITLE
Add Fyr black_arts staged discard example evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -60,6 +60,7 @@ docs/fyr/fixtures/staged-validate-example.txt
 docs/fyr/fixtures/staged-promote-example.txt
 docs/fyr/fixtures/staged-approval-ok.txt
 docs/fyr/fixtures/staged-discard-ok.txt
+docs/fyr/fixtures/staged-discard-example.txt
 docs/fyr/fixtures/staged-claim-boundary-ok.txt
 docs/fyr/fixtures/staged-workspace-ok.txt
 docs/fyr/fixtures/staged-command-contract-ok.txt
@@ -67,7 +68,7 @@ docs/fyr/fixtures/staged-status-ok.txt
 docs/fyr/fixtures/staged-status-example.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create/apply/validate/promote example output, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, status output, and a status example. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create/apply/validate/promote/discard example output, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, status output, and a status example. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-discard-example.txt
+++ b/docs/fyr/fixtures/staged-discard-example.txt
@@ -1,0 +1,11 @@
+fyr staged discard phase1-base1-candidate
+codename      : black_arts
+candidate     : phase1-base1-candidate
+reason        : failed-validation
+discard-mode  : explicit-only
+removed       : .phase1/staged-candidates/phase1-base1-candidate
+record        : discard.log
+evidence      : docs/fyr/fixtures/staged-discard-ok.txt
+live-system   : untouched
+claim-boundary: fixture-only
+result        : candidate-discard-record-ready

--- a/tests/fyr_black_arts_discard_example.rs
+++ b/tests/fyr_black_arts_discard_example.rs
@@ -1,0 +1,49 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_discard_example_has_required_output_rows() {
+    let path = "docs/fyr/fixtures/staged-discard-example.txt";
+
+    for row in [
+        "fyr staged discard phase1-base1-candidate",
+        "codename      : black_arts",
+        "candidate     : phase1-base1-candidate",
+        "reason        : failed-validation",
+        "discard-mode  : explicit-only",
+        "removed       : .phase1/staged-candidates/phase1-base1-candidate",
+        "record        : discard.log",
+        "evidence      : docs/fyr/fixtures/staged-discard-ok.txt",
+        "live-system   : untouched",
+        "claim-boundary: fixture-only",
+        "result        : candidate-discard-record-ready",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_discard_example() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-discard-example.txt",
+    );
+}
+
+#[test]
+fn discard_example_preserves_live_system_boundary() {
+    let example = read("docs/fyr/fixtures/staged-discard-example.txt");
+
+    assert!(example.contains("discard-mode  : explicit-only"));
+    assert!(example.contains("removed       : .phase1/staged-candidates/phase1-base1-candidate"));
+    assert!(example.contains("live-system   : untouched"));
+    assert!(example.contains("claim-boundary: fixture-only"));
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate track by adding a concrete discard example for the future `fyr staged discard` command.

## Changes

- Adds `docs/fyr/fixtures/staged-discard-example.txt` with deterministic discard output rows.
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the discard example fixture.
- Adds `tests/fyr_black_arts_discard_example.rs` covering:
  - exact discard example rows
  - explicit-only discard mode
  - discarded candidate path
  - discard record
  - live-system untouched marker
  - fixture-only claim boundary

## Intent

This defines the public shape of a future discard/banish report before implementation: reason, explicit discard mode, removed candidate path, discard record, evidence link, live-system boundary, result, and claim boundary.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.