### PR TITLE
Restore Fyr automation validation guard wording

### DIFF
--- a/docs/fyr/AUTOMATION_VALIDATION_MATRIX.md
+++ b/docs/fyr/AUTOMATION_VALIDATION_MATRIX.md
@@ -133,6 +133,8 @@ production OS replacement claims
 
 1. Land this matrix and the validation-demo fixture.
 2. Add regression tests that enforce the matrix, user cues, control schemes, and forbidden behavior list.
-3. Implement #317 so `fyr staged` becomes real runtime behavior.
-4. Add the first runtime validation demo command after #317 is complete.
-5. Promote public status only when source and tests prove the behavior.
+3. Wire a real runtime command only after the fixture and acceptance tests exist.
+4. Implement #317 so `fyr staged` becomes real runtime behavior.
+5. Add the first runtime validation demo command after #317 is complete.
+6. Do not raise public Fyr completion percentage until runtime implementation and tests land.
+7. Promote public status only when source and tests prove the behavior.


### PR DESCRIPTION
## Summary

Restores the evidence-bound guard wording expected by `tests/fyr_automation_validation_matrix.rs`.

## Problem

The local test run failed because `docs/fyr/AUTOMATION_VALIDATION_MATRIX.md` no longer contained the exact guard sentence:

```text
Wire a real runtime command only after the fixture and acceptance tests exist.
```

The matrix still preserved the intent through the implementation sequence, but the regression test asserts this exact guard wording.

## Changes

- Restores the expected guard sentence in the immediate implementation sequence.
- Restores the explicit public-status guard sentence:
  - `Do not raise public Fyr completion percentage until runtime implementation and tests land.`
- Keeps the existing source-and-tests promotion rule.

## Validation

Not run locally through this connector. This directly addresses the reported failing assertion in `cargo test -p phase1 --test fyr_automation_validation_matrix`.
