### PR TITLE
Add Fyr staged runtime local apply helper

### DIFF
--- a/docs/fyr/STAGED_RUNTIME_LOCAL_APPLY.md
+++ b/docs/fyr/STAGED_RUNTIME_LOCAL_APPLY.md
@@ -1,0 +1,129 @@
+# Fyr staged runtime local apply
+
+Issue: #317  
+Status: local apply instructions  
+Scope: applying `patches/fyr-staged-runtime-stub.patch` to `src/main.rs` from a developer checkout  
+Non-claim: this document does not mean the runtime source has landed until `src/main.rs` is actually patched and tested.
+
+## Why this exists
+
+The required `fyr staged` runtime patch is small, but `src/main.rs` is large. The GitHub connector view can truncate the file, so a full-file rewrite through that path risks damaging unrelated shell code.
+
+Use the checked patch and helper script from a local checkout instead.
+
+## Apply command
+
+```sh
+sh scripts/apply-fyr-staged-runtime-stub.sh
+```
+
+The helper:
+
+- checks that `patches/fyr-staged-runtime-stub.patch` exists;
+- checks that `src/main.rs` exists;
+- detects whether the staged match arm is already present;
+- runs `git apply --check` before applying;
+- applies only the source patch;
+- prints the required validation commands.
+
+## Expected source change
+
+The patch adds this `fyr_command` match arm:
+
+```rust
+Some("staged") => fyr_staged(&args[1..]),
+```
+
+The patch adds these helpers:
+
+```rust
+fn fyr_staged(args: &[String]) -> String
+fn fyr_staged_visual() -> String
+fn fyr_staged_help() -> String
+fn fyr_staged_unknown(action: &str) -> String
+```
+
+## Runtime behavior after applying
+
+```text
+fyr staged
+fyr staged status
+fyr staged help
+fyr staged nonsense
+```
+
+Required visible markers:
+
+```text
+☠ FYR black_arts // STAGED CANDIDATE MODE
+[BLACK_ARTS] FYR staged candidate mode
+live-system   : untouched
+promotion     : blocked-until-validation-and-approval
+boundary      : candidate-only | non-live | evidence-bound | claim-boundary
+claim-boundary: fixture-only
+```
+
+Unknown staged actions must report:
+
+```text
+status        : unknown staged action
+candidate     : none
+result        : no-op
+help          : fyr staged help
+```
+
+## Required validation
+
+```sh
+cargo fmt --all -- --check
+cargo test -p phase1 --test fyr_staged_runtime_patch_contract
+cargo test -p phase1 --test fyr_black_arts_runtime_stub
+cargo test -p phase1 --test fyr_black_arts_unknown_action
+cargo test --workspace --all-targets
+```
+
+## Manual smoke checks
+
+After building/running Phase1, verify:
+
+```text
+fyr staged
+fyr staged status
+fyr staged help
+fyr staged nonsense
+```
+
+The output must not contain:
+
+```text
+cargo 
+rustc 
+bash:
+sh:
+http://
+https://
+```
+
+## Still blocked
+
+Do not implement the following in this first runtime patch:
+
+```text
+candidate creation
+candidate apply/change behavior
+validation execution
+promotion execution
+discard execution
+host command execution
+network access
+live-system writes
+```
+
+## Completion rule
+
+Close #317 only after:
+
+1. `src/main.rs` is patched;
+2. runtime tests land;
+3. manual smoke confirms `fyr staged` is recognized;
+4. blocked behavior remains absent.

--- a/scripts/apply-fyr-staged-runtime-stub.sh
+++ b/scripts/apply-fyr-staged-runtime-stub.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+set -eu
+
+PATCH_PATH="patches/fyr-staged-runtime-stub.patch"
+SOURCE_PATH="src/main.rs"
+
+echo "fyr staged runtime stub apply helper"
+echo "patch     : ${PATCH_PATH}"
+echo "source    : ${SOURCE_PATH}"
+echo "mode      : local developer checkout"
+echo "boundary  : applies source patch only; no Fyr runtime host/network behavior"
+echo
+
+if [ ! -f "${PATCH_PATH}" ]; then
+  echo "error: missing ${PATCH_PATH}" >&2
+  exit 1
+fi
+
+if [ ! -f "${SOURCE_PATH}" ]; then
+  echo "error: missing ${SOURCE_PATH}" >&2
+  exit 1
+fi
+
+if grep -Fq 'Some("staged") => fyr_staged(&args[1..]),' "${SOURCE_PATH}"; then
+  echo "status    : already-applied"
+  echo "next      : run validation commands"
+else
+  echo "status    : checking patch"
+  git apply --check "${PATCH_PATH}"
+  echo "status    : applying patch"
+  git apply "${PATCH_PATH}"
+fi
+
+echo
+echo "required validation:"
+echo "  cargo fmt --all -- --check"
+echo "  cargo test -p phase1 --test fyr_staged_runtime_patch_contract"
+echo "  cargo test -p phase1 --test fyr_black_arts_runtime_stub"
+echo "  cargo test -p phase1 --test fyr_black_arts_unknown_action"
+echo "  cargo test --workspace --all-targets"
+echo
+echo "manual runtime smoke after build:"
+echo "  fyr staged"
+echo "  fyr staged status"
+echo "  fyr staged help"
+echo "  fyr staged nonsense"
+echo
+echo "blocked behavior remains: candidate creation, apply/change behavior, validation execution, promotion, discard, host command execution, network access, live-system writes"

--- a/tests/fyr_staged_runtime_apply_helper.rs
+++ b/tests/fyr_staged_runtime_apply_helper.rs
@@ -1,0 +1,83 @@
+use std::fs;
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+fn assert_contains(path: &str, needle: &str) {
+    let text = read(path);
+    assert!(text.contains(needle), "{path} should contain: {needle}");
+}
+
+#[test]
+fn apply_helper_targets_checked_patch_and_source() {
+    let path = "scripts/apply-fyr-staged-runtime-stub.sh";
+
+    for row in [
+        "PATCH_PATH=\"patches/fyr-staged-runtime-stub.patch\"",
+        "SOURCE_PATH=\"src/main.rs\"",
+        "git apply --check \"${PATCH_PATH}\"",
+        "git apply \"${PATCH_PATH}\"",
+        "Some(\"staged\") => fyr_staged(&args[1..]),",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn apply_helper_prints_required_validation_commands() {
+    let path = "scripts/apply-fyr-staged-runtime-stub.sh";
+
+    for row in [
+        "cargo fmt --all -- --check",
+        "cargo test -p phase1 --test fyr_staged_runtime_patch_contract",
+        "cargo test -p phase1 --test fyr_black_arts_runtime_stub",
+        "cargo test -p phase1 --test fyr_black_arts_unknown_action",
+        "cargo test --workspace --all-targets",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn local_apply_doc_preserves_completion_rule_and_blocked_scope() {
+    let path = "docs/fyr/STAGED_RUNTIME_LOCAL_APPLY.md";
+
+    for row in [
+        "Close #317 only after:",
+        "`src/main.rs` is patched;",
+        "runtime tests land;",
+        "manual smoke confirms `fyr staged` is recognized;",
+        "blocked behavior remains absent.",
+        "candidate creation",
+        "candidate apply/change behavior",
+        "validation execution",
+        "promotion execution",
+        "discard execution",
+        "host command execution",
+        "network access",
+        "live-system writes",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
+fn local_apply_doc_lists_runtime_smoke_and_forbidden_markers() {
+    let path = "docs/fyr/STAGED_RUNTIME_LOCAL_APPLY.md";
+
+    for row in [
+        "fyr staged",
+        "fyr staged status",
+        "fyr staged help",
+        "fyr staged nonsense",
+        "cargo ",
+        "rustc ",
+        "bash:",
+        "sh:",
+        "http://",
+        "https://",
+    ] {
+        assert_contains(path, row);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a local helper and instructions for safely applying the already-landed `fyr staged` runtime patch from a developer checkout.

## Changes

- Adds `scripts/apply-fyr-staged-runtime-stub.sh` to:
  - verify `patches/fyr-staged-runtime-stub.patch` exists
  - verify `src/main.rs` exists
  - detect already-applied state
  - run `git apply --check`
  - apply the patch
  - print required validation and manual smoke commands
- Adds `docs/fyr/STAGED_RUNTIME_LOCAL_APPLY.md` with:
  - exact apply command
  - expected source changes
  - required runtime output markers
  - validation commands
  - manual smoke checks
  - blocked behavior list
  - #317 completion rule
- Adds `tests/fyr_staged_runtime_apply_helper.rs` to enforce helper/doc expectations.

## Why

`src/main.rs` is large, and the connector view can truncate it. This makes the #317 implementation path safer: apply the exact checked patch locally instead of hand-editing or full-file rewriting through a truncated source view.

## Validation

Not run locally through this connector. Added deterministic helper/documentation tests only.

## Related

- Supports #317.
- Builds on `patches/fyr-staged-runtime-stub.patch` from PR #325.
