### PR TITLE
Add Fyr black_arts staged help contract evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -67,11 +67,12 @@ docs/fyr/fixtures/staged-workspace-ok.txt
 docs/fyr/fixtures/staged-command-contract-ok.txt
 docs/fyr/fixtures/staged-stub-contract-ok.txt
 docs/fyr/fixtures/staged-runtime-stub-ok.txt
+docs/fyr/fixtures/staged-help-ok.txt
 docs/fyr/fixtures/staged-status-ok.txt
 docs/fyr/fixtures/staged-status-example.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create/apply/validate/promote/discard example output, lifecycle summary, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, staged stub contract, runtime stub output, status output, and a status example. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create/apply/validate/promote/discard example output, lifecycle summary, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, staged stub contract, runtime stub output, staged help output, status output, and a status example. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-help-ok.txt
+++ b/docs/fyr/fixtures/staged-help-ok.txt
@@ -1,0 +1,10 @@
+fyr staged help
+codename      : black_arts
+status        : fixture-backed design help
+usage         : fyr staged <status|plan|create|apply|validate|promote|discard>
+commands      : status, plan, create, apply, validate, promote, discard
+workspace     : .phase1/staged-candidates
+boundaries    : candidate-only, non-live, evidence-bound, claim-boundary
+promotion     : validation-and-approval-required
+implementation: pending
+claim-boundary: fixture-only

--- a/tests/fyr_black_arts_help_contract.rs
+++ b/tests/fyr_black_arts_help_contract.rs
@@ -1,0 +1,48 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_help_fixture_has_required_output_rows() {
+    let path = "docs/fyr/fixtures/staged-help-ok.txt";
+
+    for row in [
+        "fyr staged help",
+        "codename      : black_arts",
+        "status        : fixture-backed design help",
+        "usage         : fyr staged <status|plan|create|apply|validate|promote|discard>",
+        "commands      : status, plan, create, apply, validate, promote, discard",
+        "workspace     : .phase1/staged-candidates",
+        "boundaries    : candidate-only, non-live, evidence-bound, claim-boundary",
+        "promotion     : validation-and-approval-required",
+        "implementation: pending",
+        "claim-boundary: fixture-only",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_help_fixture() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-help-ok.txt",
+    );
+}
+
+#[test]
+fn help_fixture_keeps_staged_commands_guarded() {
+    let help = read("docs/fyr/fixtures/staged-help-ok.txt");
+
+    assert!(help.contains("candidate-only"));
+    assert!(help.contains("non-live"));
+    assert!(help.contains("evidence-bound"));
+    assert!(help.contains("validation-and-approval-required"));
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate track by adding a help-output contract for the future `fyr staged help` command.

## Changes

- Adds `docs/fyr/fixtures/staged-help-ok.txt` with deterministic help output rows.
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the staged help fixture.
- Adds `tests/fyr_black_arts_help_contract.rs` covering:
  - exact help rows
  - usage string
  - staged command list
  - guarded response boundaries
  - fixture-only claim boundary

## Intent

This defines what the first help output for `fyr staged` should say before implementation: command usage, available actions, workspace, boundaries, promotion requirement, implementation state, and claim boundary.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.