### PR TITLE
Add Fyr black_arts source wiring checklist

### DIFF
--- a/docs/fyr/STAGED_SOURCE_WIRING.md
+++ b/docs/fyr/STAGED_SOURCE_WIRING.md
@@ -1,0 +1,69 @@
+# Fyr staged source wiring checklist
+
+Status: implementation checklist  
+Codename: `black_arts`  
+Scope: first safe `fyr staged` source wiring  
+Non-claim: this does not implement candidate creation, apply, validation, promotion, discard, or live-system changes.
+
+This checklist defines the first source wiring step for the staged candidate track. The first implementation must only expose fixture-backed, non-live help/status output.
+
+## First safe behavior
+
+The first safe implementation may add:
+
+```text
+fyr staged
+fyr staged help
+fyr staged status
+fyr staged unknown
+```
+
+The first safe implementation must not add:
+
+```text
+candidate writes
+live-system changes
+host command execution
+network access
+promotion behavior
+validation execution
+apply behavior
+discard behavior
+```
+
+## Required source hooks
+
+Update `src/main.rs` only after this checklist is satisfied:
+
+1. Add `Some("staged") => fyr_staged(&args[1..])` inside `fyr_command`.
+2. Add a `fyr_staged(args: &[String]) -> String` helper.
+3. Add a `fyr_staged_help() -> String` helper.
+4. Make `fyr staged`, `fyr staged help`, and `fyr staged status` return deterministic fixture-backed output.
+5. Make unknown staged actions return a no-op help-guidance response.
+
+## Required tests
+
+Implementation PR must include tests for:
+
+- `fyr staged` prints the runtime-stub rows.
+- `fyr staged help` prints the help rows.
+- `fyr staged status` prints the status rows.
+- unknown staged action prints the no-op rows.
+- output includes `fixture-only`.
+- output includes `live-system   : untouched` or an equivalent non-live marker.
+- output does not contain host command execution markers.
+
+## Fixture sources
+
+Reference fixtures:
+
+```text
+docs/fyr/fixtures/staged-runtime-stub-ok.txt
+docs/fyr/fixtures/staged-help-ok.txt
+docs/fyr/fixtures/staged-status-example.txt
+docs/fyr/fixtures/staged-unknown-action-ok.txt
+```
+
+## Promotion boundary
+
+Do not implement `create`, `apply`, `validate`, `promote`, or `discard` behavior in the first source-wiring PR. Those actions should remain fixture/documentation contracts until separate implementation gates exist.

--- a/tests/fyr_black_arts_source_wiring_checklist.rs
+++ b/tests/fyr_black_arts_source_wiring_checklist.rs
@@ -1,0 +1,73 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn staged_source_wiring_checklist_names_first_safe_behavior() {
+    let path = "docs/fyr/STAGED_SOURCE_WIRING.md";
+
+    for row in [
+        "Status: implementation checklist",
+        "Codename: `black_arts`",
+        "fyr staged",
+        "fyr staged help",
+        "fyr staged status",
+        "fyr staged unknown",
+        "fixture-backed",
+        "non-live",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn staged_source_wiring_checklist_blocks_later_actions_from_first_pr() {
+    let path = "docs/fyr/STAGED_SOURCE_WIRING.md";
+
+    for row in [
+        "Do not implement `create`, `apply`, `validate`, `promote`, or `discard` behavior in the first source-wiring PR.",
+        "candidate writes",
+        "live-system changes",
+        "host command execution",
+        "network access",
+        "promotion behavior",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn staged_source_wiring_checklist_names_required_source_hooks() {
+    let path = "docs/fyr/STAGED_SOURCE_WIRING.md";
+
+    for row in [
+        "Add `Some(\"staged\") => fyr_staged(&args[1..])` inside `fyr_command`.",
+        "Add a `fyr_staged(args: &[String]) -> String` helper.",
+        "Add a `fyr_staged_help() -> String` helper.",
+        "unknown staged actions return a no-op help-guidance response",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn staged_source_wiring_checklist_links_reference_fixtures() {
+    let path = "docs/fyr/STAGED_SOURCE_WIRING.md";
+
+    for fixture in [
+        "docs/fyr/fixtures/staged-runtime-stub-ok.txt",
+        "docs/fyr/fixtures/staged-help-ok.txt",
+        "docs/fyr/fixtures/staged-status-example.txt",
+        "docs/fyr/fixtures/staged-unknown-action-ok.txt",
+    ] {
+        assert_contains(path, fixture);
+        assert!(fs::metadata(fixture).is_ok(), "fixture should exist: {fixture}");
+    }
+}


### PR DESCRIPTION
## Summary

This PR prepares the first safe source-wiring step for the `black_arts` staged-candidate track.

## Changes

- Adds `docs/fyr/STAGED_SOURCE_WIRING.md` with the first safe implementation checklist for `fyr staged`.
- Adds `tests/fyr_black_arts_source_wiring_checklist.rs` covering:
  - first safe behavior names
  - required source hooks
  - blocked later actions for the first PR
  - reference fixture links

## Intent

The next source-wiring PR should only add fixture-backed, non-live output for:

- `fyr staged`
- `fyr staged help`
- `fyr staged status`
- unknown staged actions

It should not implement candidate writes, live-system changes, host command execution, network access, promotion, validation execution, apply behavior, or discard behavior.

## Validation

Not run locally through this connector. Added deterministic documentation/checklist tests.