### PR TITLE
Add Fyr automation validation demo contract

### DIFF
--- a/docs/fyr/AUTOMATION_VALIDATION_MATRIX.md
+++ b/docs/fyr/AUTOMATION_VALIDATION_MATRIX.md
@@ -1,0 +1,138 @@
+# Fyr automation validation matrix
+
+Issue: #321  
+Status: validation contract  
+Scope: full Fyr command, language, demo, user-flow, and control-scheme coverage  
+Non-claim: this matrix does not claim every listed runtime path is implemented yet.
+
+This matrix makes Fyr completion measurable. Every Fyr feature must be backed by deterministic tests, fixture evidence, user-facing recovery cues, and safety boundaries before it can count toward 100% completion.
+
+## Validation levels
+
+| Level | Meaning | Counts toward public runtime completion? |
+| --- | --- | --- |
+| Contract | Documented expected behavior and safety boundary | No |
+| Fixture | Expected deterministic output exists | No |
+| Source | Runtime command or parser behavior exists | Yes, only with tests |
+| Integration test | Automated test exercises the runtime path | Yes |
+| Demo path | Built-in operator demo exposes the flow safely | Yes, only with source and tests |
+
+## Command coverage matrix
+
+| Command | Required validation | Current gate | Required user cue | Required safety boundary |
+| --- | --- | --- | --- | --- |
+| `fyr status` | source + integration test + demo row | existing Fyr bootstrap | explain current Fyr capability | no host command, deterministic output |
+| `fyr spec` | source + integration test + docs fallback | existing Fyr bootstrap | explain missing-doc recovery | read-only docs access |
+| `fyr new <name>` | source + integration test + demo row | existing Fyr authoring | show created file and next command | VFS-only write |
+| `fyr init <package>` | source + integration test + demo row | existing Fyr package flow | show package layout and next command | VFS-only package write |
+| `fyr cat <file.fyr>` | source + integration test + error recovery | existing Fyr authoring | show missing file guidance | VFS-only read |
+| `fyr check <file.fyr|package>` | parser diagnostic tests + demo row | existing Fyr parser | show parse error and next fix | no host compiler |
+| `fyr build <file.fyr|package>` | dry-run build tests + demo row | existing Fyr build dry run | show backend and host boundary | no Cargo/Rust invocation |
+| `fyr test <package>` | package test tests + failure diagnostics | existing Fyr test runner | show pass/fail summary | VFS-only tests |
+| `fyr self` | source + integration test + demo row | existing self-report | explain non-self-hosting boundary | no self-update claim |
+| `fyr run <file.fyr>` | runtime output tests + demo row | existing seed runtime | show output and exit status | no host execution |
+| `fyr color <file.fyr>` | color tests + no-color fallback | existing syntax color path | show ANSI/no-color difference | no hidden meaning by color only |
+| `fyr highlight <file.fyr>` | alias tests + no-color fallback | existing syntax color path | show readable fallback | no hidden meaning by color only |
+| `fyr staged` | runtime source + integration tests | #317 / F100-1 | show black_arts staged mode and boundaries | fixture-backed, non-live, candidate-only |
+| `fyr staged status` | runtime source + integration tests | #317 / F100-1 | show candidate state and live boundary | fixture-backed, non-live, candidate-only |
+| `fyr staged help` | runtime source + integration tests | #317 / F100-1 | show usage, workspace, allowed commands | fixture-backed, non-live, candidate-only |
+| `fyr staged <unknown>` | runtime source + integration tests | #317 / F100-1 | show no-op and help guidance | no write, no host, no network |
+
+## Language feature coverage matrix
+
+| Feature | Required validation | Required diagnostic behavior | Safety boundary |
+| --- | --- | --- | --- |
+| `fn main() -> i32` | parser tests | missing/duplicate main is deterministic | parser-only |
+| `print("literal")` | parser + run tests | unterminated string is deterministic | no host stdout dependency beyond Phase1 output |
+| `return <integer>` | parser + run tests | invalid return is deterministic | parser-only |
+| `let` bindings | parser + run tests where supported | invalid binding name/value is deterministic | parser-only |
+| integer expressions | parser + eval tests where supported | division by zero is deterministic | parser-only |
+| `if` handling | parser + branch tests where supported | invalid condition is deterministic | parser-only |
+| `assert_eq` | test-runner tests | mismatch reports expected/actual | VFS-only tests |
+| boolean `assert` | test-runner tests | false assertion reports label/context | VFS-only tests |
+| comparison assertions | test-runner tests | comparison failure is deterministic | VFS-only tests |
+| package manifest | package tests | missing manifest is deterministic | VFS-only reads |
+| module discovery | resolver tests | duplicate `fn main` is deterministic | VFS-only reads |
+| syntax coloring | color/fallback tests | unreadable color-only output is blocked | text labels remain visible |
+
+## Built-in validation demo contract
+
+The built-in demo should be reachable through one of these stable surfaces:
+
+```text
+fyr demo validation
+fyr validate demo
+fyr self validate
+```
+
+The final runtime command can choose one canonical spelling, but docs and help should guide users to the canonical command.
+
+The demo must include these sections:
+
+```text
+FYR VALIDATION DEMO
+mode          : deterministic
+audience      : first-time and returning operators
+controls      : direct command | tab-complete | help-first | paste-safe | mobile-safe
+fallback      : ascii | no-color | compact-terminal
+runtime       : VFS-only
+host-tools    : blocked
+network       : blocked
+live-system   : untouched
+staged        : non-live black_arts candidate mode
+summary       : pass/fail rows are deterministic
+```
+
+## User considerations matrix
+
+| User consideration | Required demo cue | Required test assertion |
+| --- | --- | --- |
+| first-time user | show `fyr help` / `fyr status` path | demo fixture contains help-first cue |
+| mobile/small terminal | compact rows, no wide tables in runtime demo | demo fixture contains compact-terminal cue |
+| keyboard-only | direct command and tab-complete guidance | demo fixture contains direct command and tab-complete cues |
+| paste-safe use | commands can be copied line-by-line | demo fixture contains paste-safe cue |
+| no-color terminals | ASCII/no-color fallback listed | fixture contains ascii and no-color cues |
+| low-vision readability | text labels must carry meaning, not only symbols | fixture contains text labels for every safety state |
+| error recovery | unknown actions point to help | fixture contains unknown-command recovery cue |
+| trust boundaries | host/network/live writes are visibly blocked | fixture contains blocked boundary rows |
+
+## Control scheme requirements
+
+Fyr automation validation must cover:
+
+```text
+direct command entry
+tab-completion expectations
+help-first discovery
+copy/paste command flow
+mobile terminal constraints
+no-color output
+compact output
+safe-mode boundary
+guarded-host boundary
+unknown-command recovery
+```
+
+## Forbidden validation-demo behavior
+
+The demo and its tests must not introduce or imply:
+
+```text
+host shell execution
+network access
+Cargo invocation from Fyr commands
+Rust compiler invocation from Fyr commands
+live-system staged writes
+autonomous promotion
+autonomous mutation
+self-hosting completion
+production OS replacement claims
+```
+
+## Immediate implementation sequence
+
+1. Land this matrix and the validation-demo fixture.
+2. Add regression tests that enforce the matrix, user cues, control schemes, and forbidden behavior list.
+3. Implement #317 so `fyr staged` becomes real runtime behavior.
+4. Add the first runtime validation demo command after #317 is complete.
+5. Promote public status only when source and tests prove the behavior.

--- a/docs/fyr/fixtures/validation-demo-contract-ok.txt
+++ b/docs/fyr/fixtures/validation-demo-contract-ok.txt
@@ -1,0 +1,64 @@
+FYR VALIDATION DEMO
+mode          : deterministic
+audience      : first-time and returning operators
+controls      : direct command | tab-complete | help-first | paste-safe | mobile-safe
+fallback      : ascii | no-color | compact-terminal
+runtime       : VFS-only
+host-tools    : blocked
+network       : blocked
+live-system   : untouched
+staged        : non-live black_arts candidate mode
+claim-boundary: demo-contract-only
+
+walkthrough:
+  01 status    : fyr status -> explains current Fyr capability
+  02 help      : fyr help -> lists supported commands and next steps
+  03 new       : fyr new hello_hacker -> creates hello_hacker.fyr in VFS
+  04 check     : fyr check hello_hacker.fyr -> parser-backed diagnostics
+  05 build     : fyr build hello_hacker.fyr -> deterministic dry-run artifact report
+  06 run       : fyr run hello_hacker.fyr -> prints literal output only
+  07 init      : fyr init demo_pkg -> creates VFS package layout
+  08 test      : fyr test demo_pkg -> deterministic pass/fail summary
+  09 color     : fyr color hello_hacker.fyr -> syntax labels with no-color fallback
+  10 highlight : fyr highlight hello_hacker.fyr -> alias-safe syntax labels
+  11 staged    : fyr staged -> non-live black_arts staged candidate mode
+  12 recovery  : fyr staged nonsense -> no-op plus fyr staged help guidance
+
+user-cues:
+  first-time   : start with fyr status, then fyr help
+  mobile       : compact rows; avoid wide runtime tables
+  keyboard     : direct commands and tab-complete guidance
+  paste-safe   : commands can be copied one line at a time
+  no-color     : every colored state has a text label
+  low-vision   : text labels carry meaning; symbols are decorative only
+  recovery     : unknown commands point to help and remain no-op
+  trust        : host-tools, network, and live-system writes are visibly blocked
+
+control-schemes:
+  direct command entry
+  tab-completion expectations
+  help-first discovery
+  copy/paste command flow
+  mobile terminal constraints
+  no-color output
+  compact output
+  safe-mode boundary
+  guarded-host boundary
+  unknown-command recovery
+
+blocked-behavior:
+  host shell execution
+  network access
+  Cargo invocation from Fyr commands
+  Rust compiler invocation from Fyr commands
+  live-system staged writes
+  autonomous promotion
+  autonomous mutation
+  self-hosting completion
+  production OS replacement claims
+
+summary:
+  result        : contract-ready
+  next          : implement runtime demo after #317
+  evidence      : docs/fyr/AUTOMATION_VALIDATION_MATRIX.md
+  claim-boundary: fixture-only

--- a/tests/fyr_automation_validation_matrix.rs
+++ b/tests/fyr_automation_validation_matrix.rs
@@ -1,0 +1,130 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn automation_matrix_covers_current_fyr_command_surface() {
+    let path = "docs/fyr/AUTOMATION_VALIDATION_MATRIX.md";
+
+    for command in [
+        "`fyr status`",
+        "`fyr spec`",
+        "`fyr new <name>`",
+        "`fyr init <package>`",
+        "`fyr cat <file.fyr>`",
+        "`fyr check <file.fyr|package>`",
+        "`fyr build <file.fyr|package>`",
+        "`fyr test <package>`",
+        "`fyr self`",
+        "`fyr run <file.fyr>`",
+        "`fyr color <file.fyr>`",
+        "`fyr highlight <file.fyr>`",
+        "`fyr staged`",
+        "`fyr staged status`",
+        "`fyr staged help`",
+        "`fyr staged <unknown>`",
+    ] {
+        assert_contains(path, command);
+    }
+}
+
+#[test]
+fn automation_matrix_covers_language_features_and_diagnostics() {
+    let path = "docs/fyr/AUTOMATION_VALIDATION_MATRIX.md";
+
+    for feature in [
+        "`fn main() -> i32`",
+        "`print(\"literal\")`",
+        "`return <integer>`",
+        "`let` bindings",
+        "integer expressions",
+        "`if` handling",
+        "`assert_eq`",
+        "boolean `assert`",
+        "comparison assertions",
+        "package manifest",
+        "module discovery",
+        "syntax coloring",
+    ] {
+        assert_contains(path, feature);
+    }
+}
+
+#[test]
+fn validation_demo_fixture_contains_user_considerations() {
+    let path = "docs/fyr/fixtures/validation-demo-contract-ok.txt";
+
+    for cue in [
+        "first-time   : start with fyr status, then fyr help",
+        "mobile       : compact rows; avoid wide runtime tables",
+        "keyboard     : direct commands and tab-complete guidance",
+        "paste-safe   : commands can be copied one line at a time",
+        "no-color     : every colored state has a text label",
+        "low-vision   : text labels carry meaning; symbols are decorative only",
+        "recovery     : unknown commands point to help and remain no-op",
+        "trust        : host-tools, network, and live-system writes are visibly blocked",
+    ] {
+        assert_contains(path, cue);
+    }
+}
+
+#[test]
+fn validation_demo_fixture_contains_control_schemes() {
+    let path = "docs/fyr/fixtures/validation-demo-contract-ok.txt";
+
+    for cue in [
+        "direct command entry",
+        "tab-completion expectations",
+        "help-first discovery",
+        "copy/paste command flow",
+        "mobile terminal constraints",
+        "no-color output",
+        "compact output",
+        "safe-mode boundary",
+        "guarded-host boundary",
+        "unknown-command recovery",
+    ] {
+        assert_contains(path, cue);
+    }
+}
+
+#[test]
+fn validation_demo_fixture_blocks_unsafe_or_overclaiming_behavior() {
+    let path = "docs/fyr/fixtures/validation-demo-contract-ok.txt";
+
+    for blocked in [
+        "host shell execution",
+        "network access",
+        "Cargo invocation from Fyr commands",
+        "Rust compiler invocation from Fyr commands",
+        "live-system staged writes",
+        "autonomous promotion",
+        "autonomous mutation",
+        "self-hosting completion",
+        "production OS replacement claims",
+    ] {
+        assert_contains(path, blocked);
+    }
+}
+
+#[test]
+fn automation_matrix_keeps_runtime_claims_evidence_bound() {
+    let path = "docs/fyr/AUTOMATION_VALIDATION_MATRIX.md";
+
+    for row in [
+        "Non-claim: this matrix does not claim every listed runtime path is implemented yet.",
+        "Wire a real runtime command only after the fixture and acceptance tests exist.",
+        "Do not raise public Fyr completion percentage until runtime implementation and tests land.",
+        "Source | Runtime command or parser behavior exists | Yes, only with tests",
+        "Demo path | Built-in operator demo exposes the flow safely | Yes, only with source and tests",
+    ] {
+        assert_contains(path, row);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the first full Fyr automation validation surface for issue #321.

## Changes

- Adds `docs/fyr/AUTOMATION_VALIDATION_MATRIX.md` covering:
  - current Fyr command surface
  - language feature and diagnostic coverage
  - built-in validation demo contract
  - user considerations
  - control schemes
  - forbidden runtime/demo behavior
  - immediate implementation sequence
- Adds `docs/fyr/fixtures/validation-demo-contract-ok.txt` with deterministic demo output rows for:
  - first-time and returning operators
  - direct command, tab-complete, help-first, paste-safe, and mobile-safe controls
  - ASCII/no-color/compact fallback
  - VFS-only runtime
  - blocked host/network/live behavior
  - unknown-command recovery
- Adds `tests/fyr_automation_validation_matrix.rs` to enforce the matrix, fixture, user cues, control schemes, blocked behavior, and evidence-bound claim rules.

## Why

The attached runtime screenshot shows `fyr staged` is still unrecognized. This PR creates the broader validation contract needed before Fyr can move toward 100%: not only one command, but automated coverage for features, UX, accessibility/fallbacks, control schemes, and safety boundaries.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests only.

## Related

- Opens the implementation track for #321.
- Keeps #317 as the immediate source wiring blocker for `fyr staged`.
