### PR TITLE
Add check mode to Fyr staged runtime helper

### DIFF
--- a/scripts/apply-fyr-staged-runtime-stub.sh
+++ b/scripts/apply-fyr-staged-runtime-stub.sh
@@ -3,12 +3,34 @@ set -eu
 
 PATCH_PATH="patches/fyr-staged-runtime-stub.patch"
 SOURCE_PATH="src/main.rs"
+MODE="apply"
+
+case "${1:-}" in
+  ""|"apply")
+    MODE="apply"
+    ;;
+  "check"|"--check")
+    MODE="check"
+    ;;
+  "help"|"-h"|"--help")
+    echo "usage: sh scripts/apply-fyr-staged-runtime-stub.sh [apply|check]"
+    echo
+    echo "apply  : verify and apply patches/fyr-staged-runtime-stub.patch"
+    echo "check  : verify the patch can apply without changing files"
+    exit 0
+    ;;
+  *)
+    echo "error: unknown mode '${1:-}'" >&2
+    echo "usage: sh scripts/apply-fyr-staged-runtime-stub.sh [apply|check]" >&2
+    exit 2
+    ;;
+esac
 
 echo "fyr staged runtime stub apply helper"
 echo "patch     : ${PATCH_PATH}"
 echo "source    : ${SOURCE_PATH}"
-echo "mode      : local developer checkout"
-echo "boundary  : applies source patch only; no Fyr runtime host/network behavior"
+echo "mode      : ${MODE}"
+echo "boundary  : source patch helper only; no Fyr runtime host/network behavior"
 echo
 
 if [ ! -f "${PATCH_PATH}" ]; then
@@ -27,14 +49,21 @@ if grep -Fq 'Some("staged") => fyr_staged(&args[1..]),' "${SOURCE_PATH}"; then
 else
   echo "status    : checking patch"
   git apply --check "${PATCH_PATH}"
-  echo "status    : applying patch"
-  git apply "${PATCH_PATH}"
+  if [ "${MODE}" = "check" ]; then
+    echo "status    : check-only-pass"
+    echo "next      : run 'sh scripts/apply-fyr-staged-runtime-stub.sh apply' when ready"
+  else
+    echo "status    : applying patch"
+    git apply "${PATCH_PATH}"
+    echo "status    : applied"
+  fi
 fi
 
 echo
 echo "required validation:"
 echo "  cargo fmt --all -- --check"
 echo "  cargo test -p phase1 --test fyr_staged_runtime_patch_contract"
+echo "  cargo test -p phase1 --test fyr_staged_runtime_apply_helper"
 echo "  cargo test -p phase1 --test fyr_black_arts_runtime_stub"
 echo "  cargo test -p phase1 --test fyr_black_arts_unknown_action"
 echo "  cargo test --workspace --all-targets"

--- a/tests/fyr_staged_runtime_apply_helper.rs
+++ b/tests/fyr_staged_runtime_apply_helper.rs
@@ -25,12 +25,28 @@ fn apply_helper_targets_checked_patch_and_source() {
 }
 
 #[test]
+fn apply_helper_supports_check_only_mode_before_apply() {
+    let path = "scripts/apply-fyr-staged-runtime-stub.sh";
+
+    for row in [
+        "usage: sh scripts/apply-fyr-staged-runtime-stub.sh [apply|check]",
+        "check  : verify the patch can apply without changing files",
+        "MODE=\"check\"",
+        "status    : check-only-pass",
+        "run 'sh scripts/apply-fyr-staged-runtime-stub.sh apply' when ready",
+    ] {
+        assert_contains(path, row);
+    }
+}
+
+#[test]
 fn apply_helper_prints_required_validation_commands() {
     let path = "scripts/apply-fyr-staged-runtime-stub.sh";
 
     for row in [
         "cargo fmt --all -- --check",
         "cargo test -p phase1 --test fyr_staged_runtime_patch_contract",
+        "cargo test -p phase1 --test fyr_staged_runtime_apply_helper",
         "cargo test -p phase1 --test fyr_black_arts_runtime_stub",
         "cargo test -p phase1 --test fyr_black_arts_unknown_action",
         "cargo test --workspace --all-targets",


### PR DESCRIPTION
## Summary

Improves the Fyr staged runtime apply helper with a check-only mode before applying the source patch.

## Changes

- Updates `scripts/apply-fyr-staged-runtime-stub.sh` to support:
  - `apply` / default mode
  - `check` / `--check` mode
  - help output
  - unknown mode handling
- Check mode runs `git apply --check` and exits without changing files.
- Apply mode still checks first, then applies the patch.
- Updates `tests/fyr_staged_runtime_apply_helper.rs` to enforce the check-only path and validation command list.

## Why

This makes the local #317 implementation path safer on a developer machine: verify the patch applies cleanly before touching `src/main.rs`.

## Validation

Not run locally through this connector. Added deterministic helper tests only.

## Related

- Supports #317.
- Builds on PR #326.
