### PR TITLE
Add Fyrlings course and in-Phase1 book contract

### DIFF
--- a/docs/fyr/FYRLINGS_OPERATOR_COURSE.md
+++ b/docs/fyr/FYRLINGS_OPERATOR_COURSE.md
@@ -1,0 +1,153 @@
+# Fyrlings operator course
+
+Issue: #323  
+Status: learning contract  
+Scope: Rustlings-style Fyr course for Phase1 operators  
+Non-claim: this document defines the course path; it does not claim the runtime course command is implemented yet.
+
+Fyrlings is the guided learning path for Fyr operators. It should teach Fyr by small, deterministic exercises that can run inside Phase1 without host tools, network access, Cargo, Rust compiler invocation, or live-system mutation.
+
+## Operator-facing command surface
+
+The preferred Phase1 shell surface is:
+
+```text
+fyr learn
+fyr learn list
+fyr learn run <lesson>
+fyr learn hint <lesson>
+fyr learn verify
+fyr learn reset <lesson>
+fyr book
+fyr book list
+fyr book read <chapter>
+fyr book next
+fyr book search <term>
+```
+
+A short alias may exist later:
+
+```text
+fyrlings
+```
+
+The canonical path must remain discoverable through `fyr help` and the in-Phase1 Fyr book.
+
+## Learning model
+
+Each lesson should have:
+
+- lesson id;
+- title;
+- goal;
+- starter code or scenario;
+- hint text;
+- expected fix or expected command sequence;
+- validation rule;
+- pass output;
+- failure output;
+- next lesson guidance;
+- safety boundary row.
+
+## Course sequence
+
+| Lesson | Title | Teaches | Validation style |
+| --- | --- | --- | --- |
+| 001 | Orientation | Fyr purpose, VFS-only boundary, commands | read-only quiz/check row |
+| 002 | Hello Fyr | `fyr new`, `fyr run`, string output | run output includes literal |
+| 003 | Main function | `fn main() -> i32` shape | parser accepts valid entrypoint |
+| 004 | Printing | `print("literal")` | output matches expected text |
+| 005 | Returning | `return <integer>` | deterministic exit/result row |
+| 006 | Fix diagnostics | missing semicolon/string/return recovery | parser diagnostic matches expected |
+| 007 | Bindings | `let` bindings where supported | parser/evaluator validates value |
+| 008 | Expressions | integer expressions where supported | evaluator validates result |
+| 009 | Branching | `if` handling where supported | branch output is deterministic |
+| 010 | Equality asserts | `assert_eq` | pass/fail diagnostics are deterministic |
+| 011 | Boolean asserts | `assert(true)` and `assert(false)` | assertion result is deterministic |
+| 012 | Comparisons | `==`, `!=`, `>`, `<` assertions | comparison diagnostics are deterministic |
+| 013 | Packages | `fyr init`, manifest, `src/main.fyr` | package check passes |
+| 014 | Modules | module discovery and duplicate main recovery | resolver diagnostics are deterministic |
+| 015 | Highlighting | `fyr color` / `fyr highlight` | ANSI and no-color fallback both readable |
+| 016 | Staged mode | `fyr staged` / `black_arts` non-live mode | no host/network/live markers appear |
+| 017 | Validation demo | full operator validation walkthrough | validation demo summary passes |
+
+## User considerations
+
+Fyrlings must support:
+
+- first-time users who start with no Fyr context;
+- keyboard-only use;
+- tab-completion discovery;
+- copy/paste lesson commands;
+- mobile and small terminal use;
+- compact output;
+- no-color terminals;
+- ASCII fallback;
+- low-vision readability through text labels;
+- unknown-command recovery;
+- safe-mode and guarded-host boundaries;
+- explicit non-claims for unfinished Fyr behavior.
+
+## Control schemes
+
+Each runtime learning command should remain usable through:
+
+```text
+direct command entry
+help-first discovery
+tab-completion guidance
+copy/paste command flow
+mobile terminal flow
+compact terminal flow
+no-color output
+ASCII fallback
+unknown-command recovery
+```
+
+## Safety boundaries
+
+Fyrlings must not perform or imply:
+
+```text
+host shell execution
+network access
+Cargo invocation from Fyr learning commands
+Rust compiler invocation from Fyr learning commands
+live-system writes
+autonomous promotion
+autonomous mutation
+self-hosting completion
+production OS replacement claims
+```
+
+## Progress and state
+
+The first implementation should use deterministic VFS-only lesson files. Progress may be held in Phase1 state later, but the first course should work without persistent state.
+
+Required state rows:
+
+```text
+course        : fyrlings
+mode          : deterministic
+runtime       : VFS-only
+host-tools    : blocked
+network       : blocked
+live-system   : untouched
+claim-boundary: learning-contract-only
+```
+
+## Runtime implementation gates
+
+Fyrlings should be implemented in phases:
+
+1. contract and fixtures;
+2. docs/book chapters;
+3. lesson registry;
+4. `fyr learn list` and `fyr book list`;
+5. `fyr book read <chapter>`;
+6. `fyr learn run <lesson>` for the first lesson;
+7. lesson validation and hints;
+8. full course verification;
+9. status integration after tests prove behavior.
+
+Do not raise Fyr public completion percentage for this plan alone.

--- a/docs/fyr/FYR_BOOK_IN_PHASE1.md
+++ b/docs/fyr/FYR_BOOK_IN_PHASE1.md
@@ -1,0 +1,123 @@
+# Fyr book inside Phase1
+
+Issue: #323  
+Status: book reader contract  
+Scope: offline Fyr book content readable from the Phase1 shell  
+Non-claim: this document defines the book reader contract; it does not claim the runtime `fyr book` command is implemented yet.
+
+The Fyr book should be available inside Phase1 so operators can learn without leaving the shell. The reader must be compact, accessible, deterministic, offline-first, and safe.
+
+## Operator-facing command surface
+
+Preferred command surface:
+
+```text
+fyr book
+fyr book list
+fyr book read <chapter>
+fyr book next
+fyr book prev
+fyr book search <term>
+fyr book help
+```
+
+The reader should also be linked from:
+
+```text
+fyr help
+fyr learn
+fyr self
+```
+
+## Reader behavior
+
+Required behavior:
+
+- list chapters with stable ids;
+- read a selected chapter by id or slug;
+- show next and previous chapter guidance;
+- show lesson links when a chapter maps to Fyrlings lessons;
+- search chapter text offline;
+- render in compact terminal widths;
+- preserve readable output in no-color mode;
+- preserve readable output in ASCII mode;
+- keep every safety state visible through text labels;
+- recover from unknown chapter ids with help guidance;
+- remain deterministic and testable.
+
+## Book structure
+
+Initial chapter set:
+
+| Chapter | Title | Purpose | Related Fyrlings lessons |
+| --- | --- | --- | --- |
+| 00 | What is Fyr? | orientation, non-claims, safety | 001 |
+| 01 | Your first Fyr program | `fyr new`, `fyr run`, hello flow | 002 |
+| 02 | Main functions | `fn main() -> i32` | 003 |
+| 03 | Printing and returning | `print`, `return` | 004, 005 |
+| 04 | Fixing parser errors | diagnostics and recovery | 006 |
+| 05 | Values and expressions | `let`, expressions, `if` where supported | 007, 008, 009 |
+| 06 | Testing with assertions | `assert_eq`, boolean asserts, comparisons | 010, 011, 012 |
+| 07 | Packages and modules | manifests, modules, duplicate main recovery | 013, 014 |
+| 08 | Reading Fyr code | syntax highlighting and no-color fallback | 015 |
+| 09 | Staged candidate mode | `black_arts` and non-live staging | 016 |
+| 10 | Operator validation | full validation demo and trust boundaries | 017 |
+
+## Required chapter metadata
+
+Every chapter fixture should include:
+
+```text
+book          : Fyr
+chapter       : <stable-id>
+title         : <chapter-title>
+audience      : first-time and returning operators
+controls      : direct command | tab-complete | help-first | paste-safe | mobile-safe
+fallback      : ascii | no-color | compact-terminal
+runtime       : VFS-only
+host-tools    : blocked
+network       : blocked
+live-system   : untouched
+claim-boundary: book-contract-only
+```
+
+## Accessibility and small-terminal requirements
+
+The in-Phase1 reader must account for:
+
+- mobile terminal width;
+- keyboard-only navigation;
+- copy/paste-friendly examples;
+- clear headings;
+- short paragraphs;
+- no dependency on color alone;
+- plain ASCII fallback for symbols;
+- explicit safety labels;
+- next-step and recovery cues.
+
+## Safety and non-claims
+
+The book reader must not perform or imply:
+
+```text
+host shell execution
+network access
+Cargo invocation from Fyr book commands
+Rust compiler invocation from Fyr book commands
+live-system writes
+autonomous promotion
+autonomous mutation
+self-hosting completion
+production OS replacement claims
+```
+
+The book may describe future goals only when they are labeled as future work or non-claims.
+
+## Runtime implementation gates
+
+1. Land this reader contract and chapter fixtures.
+2. Add deterministic tests for metadata, chapter list, accessibility cues, control schemes, and forbidden behavior.
+3. Add an in-shell reader that can list and read repository/VFS-backed chapter text.
+4. Add search once list/read is stable.
+5. Link `fyr book` from `fyr help` and `fyr learn`.
+6. Do not update public Fyr completion percentage until runtime behavior and tests land.

--- a/docs/fyr/book/00-what-is-fyr.txt
+++ b/docs/fyr/book/00-what-is-fyr.txt
@@ -1,0 +1,58 @@
+book          : Fyr
+chapter       : 00
+title         : What is Fyr?
+audience      : first-time and returning operators
+controls      : direct command | tab-complete | help-first | paste-safe | mobile-safe
+fallback      : ascii | no-color | compact-terminal
+runtime       : VFS-only
+host-tools    : blocked
+network       : blocked
+live-system   : untouched
+claim-boundary: book-contract-only
+
+# What is Fyr?
+
+Fyr is the Phase1-owned language path for learning, automation, and eventual self-directed Phase1 workflows.
+
+Fyr is not claimed to be self-hosting yet. Rust remains the implementation language for Phase1 today. Fyr lessons and book chapters must say what exists, what is planned, and what is blocked.
+
+Start here:
+
+```text
+fyr status
+fyr help
+fyr book list
+fyr learn list
+```
+
+What Fyr teaches first:
+
+```text
+fn main() -> i32
+print("Hello from Fyr")
+return 0
+```
+
+Operator safety:
+
+```text
+host-tools    : blocked
+network       : blocked
+live-system   : untouched
+runtime       : VFS-only
+```
+
+Control cues:
+
+- Use direct commands when you know the command.
+- Use `fyr help` when you are unsure.
+- Use tab-completion to discover files and commands as support lands.
+- Copy and paste one command per line on mobile terminals.
+- No-color and ASCII output must still preserve the meaning of every safety state.
+
+Next:
+
+```text
+fyr book read 01
+fyr learn run 001
+```

--- a/docs/fyr/fixtures/fyrlings-lesson-001-ok.txt
+++ b/docs/fyr/fixtures/fyrlings-lesson-001-ok.txt
@@ -1,0 +1,41 @@
+course        : fyrlings
+lesson        : 001
+title         : Orientation
+mode          : deterministic
+audience      : first-time and returning operators
+controls      : direct command | tab-complete | help-first | paste-safe | mobile-safe
+fallback      : ascii | no-color | compact-terminal
+runtime       : VFS-only
+host-tools    : blocked
+network       : blocked
+live-system   : untouched
+claim-boundary: learning-fixture-only
+
+goal:
+  Learn what Fyr is, how to ask for help, and which safety boundaries are always visible.
+
+starter commands:
+  fyr status
+  fyr help
+  fyr book read 00
+
+exercise:
+  Read the Fyr status output and identify the runtime boundary row.
+
+hint:
+  Look for rows that say VFS-only, host-tools blocked, network blocked, and live-system untouched.
+
+expected answer:
+  Fyr learning starts in a deterministic VFS-only mode with host tools, network, and live-system writes blocked.
+
+validation:
+  pass when the operator can explain the boundary without relying on color or icons only.
+
+pass output:
+  fyrlings 001: pass - operator understands Fyr orientation and safety boundaries
+
+failure output:
+  fyrlings 001: review - run fyr status and fyr book read 00, then try again
+
+next:
+  fyr learn run 002

--- a/tests/fyrlings_book_contract.rs
+++ b/tests/fyrlings_book_contract.rs
@@ -1,0 +1,185 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn fyrlings_course_contract_defines_operator_command_surface() {
+    let path = "docs/fyr/FYRLINGS_OPERATOR_COURSE.md";
+
+    for command in [
+        "fyr learn",
+        "fyr learn list",
+        "fyr learn run <lesson>",
+        "fyr learn hint <lesson>",
+        "fyr learn verify",
+        "fyr learn reset <lesson>",
+        "fyr book",
+        "fyr book list",
+        "fyr book read <chapter>",
+        "fyr book search <term>",
+        "fyrlings",
+    ] {
+        assert_contains(path, command);
+    }
+}
+
+#[test]
+fn fyrlings_course_covers_required_lessons() {
+    let path = "docs/fyr/FYRLINGS_OPERATOR_COURSE.md";
+
+    for lesson in [
+        "Orientation",
+        "Hello Fyr",
+        "Main function",
+        "Printing",
+        "Returning",
+        "Fix diagnostics",
+        "Bindings",
+        "Expressions",
+        "Branching",
+        "Equality asserts",
+        "Boolean asserts",
+        "Comparisons",
+        "Packages",
+        "Modules",
+        "Highlighting",
+        "Staged mode",
+        "Validation demo",
+    ] {
+        assert_contains(path, lesson);
+    }
+}
+
+#[test]
+fn fyr_book_contract_defines_in_phase1_reader_surface() {
+    let path = "docs/fyr/FYR_BOOK_IN_PHASE1.md";
+
+    for command in [
+        "fyr book",
+        "fyr book list",
+        "fyr book read <chapter>",
+        "fyr book next",
+        "fyr book prev",
+        "fyr book search <term>",
+        "fyr book help",
+    ] {
+        assert_contains(path, command);
+    }
+}
+
+#[test]
+fn fyr_book_contract_covers_initial_chapter_set() {
+    let path = "docs/fyr/FYR_BOOK_IN_PHASE1.md";
+
+    for chapter in [
+        "What is Fyr?",
+        "Your first Fyr program",
+        "Main functions",
+        "Printing and returning",
+        "Fixing parser errors",
+        "Values and expressions",
+        "Testing with assertions",
+        "Packages and modules",
+        "Reading Fyr code",
+        "Staged candidate mode",
+        "Operator validation",
+    ] {
+        assert_contains(path, chapter);
+    }
+}
+
+#[test]
+fn first_book_chapter_is_readable_inside_phase1_constraints() {
+    let path = "docs/fyr/book/00-what-is-fyr.txt";
+
+    for row in [
+        "book          : Fyr",
+        "chapter       : 00",
+        "title         : What is Fyr?",
+        "controls      : direct command | tab-complete | help-first | paste-safe | mobile-safe",
+        "fallback      : ascii | no-color | compact-terminal",
+        "runtime       : VFS-only",
+        "host-tools    : blocked",
+        "network       : blocked",
+        "live-system   : untouched",
+        "claim-boundary: book-contract-only",
+        "fyr book read 01",
+        "fyr learn run 001",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn first_fyrlings_lesson_fixture_has_guided_learning_shape() {
+    let path = "docs/fyr/fixtures/fyrlings-lesson-001-ok.txt";
+
+    for row in [
+        "course        : fyrlings",
+        "lesson        : 001",
+        "title         : Orientation",
+        "goal:",
+        "starter commands:",
+        "exercise:",
+        "hint:",
+        "expected answer:",
+        "validation:",
+        "pass output:",
+        "failure output:",
+        "next:",
+        "host-tools    : blocked",
+        "network       : blocked",
+        "live-system   : untouched",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn fyrlings_and_book_contracts_block_unsafe_or_overclaiming_behavior() {
+    for path in [
+        "docs/fyr/FYRLINGS_OPERATOR_COURSE.md",
+        "docs/fyr/FYR_BOOK_IN_PHASE1.md",
+    ] {
+        for blocked in [
+            "host shell execution",
+            "network access",
+            "Cargo invocation",
+            "Rust compiler invocation",
+            "live-system writes",
+            "autonomous promotion",
+            "autonomous mutation",
+            "self-hosting completion",
+            "production OS replacement claims",
+        ] {
+            assert_contains(path, blocked);
+        }
+    }
+}
+
+#[test]
+fn fyrlings_and_book_contracts_preserve_non_claim_boundary() {
+    assert_contains(
+        "docs/fyr/FYRLINGS_OPERATOR_COURSE.md",
+        "Non-claim: this document defines the course path; it does not claim the runtime course command is implemented yet.",
+    );
+    assert_contains(
+        "docs/fyr/FYR_BOOK_IN_PHASE1.md",
+        "Non-claim: this document defines the book reader contract; it does not claim the runtime `fyr book` command is implemented yet.",
+    );
+    assert_contains(
+        "docs/fyr/FYRLINGS_OPERATOR_COURSE.md",
+        "Do not raise Fyr public completion percentage for this plan alone.",
+    );
+    assert_contains(
+        "docs/fyr/FYR_BOOK_IN_PHASE1.md",
+        "Do not update public Fyr completion percentage until runtime behavior and tests land.",
+    );
+}


### PR DESCRIPTION
## Summary

Adds the first Fyrlings-style operator learning contract and in-Phase1 Fyr book reader contract for issue #323.

## Changes

- Adds `docs/fyr/FYRLINGS_OPERATOR_COURSE.md` with:
  - Rustlings-style lesson model for Fyr
  - proposed `fyr learn` command surface
  - 17-lesson operator course sequence
  - user/control considerations
  - safety boundaries and implementation gates
- Adds `docs/fyr/FYR_BOOK_IN_PHASE1.md` with:
  - proposed `fyr book` reader surface
  - initial chapter set
  - chapter metadata requirements
  - accessibility and small-terminal requirements
  - safety/non-claim boundaries
- Adds `docs/fyr/book/00-what-is-fyr.txt` as the first readable in-Phase1 book chapter fixture.
- Adds `docs/fyr/fixtures/fyrlings-lesson-001-ok.txt` as the first Fyrlings lesson fixture.
- Adds `tests/fyrlings_book_contract.rs` covering command surfaces, lesson/chapter coverage, first fixtures, blocked behavior, and non-claim boundaries.

## Why

Fyr needs an operator learning path like Rustlings, and the Fyr book should be readable from inside Phase1 instead of requiring external docs. This PR makes that learning/book surface explicit and testable before runtime commands are wired.

## Validation

Not run locally through this connector. Added deterministic documentation/fixture tests only.

## Related

- Opens the implementation path for #323.
- Complements #321 automation validation demo coverage.
- Keeps #317 as the immediate runtime blocker for `fyr staged`.
