### PR TITLE
Add Fyr black_arts staged stub contract evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -65,11 +65,12 @@ docs/fyr/fixtures/staged-lifecycle-example.txt
 docs/fyr/fixtures/staged-claim-boundary-ok.txt
 docs/fyr/fixtures/staged-workspace-ok.txt
 docs/fyr/fixtures/staged-command-contract-ok.txt
+docs/fyr/fixtures/staged-stub-contract-ok.txt
 docs/fyr/fixtures/staged-status-ok.txt
 docs/fyr/fixtures/staged-status-example.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create/apply/validate/promote/discard example output, lifecycle summary, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, status output, and a status example. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create/apply/validate/promote/discard example output, lifecycle summary, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, staged stub contract, status output, and a status example. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-stub-contract-ok.txt
+++ b/docs/fyr/fixtures/staged-stub-contract-ok.txt
@@ -1,0 +1,21 @@
+name: black-arts-staged-stub-contract
+kind: staged-stub-contract-fixture
+command-family: fyr staged
+current-state: contract-before-implementation
+expected-entrypoint: fyr_command
+required-actions:
+  - status
+  - plan
+  - create
+  - apply
+  - validate
+  - promote
+  - discard
+required-response-boundaries:
+  - fixture-backed
+  - non-live
+  - candidate-only
+  - evidence-bound
+  - claim-boundary
+implementation-note: source wiring must update fyr_command without changing live-system behavior
+claim: fixture-only

--- a/tests/fyr_black_arts_staged_stub_contract.rs
+++ b/tests/fyr_black_arts_staged_stub_contract.rs
@@ -1,0 +1,56 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_staged_stub_contract_has_required_shape() {
+    let path = "docs/fyr/fixtures/staged-stub-contract-ok.txt";
+
+    for field in [
+        "name: black-arts-staged-stub-contract",
+        "kind: staged-stub-contract-fixture",
+        "command-family: fyr staged",
+        "current-state: contract-before-implementation",
+        "expected-entrypoint: fyr_command",
+        "required-actions:",
+        "status",
+        "plan",
+        "create",
+        "apply",
+        "validate",
+        "promote",
+        "discard",
+        "required-response-boundaries:",
+        "fixture-backed",
+        "non-live",
+        "candidate-only",
+        "evidence-bound",
+        "claim-boundary",
+        "claim: fixture-only",
+    ] {
+        assert_contains(path, field);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_stub_contract_fixture() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-stub-contract-ok.txt",
+    );
+}
+
+#[test]
+fn source_contains_fyr_command_entrypoint_for_future_stub() {
+    let source = read("src/main.rs");
+
+    assert!(source.contains("fn fyr_command"));
+    assert!(source.contains("Some(\"help\") | Some(\"-h\") | Some(\"--help\") => fyr_help()"));
+}


### PR DESCRIPTION
## Summary

This PR moves the `black_arts` staged-candidate track toward implementation by adding a staged command stub contract.

## Changes

- Adds `docs/fyr/fixtures/staged-stub-contract-ok.txt` with:
  - `fyr staged` command-family contract
  - required actions
  - required response boundaries
  - implementation note for `fyr_command`
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the stub contract fixture.
- Adds `tests/fyr_black_arts_staged_stub_contract.rs` covering:
  - staged stub contract fixture shape
  - fixture-only boundary
  - source contains the `fyr_command` entrypoint for future wiring

## Intent

This keeps the next implementation step safe: the command contract is now explicit before source wiring. The future stub must stay fixture-backed, non-live, candidate-only, evidence-bound, and claim-boundary aware.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.