### PR TITLE
Add Fyr black_arts staged lifecycle example evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -61,6 +61,7 @@ docs/fyr/fixtures/staged-promote-example.txt
 docs/fyr/fixtures/staged-approval-ok.txt
 docs/fyr/fixtures/staged-discard-ok.txt
 docs/fyr/fixtures/staged-discard-example.txt
+docs/fyr/fixtures/staged-lifecycle-example.txt
 docs/fyr/fixtures/staged-claim-boundary-ok.txt
 docs/fyr/fixtures/staged-workspace-ok.txt
 docs/fyr/fixtures/staged-command-contract-ok.txt
@@ -68,7 +69,7 @@ docs/fyr/fixtures/staged-status-ok.txt
 docs/fyr/fixtures/staged-status-example.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create/apply/validate/promote/discard example output, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, status output, and a status example. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create/apply/validate/promote/discard example output, lifecycle summary, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, status output, and a status example. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-lifecycle-example.txt
+++ b/docs/fyr/fixtures/staged-lifecycle-example.txt
@@ -1,0 +1,15 @@
+black_arts staged lifecycle
+codename      : black_arts
+candidate     : phase1-base1-candidate
+workspace     : .phase1/staged-candidates/phase1-base1-candidate
+
+1 plan        : docs/fyr/fixtures/staged-plan-example.txt
+2 create      : docs/fyr/fixtures/staged-create-example.txt
+3 apply       : docs/fyr/fixtures/staged-apply-example.txt
+4 validate    : docs/fyr/fixtures/staged-validate-example.txt
+5 promote     : docs/fyr/fixtures/staged-promote-example.txt
+6 discard     : docs/fyr/fixtures/staged-discard-example.txt
+
+guards        : candidate-only, evidence-recorded, claim-boundary, operator-approval
+live-system   : untouched-until-explicit-promotion
+claim-boundary: fixture-only

--- a/tests/fyr_black_arts_lifecycle_example.rs
+++ b/tests/fyr_black_arts_lifecycle_example.rs
@@ -1,0 +1,58 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_lifecycle_example_has_required_rows() {
+    let path = "docs/fyr/fixtures/staged-lifecycle-example.txt";
+
+    for row in [
+        "black_arts staged lifecycle",
+        "codename      : black_arts",
+        "candidate     : phase1-base1-candidate",
+        "workspace     : .phase1/staged-candidates/phase1-base1-candidate",
+        "1 plan        : docs/fyr/fixtures/staged-plan-example.txt",
+        "2 create      : docs/fyr/fixtures/staged-create-example.txt",
+        "3 apply       : docs/fyr/fixtures/staged-apply-example.txt",
+        "4 validate    : docs/fyr/fixtures/staged-validate-example.txt",
+        "5 promote     : docs/fyr/fixtures/staged-promote-example.txt",
+        "6 discard     : docs/fyr/fixtures/staged-discard-example.txt",
+        "guards        : candidate-only, evidence-recorded, claim-boundary, operator-approval",
+        "live-system   : untouched-until-explicit-promotion",
+        "claim-boundary: fixture-only",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_lifecycle_example() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-lifecycle-example.txt",
+    );
+}
+
+#[test]
+fn lifecycle_example_links_existing_example_fixtures() {
+    let lifecycle = read("docs/fyr/fixtures/staged-lifecycle-example.txt");
+
+    for path in [
+        "docs/fyr/fixtures/staged-plan-example.txt",
+        "docs/fyr/fixtures/staged-create-example.txt",
+        "docs/fyr/fixtures/staged-apply-example.txt",
+        "docs/fyr/fixtures/staged-validate-example.txt",
+        "docs/fyr/fixtures/staged-promote-example.txt",
+        "docs/fyr/fixtures/staged-discard-example.txt",
+    ] {
+        assert!(lifecycle.contains(path), "lifecycle should list {path}");
+        assert!(fs::metadata(path).is_ok(), "listed fixture should exist: {path}");
+    }
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate track by adding a consolidated lifecycle example that links the full fixture path.

## Changes

- Adds `docs/fyr/fixtures/staged-lifecycle-example.txt` with deterministic lifecycle rows.
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the lifecycle example fixture.
- Adds `tests/fyr_black_arts_lifecycle_example.rs` covering:
  - lifecycle fixture rows
  - linked example fixtures exist
  - candidate workspace and guard summary
  - fixture-only claim boundary

## Intent

This ties the first `black_arts` command examples together into one end-to-end lifecycle: plan → create → apply → validate → promote/discard, while preserving candidate-only operation, evidence records, claim boundaries, and explicit approval.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.