### PR TITLE
Add Fyr black_arts visual runtime checklist

### DIFF
--- a/docs/fyr/STAGED_VISUAL_RUNTIME_CHECKLIST.md
+++ b/docs/fyr/STAGED_VISUAL_RUNTIME_CHECKLIST.md
@@ -1,0 +1,85 @@
+# Fyr black_arts visual runtime checklist
+
+Status: implementation checklist  
+Scope: showing operator-facing `black_arts` visual cues in the first safe `fyr staged` runtime stub  
+Non-claim: this does not implement candidate creation, apply, validation, promotion, discard, or live-system changes.
+
+The first `fyr staged` source wiring must make `black_arts` mode visibly different from normal Fyr command output while preserving text safety boundaries.
+
+## First visual runtime target
+
+The first safe runtime output should include the rows from:
+
+```text
+docs/fyr/fixtures/staged-operator-visual-ok.txt
+```
+
+It may be printed by:
+
+```text
+fyr staged
+fyr staged status
+fyr staged help
+```
+
+Unknown staged actions should still print a no-op/help response.
+
+## Required visible rows
+
+The runtime output must include:
+
+```text
+☠ FYR black_arts // STAGED CANDIDATE MODE
+candidate     : phase1-base1-candidate
+workspace     : .phase1/staged-candidates/phase1-base1-candidate
+state         : fixture-backed
+live-system   : untouched
+promotion     : blocked-until-validation-and-approval
+evidence      : docs/fyr/fixtures/staged-lifecycle-example.txt
+boundary      : candidate-only | non-live | evidence-bound | claim-boundary
+claim-boundary: fixture-only
+```
+
+## ASCII fallback requirement
+
+The runtime output or help must include:
+
+```text
+[BLACK_ARTS] FYR staged candidate mode
+```
+
+## Source wiring target
+
+When implemented in `src/main.rs`, the first source PR should:
+
+1. Add `fyr_staged_visual() -> String` or equivalent.
+2. Call it from `fyr_staged` for the no-argument/status path.
+3. Keep `fyr_staged_help()` plain-text and readable.
+4. Keep unknown actions no-op and help-guided.
+5. Avoid adding candidate writes or host commands.
+
+## Required tests for source implementation
+
+The implementation PR must test that:
+
+- `fyr staged` includes the visual banner.
+- `fyr staged status` includes the visual banner.
+- `fyr staged help` includes the ASCII fallback and boundary text.
+- unknown actions do not select a candidate.
+- output includes `live-system   : untouched`.
+- output includes `claim-boundary: fixture-only`.
+
+## Blocked in first implementation
+
+Do not implement these in the visual runtime PR:
+
+```text
+candidate creation
+candidate apply/change behavior
+validation execution
+promotion execution
+discard execution
+host command execution
+network access
+live-system writes
+```

--- a/tests/fyr_black_arts_visual_runtime_checklist.rs
+++ b/tests/fyr_black_arts_visual_runtime_checklist.rs
@@ -1,0 +1,80 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn visual_runtime_checklist_names_required_banner_rows() {
+    let path = "docs/fyr/STAGED_VISUAL_RUNTIME_CHECKLIST.md";
+
+    for row in [
+        "☠ FYR black_arts // STAGED CANDIDATE MODE",
+        "candidate     : phase1-base1-candidate",
+        "workspace     : .phase1/staged-candidates/phase1-base1-candidate",
+        "state         : fixture-backed",
+        "live-system   : untouched",
+        "promotion     : blocked-until-validation-and-approval",
+        "boundary      : candidate-only | non-live | evidence-bound | claim-boundary",
+        "claim-boundary: fixture-only",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn visual_runtime_checklist_requires_ascii_fallback() {
+    assert_contains(
+        "docs/fyr/STAGED_VISUAL_RUNTIME_CHECKLIST.md",
+        "[BLACK_ARTS] FYR staged candidate mode",
+    );
+}
+
+#[test]
+fn visual_runtime_checklist_names_source_wiring_target() {
+    let path = "docs/fyr/STAGED_VISUAL_RUNTIME_CHECKLIST.md";
+
+    for row in [
+        "Add `fyr_staged_visual() -> String` or equivalent.",
+        "Call it from `fyr_staged` for the no-argument/status path.",
+        "Keep unknown actions no-op and help-guided.",
+        "Avoid adding candidate writes or host commands.",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn visual_runtime_checklist_blocks_unsafe_first_implementation_scope() {
+    let path = "docs/fyr/STAGED_VISUAL_RUNTIME_CHECKLIST.md";
+
+    for row in [
+        "candidate creation",
+        "candidate apply/change behavior",
+        "validation execution",
+        "promotion execution",
+        "discard execution",
+        "host command execution",
+        "network access",
+        "live-system writes",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn visual_runtime_checklist_links_operator_visual_fixture() {
+    assert_contains(
+        "docs/fyr/STAGED_VISUAL_RUNTIME_CHECKLIST.md",
+        "docs/fyr/fixtures/staged-operator-visual-ok.txt",
+    );
+    assert!(
+        fs::metadata("docs/fyr/fixtures/staged-operator-visual-ok.txt").is_ok(),
+        "operator visual fixture should exist"
+    );
+}


### PR DESCRIPTION
## Summary

This PR connects the `black_arts` operator visual-mode contract to the first safe runtime-stub implementation plan.

## Changes

- Adds `docs/fyr/STAGED_VISUAL_RUNTIME_CHECKLIST.md` with visual runtime requirements for the first `fyr staged` source wiring.
- Adds `tests/fyr_black_arts_visual_runtime_checklist.rs` covering:
  - required visual banner rows
  - ASCII fallback
  - source wiring target
  - blocked first-implementation scope
  - operator visual fixture link

## Intent

The first `fyr staged` implementation should clearly show the operator they are in `black_arts` staged-candidate mechanics while keeping text safety cues visible. It should not implement candidate creation, apply/change behavior, validation execution, promotion execution, discard execution, host command execution, network access, or live-system writes.

## Validation

Not run locally through this connector. Added deterministic documentation/checklist tests.