### PR TITLE
Document Fyr F3 if-body assertion regression

### DIFF
--- a/docs/fyr/F3_IF_ASSERTION_BODY_REGRESSION.md
+++ b/docs/fyr/F3_IF_ASSERTION_BODY_REGRESSION.md
@@ -1,0 +1,113 @@
+# Fyr F3 if-body assertion regression
+
+Issue: #330  
+Status: regression handoff  
+Scope: parser/runtime support for supported assertion statements before `return` inside F3 `if` bodies  
+Non-claim: this document does not fix the runtime behavior by itself.
+
+## Failing test
+
+```sh
+cargo test -p phase1 --test fyr_f3_expression_diagnostics
+```
+
+Failing case:
+
+```text
+fyr_f3_boolean_operator_precedence_remains_deterministic
+```
+
+## Current failure
+
+The current runtime rejects an `if` body containing `assert_eq(...)` before `return`:
+
+```text
+fyr check: bool.fyr: expected return statement in if body
+fyr build: bool.fyr: expected return statement in if body
+```
+
+## Source under test
+
+```fyr
+fn main() -> i32 {
+  let answer = 42;
+  if (answer > 40 && answer < 50) {
+    assert_eq(answer, 42);
+    return answer;
+  }
+  return 0;
+}
+```
+
+## Expected behavior
+
+The Fyr F3 parser/rewriter should accept supported assertion statements before the required `return` statement inside an `if` body.
+
+Expected output:
+
+```text
+fyr check: ok bool.fyr
+status  : dry-run artifact ready
+```
+
+## Implementation target
+
+In `src/main.rs`, find the code path that emits:
+
+```text
+expected return statement in if body
+```
+
+Update that path so an F3 `if` body can consume the supported statement sequence:
+
+```text
+assert_eq(...);
+assert(...);
+return <integer-expression-or-binding>;
+```
+
+The fix should preserve the existing requirement that a supported F3 `if` body has a return. It should not broadly accept arbitrary statements.
+
+## Suggested parser rule
+
+A supported F3 `if` body should be parsed as:
+
+```text
+zero or more supported assertion statements
+one required return statement
+```
+
+Supported assertion statements for this fix:
+
+```text
+assert_eq(<integer-expression>, <integer-expression>);
+assert(<boolean-expression>);
+```
+
+## Safety boundary
+
+This is a parser/runtime fix only.
+
+Do not introduce:
+
+```text
+host command execution
+network access
+Cargo invocation from Fyr commands
+Rust compiler invocation from Fyr commands
+live-system writes
+unsupported arbitrary statements in if bodies
+```
+
+## Acceptance commands
+
+```sh
+cargo test -p phase1 --test fyr_f3_expression_diagnostics
+cargo test -p phase1 --test fyr_boolean_operators
+cargo test -p phase1 --test fyr_boolean_grouping
+cargo test -p phase1 --test fyr_automation_validation_matrix
+```
+
+## Completion rule
+
+Close #330 only after the runtime parser fix lands and the acceptance commands pass.


### PR DESCRIPTION
## Summary

Adds a focused regression handoff for the Fyr F3 parser failure found in the local X200 test run.

## Context

The failing test is:

```text
cargo test -p phase1 --test fyr_f3_expression_diagnostics
```

Specific failing case:

```text
fyr_f3_boolean_operator_precedence_remains_deterministic
```

Observed diagnostic:

```text
expected return statement in if body
```

## Changes

- Adds `docs/fyr/F3_IF_ASSERTION_BODY_REGRESSION.md` documenting:
  - the failing test and exact source shape
  - the current diagnostic
  - expected behavior
  - parser implementation target
  - narrow supported statement sequence
  - acceptance command set
  - completion rule for #330

## Why

This keeps the next Fyr parser fix precise: accept supported assertion statements before the required return in F3 if bodies without broadening the language surface beyond the supported rule.

## Validation

Not run locally through this connector. Documentation handoff only.

## Related

- Tracks #330.
