### PR TITLE
Fix Fyr staged runtime patch format

### DIFF
--- a/patches/fyr-staged-runtime-stub.patch
+++ b/patches/fyr-staged-runtime-stub.patch
@@ -1,7 +1,7 @@
 diff --git a/src/main.rs b/src/main.rs
 --- a/src/main.rs
 +++ b/src/main.rs
-@@
+@@ -520,19 +520,77 @@ fn fyr_command(shell: &mut Phase1Shell, args: &[String]) -> String {
  fn fyr_command(shell: &mut Phase1Shell, args: &[String]) -> String {
      match args.first().map(String::as_str) {
          None | Some("status") => fyr_status(),
@@ -77,3 +77,5 @@ diff --git a/src/main.rs b/src/main.rs
 +         claim-boundary: fixture-only\n"
 +    )
 +}
+ 
+ fn fyr_status() -> String {

--- a/patches/fyr-staged-runtime-stub.patch
+++ b/patches/fyr-staged-runtime-stub.patch
@@ -1,7 +1,7 @@
 diff --git a/src/main.rs b/src/main.rs
 --- a/src/main.rs
 +++ b/src/main.rs
-@@ -520,19 +520,77 @@ fn fyr_command(shell: &mut Phase1Shell, args: &[String]) -> String {
+@@ -520,19 +520,78 @@ fn fyr_command(shell: &mut Phase1Shell, args: &[String]) -> String {
  fn fyr_command(shell: &mut Phase1Shell, args: &[String]) -> String {
      match args.first().map(String::as_str) {
          None | Some("status") => fyr_status(),

--- a/patches/fyr-staged-runtime-stub.patch
+++ b/patches/fyr-staged-runtime-stub.patch
@@ -1,7 +1,7 @@
 diff --git a/src/main.rs b/src/main.rs
 --- a/src/main.rs
 +++ b/src/main.rs
-@@ -520,19 +520,78 @@ fn fyr_command(shell: &mut Phase1Shell, args: &[String]) -> String {
+@@ -520,19 +520,77 @@ fn fyr_command(shell: &mut Phase1Shell, args: &[String]) -> String {
  fn fyr_command(shell: &mut Phase1Shell, args: &[String]) -> String {
      match args.first().map(String::as_str) {
          None | Some("status") => fyr_status(),

--- a/tests/fyr_staged_runtime_patch_contract.rs
+++ b/tests/fyr_staged_runtime_patch_contract.rs
@@ -10,6 +10,21 @@ fn assert_contains(path: &str, needle: &str) {
 }
 
 #[test]
+fn staged_runtime_patch_has_git_apply_compatible_header() {
+    let path = "patches/fyr-staged-runtime-stub.patch";
+    let text = read(path);
+
+    assert_contains(path, "diff --git a/src/main.rs b/src/main.rs");
+    assert_contains(path, "--- a/src/main.rs");
+    assert_contains(path, "+++ b/src/main.rs");
+    assert_contains(path, "@@ -520,19 +520,77 @@ fn fyr_command(shell: &mut Phase1Shell, args: &[String]) -> String {");
+    assert!(
+        !text.lines().any(|line| line == "@@"),
+        "patch must not contain an unnumbered hunk header"
+    );
+}
+
+#[test]
 fn staged_runtime_patch_adds_match_arm_and_helpers() {
     let path = "patches/fyr-staged-runtime-stub.patch";
 


### PR DESCRIPTION
## Summary

Fixes `patches/fyr-staged-runtime-stub.patch` so the local apply helper can use it with `git apply`.

## Problem

The previous patch used an unnumbered hunk header:

```text
@@
```

That causes `git apply` to fail with:

```text
error: patch with only garbage at line 4
```

## Changes

- Replaces the unnumbered hunk header with a numbered unified-diff header.
- Keeps the intended `src/main.rs` staged runtime source change unchanged.
- Updates `tests/fyr_staged_runtime_patch_contract.rs` to require a Git-compatible hunk header and reject a bare `@@` hunk header.

## Validation

Not run locally through this connector. The failing local command was reported from an X200 checkout and this PR fixes the malformed patch format that caused that failure.

## Related

- Supports #317.
- Fixes the local helper path added by PR #326 and improved by PR #327.
