### PR TITLE
Add Fyr black_arts runtime stub evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -66,11 +66,12 @@ docs/fyr/fixtures/staged-claim-boundary-ok.txt
 docs/fyr/fixtures/staged-workspace-ok.txt
 docs/fyr/fixtures/staged-command-contract-ok.txt
 docs/fyr/fixtures/staged-stub-contract-ok.txt
+docs/fyr/fixtures/staged-runtime-stub-ok.txt
 docs/fyr/fixtures/staged-status-ok.txt
 docs/fyr/fixtures/staged-status-example.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create/apply/validate/promote/discard example output, lifecycle summary, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, staged stub contract, status output, and a status example. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create/apply/validate/promote/discard example output, lifecycle summary, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, staged stub contract, runtime stub output, status output, and a status example. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-runtime-stub-ok.txt
+++ b/docs/fyr/fixtures/staged-runtime-stub-ok.txt
@@ -1,0 +1,10 @@
+fyr staged
+codename      : black_arts
+status        : fixture-backed design stub
+live-system   : untouched
+workspace     : .phase1/staged-candidates
+commands      : status, plan, create, apply, validate, promote, discard
+boundaries    : candidate-only, non-live, evidence-bound, claim-boundary
+implementation: pending
+next          : wire fyr staged in fyr_command
+claim-boundary: fixture-only

--- a/tests/fyr_black_arts_runtime_stub.rs
+++ b/tests/fyr_black_arts_runtime_stub.rs
@@ -1,0 +1,47 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_runtime_stub_fixture_has_required_rows() {
+    let path = "docs/fyr/fixtures/staged-runtime-stub-ok.txt";
+
+    for row in [
+        "fyr staged",
+        "codename      : black_arts",
+        "status        : fixture-backed design stub",
+        "live-system   : untouched",
+        "workspace     : .phase1/staged-candidates",
+        "commands      : status, plan, create, apply, validate, promote, discard",
+        "boundaries    : candidate-only, non-live, evidence-bound, claim-boundary",
+        "implementation: pending",
+        "next          : wire fyr staged in fyr_command",
+        "claim-boundary: fixture-only",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_runtime_stub_fixture() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-runtime-stub-ok.txt",
+    );
+}
+
+#[test]
+fn source_entrypoint_is_ready_for_future_fyr_staged_wiring() {
+    let source = read("src/main.rs");
+
+    assert!(source.contains("fn fyr_command"));
+    assert!(source.contains("Some(\"status\") => fyr_status()"));
+    assert!(source.contains("Some(\"help\") | Some(\"-h\") | Some(\"--help\") => fyr_help()"));
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate track by adding a runtime-stub output contract for the future `fyr staged` command family.

## Changes

- Adds `docs/fyr/fixtures/staged-runtime-stub-ok.txt` with deterministic stub output rows.
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the runtime stub fixture.
- Adds `tests/fyr_black_arts_runtime_stub.rs` covering:
  - runtime stub fixture rows
  - fixture-backed status
  - non-live boundary
  - available staged commands
  - source entrypoint readiness for future `fyr staged` wiring

## Intent

This defines what the first `fyr staged` runtime stub should print before implementation: codename, fixture-backed status, live-system boundary, workspace, command list, boundaries, implementation state, and claim boundary.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.