### PR TITLE
Add Fyr black_arts source wiring plan evidence

### DIFF
--- a/docs/fyr/STAGED_CANDIDATES.md
+++ b/docs/fyr/STAGED_CANDIDATES.md
@@ -68,11 +68,12 @@ docs/fyr/fixtures/staged-command-contract-ok.txt
 docs/fyr/fixtures/staged-stub-contract-ok.txt
 docs/fyr/fixtures/staged-runtime-stub-ok.txt
 docs/fyr/fixtures/staged-help-ok.txt
+docs/fyr/fixtures/staged-source-wiring-plan-ok.txt
 docs/fyr/fixtures/staged-status-ok.txt
 docs/fyr/fixtures/staged-status-example.txt
 ```
 
-These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create/apply/validate/promote/discard example output, lifecycle summary, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, staged stub contract, runtime stub output, staged help output, status output, and a status example. They are not implementations.
+These fixtures define expected shapes for candidate metadata, plan metadata, plan example output, create/apply/validate/promote/discard example output, lifecycle summary, change logs, validation results, explicit approval, discard records, claim boundaries, staged workspace layout, command contract, staged stub contract, runtime stub output, staged help output, source wiring plan, status output, and a status example. They are not implementations.
 
 ## Safety rules
 

--- a/docs/fyr/fixtures/staged-source-wiring-plan-ok.txt
+++ b/docs/fyr/fixtures/staged-source-wiring-plan-ok.txt
@@ -1,0 +1,20 @@
+name: black-arts-source-wiring-plan
+kind: staged-source-wiring-plan-fixture
+entrypoint: fyr_command
+first-safe-action: fyr staged
+expected-output-source: docs/fyr/fixtures/staged-runtime-stub-ok.txt
+required-source-changes:
+  - match staged in fyr_command
+  - add fyr_staged helper
+  - add fyr_staged_help helper
+  - add fixture-backed status response
+required-tests:
+  - fyr staged prints runtime stub rows
+  - fyr staged help prints help rows
+  - unknown staged action stays non-live
+boundaries:
+  - no candidate writes
+  - no live-system changes
+  - no host command execution
+  - no promotion
+claim: fixture-only

--- a/tests/fyr_black_arts_source_wiring_plan.rs
+++ b/tests/fyr_black_arts_source_wiring_plan.rs
@@ -1,0 +1,54 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_source_wiring_plan_has_required_shape() {
+    let path = "docs/fyr/fixtures/staged-source-wiring-plan-ok.txt";
+
+    for row in [
+        "name: black-arts-source-wiring-plan",
+        "kind: staged-source-wiring-plan-fixture",
+        "entrypoint: fyr_command",
+        "first-safe-action: fyr staged",
+        "expected-output-source: docs/fyr/fixtures/staged-runtime-stub-ok.txt",
+        "match staged in fyr_command",
+        "add fyr_staged helper",
+        "add fyr_staged_help helper",
+        "add fixture-backed status response",
+        "fyr staged prints runtime stub rows",
+        "fyr staged help prints help rows",
+        "unknown staged action stays non-live",
+        "no candidate writes",
+        "no live-system changes",
+        "no host command execution",
+        "no promotion",
+        "claim: fixture-only",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn staged_candidate_doc_links_source_wiring_plan() {
+    assert_contains(
+        "docs/fyr/STAGED_CANDIDATES.md",
+        "docs/fyr/fixtures/staged-source-wiring-plan-ok.txt",
+    );
+}
+
+#[test]
+fn source_has_fyr_command_entrypoint_for_staged_wiring() {
+    let source = read("src/main.rs");
+
+    assert!(source.contains("fn fyr_command"));
+    assert!(source.contains("Some(\"run\") => fyr_run(shell, &args[1..])"));
+    assert!(source.contains("Some(\"help\") | Some(\"-h\") | Some(\"--help\") => fyr_help()"));
+}


### PR DESCRIPTION
## Summary

This PR continues the `black_arts` staged-candidate track by adding a source-wiring plan for the first safe `fyr staged` runtime stub.

## Changes

- Adds `docs/fyr/fixtures/staged-source-wiring-plan-ok.txt` with:
  - `fyr_command` entrypoint target
  - first safe action: `fyr staged`
  - expected runtime-stub fixture source
  - required source changes
  - required tests
  - non-live boundaries
- Updates `docs/fyr/STAGED_CANDIDATES.md` to link the source-wiring plan fixture.
- Adds `tests/fyr_black_arts_source_wiring_plan.rs` covering:
  - source-wiring plan shape
  - source entrypoint readiness
  - required first-safe-action boundary

## Intent

This prepares the actual source wiring step without mutating behavior yet. The first implementation should only print the fixture-backed runtime stub and must not write candidates, change the live system, run host commands, or promote anything.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.