### PR TITLE
Add Fyr black_arts operator visual mode evidence

### DIFF
--- a/docs/fyr/BLACK_ARTS_OPERATOR_VISUALS.md
+++ b/docs/fyr/BLACK_ARTS_OPERATOR_VISUALS.md
@@ -1,0 +1,88 @@
+# Fyr black_arts operator visual mode
+
+Status: design contract  
+Scope: operator-facing visual cues for staged candidate mechanics  
+Non-claim: this does not implement live mutation, promotion, recovery, or production update behavior.
+
+When an operator uses the `black_arts` staged candidate mechanics, Phase1 should make the mode obvious. The interface must show that the operator is not in normal Fyr mode and not changing the live system directly.
+
+## Design goals
+
+The visual mode should communicate:
+
+- `black_arts` is active;
+- staged candidate mechanics are being used;
+- the current candidate name;
+- the current lifecycle state;
+- whether promotion is blocked, approved, or unavailable;
+- whether the live system is untouched;
+- where evidence is recorded;
+- that the track remains fixture-backed until implementation lands.
+
+## Required visual cues
+
+The first implementation should include plain-text safe cues before any advanced UI:
+
+```text
+☠ FYR black_arts // STAGED CANDIDATE MODE
+candidate     : phase1-base1-candidate
+workspace     : .phase1/staged-candidates/phase1-base1-candidate
+state         : fixture-backed
+live-system   : untouched
+promotion     : blocked-until-validation-and-approval
+evidence      : docs/fyr/fixtures/staged-lifecycle-example.txt
+boundary      : candidate-only | non-live | evidence-bound | claim-boundary
+```
+
+ASCII fallback:
+
+```text
+[BLACK_ARTS] FYR staged candidate mode
+```
+
+## Prompt marker
+
+When an interactive staged mode exists, the prompt should include a clear marker:
+
+```text
+fyr:black_arts(candidate=phase1-base1-candidate,state=staged)> 
+```
+
+If the terminal cannot render symbols, use:
+
+```text
+fyr:black_arts> 
+```
+
+## Color and style direction
+
+Preferred style:
+
+- black background;
+- ember orange accent;
+- subtle red warning accent only for blocked or rejected actions;
+- no green success glow unless validation has passed;
+- no celebratory promotion visuals until explicit approval exists;
+- keep text readable in monochrome terminals.
+
+## Safety wording
+
+Every visual mode report should preserve these messages:
+
+```text
+live-system   : untouched
+promotion     : blocked-until-validation-and-approval
+boundary      : candidate-only | non-live | evidence-bound | claim-boundary
+```
+
+## Implementation rule
+
+Do not hide the safety state behind icons. Icons may decorate, but text must always say the current boundary.
+
+## First fixture
+
+Reference fixture:
+
+```text
+docs/fyr/fixtures/staged-operator-visual-ok.txt
+```

--- a/docs/fyr/fixtures/staged-operator-visual-ok.txt
+++ b/docs/fyr/fixtures/staged-operator-visual-ok.txt
@@ -1,0 +1,11 @@
+☠ FYR black_arts // STAGED CANDIDATE MODE
+candidate     : phase1-base1-candidate
+workspace     : .phase1/staged-candidates/phase1-base1-candidate
+state         : fixture-backed
+live-system   : untouched
+promotion     : blocked-until-validation-and-approval
+evidence      : docs/fyr/fixtures/staged-lifecycle-example.txt
+boundary      : candidate-only | non-live | evidence-bound | claim-boundary
+ascii-fallback: [BLACK_ARTS] FYR staged candidate mode
+prompt        : fyr:black_arts(candidate=phase1-base1-candidate,state=staged)>
+claim-boundary: fixture-only

--- a/tests/fyr_black_arts_operator_visuals.rs
+++ b/tests/fyr_black_arts_operator_visuals.rs
@@ -1,0 +1,55 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn black_arts_operator_visual_fixture_has_required_rows() {
+    let path = "docs/fyr/fixtures/staged-operator-visual-ok.txt";
+
+    for row in [
+        "☠ FYR black_arts // STAGED CANDIDATE MODE",
+        "candidate     : phase1-base1-candidate",
+        "workspace     : .phase1/staged-candidates/phase1-base1-candidate",
+        "state         : fixture-backed",
+        "live-system   : untouched",
+        "promotion     : blocked-until-validation-and-approval",
+        "evidence      : docs/fyr/fixtures/staged-lifecycle-example.txt",
+        "boundary      : candidate-only | non-live | evidence-bound | claim-boundary",
+        "ascii-fallback: [BLACK_ARTS] FYR staged candidate mode",
+        "prompt        : fyr:black_arts(candidate=phase1-base1-candidate,state=staged)>",
+        "claim-boundary: fixture-only",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn black_arts_operator_visual_spec_preserves_text_safety_cues() {
+    let path = "docs/fyr/BLACK_ARTS_OPERATOR_VISUALS.md";
+
+    for row in [
+        "Do not hide the safety state behind icons.",
+        "live-system   : untouched",
+        "promotion     : blocked-until-validation-and-approval",
+        "boundary      : candidate-only | non-live | evidence-bound | claim-boundary",
+        "[BLACK_ARTS] FYR staged candidate mode",
+        "fyr:black_arts(candidate=phase1-base1-candidate,state=staged)>",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn black_arts_operator_visual_spec_links_fixture() {
+    assert_contains(
+        "docs/fyr/BLACK_ARTS_OPERATOR_VISUALS.md",
+        "docs/fyr/fixtures/staged-operator-visual-ok.txt",
+    );
+}


### PR DESCRIPTION
## Summary

This PR adds the operator-facing visual mode contract for Fyr `black_arts` staged candidate mechanics.

## Changes

- Adds `docs/fyr/BLACK_ARTS_OPERATOR_VISUALS.md` defining visual and prompt cues for `black_arts` mode.
- Adds `docs/fyr/fixtures/staged-operator-visual-ok.txt` with the first visual-mode output fixture.
- Adds `tests/fyr_black_arts_operator_visuals.rs` covering:
  - visual-mode rows
  - candidate/workspace/state display
  - live-system untouched marker
  - blocked promotion marker
  - ASCII fallback
  - prompt marker
  - text safety cues that cannot be hidden behind icons

## Intent

When an operator enters or views `black_arts` mechanics, the shell should make that mode obvious: codename, staged candidate state, workspace, evidence link, live-system boundary, promotion block, and claim boundary should be visible even in plain text.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests.