### PR TITLE
Add metadata-only analyze load registry

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,0 +1,254 @@
+use crate::commands::Phase1Shell;
+use crate::kernel::VfsNode;
+
+pub fn run(shell: &mut Phase1Shell, args: &[String]) -> String {
+    match args.first().map(String::as_str) {
+        None | Some("status") | Some("help") | Some("--help") | Some("-h") => status(),
+        Some("load") => load(shell, &args[1..]),
+        Some("inspect") => planned("inspect"),
+        Some("report") => planned("report"),
+        Some("forget") => planned("forget"),
+        Some(other) => format!(
+            "phase1 analysis\nstatus           : unknown-action\naction           : {other}\nmode             : no-execute\nexecution-state  : not-executed\nhost-execution   : disabled\nsandbox-claim    : not-claimed\nhelp             : analyze status | analyze load <path>\n"
+        ),
+    }
+}
+
+fn status() -> String {
+    concat!(
+        "phase1 analysis\n",
+        "status           : experimental\n",
+        "mode             : metadata-only\n",
+        "execution-state  : not-executed\n",
+        "host-execution   : disabled\n",
+        "sandbox-claim    : not-claimed\n",
+        "static-analysis  : planned\n",
+        "dynamic-analysis : future-restricted\n",
+        "sample-registry  : session-local\n",
+        "reports          : planned\n",
+        "fyr-integration  : planned\n",
+        "base1-evidence   : planned\n",
+        "claim-boundary   : metadata-only-loading\n",
+        "usage            : analyze load <path>\n",
+    )
+    .to_string()
+}
+
+fn planned(action: &str) -> String {
+    format!(
+        "phase1 analysis\nstatus           : planned\naction           : {action}\nmode             : no-execute\nexecution-state  : not-executed\nhost-execution   : disabled\nsandbox-claim    : not-claimed\nclaim-boundary   : metadata-only-loading\n"
+    )
+}
+
+fn load(shell: &mut Phase1Shell, args: &[String]) -> String {
+    let Some(path) = args.first().map(String::as_str) else {
+        return concat!(
+            "phase1 analysis load\n",
+            "status           : missing-path\n",
+            "usage            : analyze load <path>\n",
+            "mode             : no-execute\n",
+            "execution-state  : not-executed\n",
+            "host-execution   : disabled\n",
+            "sandbox-claim    : not-claimed\n",
+        )
+        .to_string();
+    };
+
+    let resolved = shell.kernel.vfs.resolve_path(path);
+    let Some(node) = shell.kernel.vfs.get_node(&resolved) else {
+        return format!(
+            "phase1 analysis load\nstatus           : missing\npath             : {}\nerror            : no-such-vfs-file\nmode             : no-execute\nexecution-state  : not-executed\nhost-execution   : disabled\nsandbox-claim    : not-claimed\nclaim-boundary   : metadata-only-loading\n",
+            resolved.display()
+        );
+    };
+
+    let VfsNode::File { content, .. } = node else {
+        return format!(
+            "phase1 analysis load\nstatus           : unsupported\npath             : {}\nerror            : directory-not-sample\nmode             : no-execute\nexecution-state  : not-executed\nhost-execution   : disabled\nsandbox-claim    : not-claimed\nclaim-boundary   : metadata-only-loading\n",
+            resolved.display()
+        );
+    };
+
+    let bytes = content.as_bytes();
+    let digest = sha256_hex(bytes);
+    let id = format!("sha256-{}", &digest[..12]);
+    let registry_key = "PHASE1_ANALYSIS_REGISTRY";
+    let prior = shell.env.get(registry_key).cloned().unwrap_or_default();
+    let duplicate = prior
+        .split(',')
+        .filter(|item| !item.is_empty())
+        .any(|item| item == id);
+
+    if !duplicate {
+        let next = if prior.trim().is_empty() {
+            id.clone()
+        } else {
+            format!("{prior},{id}")
+        };
+        shell.env.insert(registry_key.to_string(), next);
+    }
+
+    shell.kernel.audit.record(format!(
+        "analysis.load id={id} path={} bytes={} state=not-executed",
+        resolved.display(),
+        bytes.len()
+    ));
+
+    format!(
+        "phase1 analysis load\nstatus           : {}\nid               : {id}\npath             : {}\nsize-bytes       : {}\nsha256           : {digest}\nsource           : vfs\nloaded-at        : session\ntrust-state      : untrusted\nexecution-state  : not-executed\nhost-execution   : disabled\nsandbox-claim    : not-claimed\ndynamic-analysis : future-restricted\nclaim-boundary   : metadata-only-loading\n",
+        if duplicate { "duplicate" } else { "loaded" },
+        resolved.display(),
+        bytes.len()
+    )
+}
+
+fn sha256_hex(input: &[u8]) -> String {
+    const H0: [u32; 8] = [
+        0x6a09e667,
+        0xbb67ae85,
+        0x3c6ef372,
+        0xa54ff53a,
+        0x510e527f,
+        0x9b05688c,
+        0x1f83d9ab,
+        0x5be0cd19,
+    ];
+    const K: [u32; 64] = [
+        0x428a2f98,
+        0x71374491,
+        0xb5c0fbcf,
+        0xe9b5dba5,
+        0x3956c25b,
+        0x59f111f1,
+        0x923f82a4,
+        0xab1c5ed5,
+        0xd807aa98,
+        0x12835b01,
+        0x243185be,
+        0x550c7dc3,
+        0x72be5d74,
+        0x80deb1fe,
+        0x9bdc06a7,
+        0xc19bf174,
+        0xe49b69c1,
+        0xefbe4786,
+        0x0fc19dc6,
+        0x240ca1cc,
+        0x2de92c6f,
+        0x4a7484aa,
+        0x5cb0a9dc,
+        0x76f988da,
+        0x983e5152,
+        0xa831c66d,
+        0xb00327c8,
+        0xbf597fc7,
+        0xc6e00bf3,
+        0xd5a79147,
+        0x06ca6351,
+        0x14292967,
+        0x27b70a85,
+        0x2e1b2138,
+        0x4d2c6dfc,
+        0x53380d13,
+        0x650a7354,
+        0x766a0abb,
+        0x81c2c92e,
+        0x92722c85,
+        0xa2bfe8a1,
+        0xa81a664b,
+        0xc24b8b70,
+        0xc76c51a3,
+        0xd192e819,
+        0xd6990624,
+        0xf40e3585,
+        0x106aa070,
+        0x19a4c116,
+        0x1e376c08,
+        0x2748774c,
+        0x34b0bcb5,
+        0x391c0cb3,
+        0x4ed8aa4a,
+        0x5b9cca4f,
+        0x682e6ff3,
+        0x748f82ee,
+        0x78a5636f,
+        0x84c87814,
+        0x8cc70208,
+        0x90befffa,
+        0xa4506ceb,
+        0xbef9a3f7,
+        0xc67178f2,
+    ];
+
+    let mut h = H0;
+    let bit_len = (input.len() as u64) * 8;
+    let mut data = input.to_vec();
+    data.push(0x80);
+    while data.len() % 64 != 56 {
+        data.push(0);
+    }
+    data.extend_from_slice(&bit_len.to_be_bytes());
+
+    for chunk in data.chunks(64) {
+        let mut w = [0u32; 64];
+        for (i, word) in w.iter_mut().take(16).enumerate() {
+            let start = i * 4;
+            *word = u32::from_be_bytes([
+                chunk[start],
+                chunk[start + 1],
+                chunk[start + 2],
+                chunk[start + 3],
+            ]);
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+
+        let mut a = h[0];
+        let mut b = h[1];
+        let mut c = h[2];
+        let mut d = h[3];
+        let mut e = h[4];
+        let mut f = h[5];
+        let mut g = h[6];
+        let mut hh = h[7];
+
+        for i in 0..64 {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ ((!e) & g);
+            let temp1 = hh
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[i])
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let temp2 = s0.wrapping_add(maj);
+
+            hh = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(temp1);
+            d = c;
+            c = b;
+            b = a;
+            a = temp1.wrapping_add(temp2);
+        }
+
+        h[0] = h[0].wrapping_add(a);
+        h[1] = h[1].wrapping_add(b);
+        h[2] = h[2].wrapping_add(c);
+        h[3] = h[3].wrapping_add(d);
+        h[4] = h[4].wrapping_add(e);
+        h[5] = h[5].wrapping_add(f);
+        h[6] = h[6].wrapping_add(g);
+        h[7] = h[7].wrapping_add(hh);
+    }
+
+    h.iter().map(|word| format!("{word:08x}")).collect()
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,3 +1,5 @@
+#[path = "analysis.rs"]
+mod analysis;
 #[path = "pipeline.rs"]
 mod pipeline;
 #[path = "release.rs"]
@@ -318,6 +320,7 @@ pub fn dispatch(shell: &mut Phase1Shell, cmd: &str, args: &[String]) {
 
     match command {
         "help" => print!("{}", registry::help(args)),
+        "analyze" => print!("{}", analysis::run(shell, args)),
         "complete" => print_completions(args.first().map(String::as_str)),
         "capabilities" => print!("{}", registry::capabilities_report()),
         "dash" => print!("{}", dashboard(shell, args)),

--- a/tests/analysis_command_stub.rs
+++ b/tests/analysis_command_stub.rs
@@ -6,7 +6,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 static RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-fn run_phase1_with_analyze_plugin(input: &str) -> String {
+fn run_phase1(input: &str) -> String {
     let nonce = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_nanos())
@@ -16,36 +16,8 @@ fn run_phase1_with_analyze_plugin(input: &str) -> String {
         "phase1-analysis-command-stub-{}-{nonce}-{seq}",
         process::id()
     ));
-    let plugin_dir = run_dir.join("plugins");
     let _ = fs::remove_dir_all(&run_dir);
-    fs::create_dir_all(&plugin_dir).expect("create analysis plugin dir");
-    fs::write(plugin_dir.join("analyze.wasm"), b"\0asm\x01\0\0\0")
-        .expect("write analyze wasm marker");
-    fs::write(
-        plugin_dir.join("analyze.wasi"),
-        concat!(
-            "name=analyze\n",
-            "capability=none\n",
-            "stdout=phase1 analysis\n",
-            "stdout=status           : planned\n",
-            "stdout=mode             : no-execute\n",
-            "stdout=execution-state  : not-executed\n",
-            "stdout=host-execution   : disabled\n",
-            "stdout=sandbox-claim    : not-claimed\n",
-            "stdout=static-analysis  : planned\n",
-            "stdout=dynamic-analysis : future-restricted\n",
-            "stdout=sample-registry  : planned\n",
-            "stdout=reports          : planned\n",
-            "stdout=fyr-integration  : planned\n",
-            "stdout=base1-evidence   : planned\n",
-            "stdout=claim-boundary   : metadata-only-planning\n",
-            "stdout=load             : planned-no-op\n",
-            "stdout=inspect          : planned-no-op\n",
-            "stdout=report           : planned-no-op\n",
-            "stdout=forget           : planned-no-op\n",
-        ),
-    )
-    .expect("write analyze wasi manifest");
+    fs::create_dir_all(&run_dir).expect("create analysis command stub test dir");
 
     let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
         .current_dir(&run_dir)
@@ -80,37 +52,35 @@ fn run_phase1_with_analyze_plugin(input: &str) -> String {
 
 #[test]
 fn analyze_command_stub_reports_no_execute_boundary() {
-    let output = run_phase1_with_analyze_plugin(
-        "wasm list\nanalyze\nanalyze status\nanalyze help\nanalyze load sample.bin\nexit\n",
-    );
+    let output = run_phase1("wasm list\nanalyze\nanalyze status\nanalyze help\nanalyze load sample.bin\nexit\n");
 
     for required in [
         "analyze",
-        "phase1 wasi run",
-        "plugin : analyze",
-        "sandbox: fs=virtual net=disabled host=blocked",
+        "phase1 wasm plugins",
         "phase1 analysis",
-        "status           : planned",
-        "mode             : no-execute",
+        "status           : experimental",
+        "mode             : metadata-only",
         "execution-state  : not-executed",
         "host-execution   : disabled",
         "sandbox-claim    : not-claimed",
         "static-analysis  : planned",
         "dynamic-analysis : future-restricted",
-        "sample-registry  : planned",
+        "sample-registry  : session-local",
         "reports          : planned",
         "fyr-integration  : planned",
         "base1-evidence   : planned",
-        "claim-boundary   : metadata-only-planning",
-        "load             : planned-no-op",
-        "inspect          : planned-no-op",
-        "report           : planned-no-op",
-        "forget           : planned-no-op",
+        "claim-boundary   : metadata-only-loading",
+        "usage            : analyze load <path>",
+        "phase1 analysis load",
+        "status           : missing",
+        "path             : /home/sample.bin",
+        "error            : no-such-vfs-file",
     ] {
         assert!(output.contains(required), "missing {required:?}:\n{output}");
     }
 
     for forbidden in [
+        "phase1 wasi run",
         "host=enabled",
         "host-execution   : enabled",
         "execution-state  : executed",

--- a/tests/analysis_command_stub.rs
+++ b/tests/analysis_command_stub.rs
@@ -52,7 +52,9 @@ fn run_phase1(input: &str) -> String {
 
 #[test]
 fn analyze_command_stub_reports_no_execute_boundary() {
-    let output = run_phase1("wasm list\nanalyze\nanalyze status\nanalyze help\nanalyze load sample.bin\nexit\n");
+    let output = run_phase1(
+        "wasm list\nanalyze\nanalyze status\nanalyze help\nanalyze load sample.bin\nexit\n",
+    );
 
     for required in [
         "analyze",

--- a/tests/analysis_load_metadata.rs
+++ b/tests/analysis_load_metadata.rs
@@ -1,0 +1,111 @@
+use std::fs;
+use std::io::Write;
+use std::process::{self, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn run_phase1(input: &str) -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let seq = RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let run_dir = std::env::temp_dir().join(format!(
+        "phase1-analysis-load-metadata-{}-{nonce}-{seq}",
+        process::id()
+    ));
+    let _ = fs::remove_dir_all(&run_dir);
+    fs::create_dir_all(&run_dir).expect("create analysis load metadata test dir");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .current_dir(&run_dir)
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_PERSISTENT_STATE", "0")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_BLEEDING_EDGE", "1")
+        .env_remove("PHASE1_THEME")
+        .env_remove("PHASE1_ALLOW_HOST_TOOLS")
+        .env_remove("PHASE1_SAFE_MODE")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("phase1 output");
+    let _ = fs::remove_dir_all(&run_dir);
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn analyze_load_records_vfs_file_metadata_without_execution() {
+    let output = run_phase1(
+        "echo 'phase1-sample' > sample.bin\nanalyze load sample.bin\nanalyze load sample.bin\nexit\n",
+    );
+
+    for required in [
+        "phase1 analysis load",
+        "status           : loaded",
+        "status           : duplicate",
+        "id               : sha256-016644b74537",
+        "path             : /home/sample.bin",
+        "size-bytes       : 14",
+        "sha256           : 016644b74537df25d6d98eaf0e62f5a71340a7ad7222d7d652c4d2d238109445",
+        "source           : vfs",
+        "loaded-at        : session",
+        "trust-state      : untrusted",
+        "execution-state  : not-executed",
+        "host-execution   : disabled",
+        "sandbox-claim    : not-claimed",
+        "dynamic-analysis : future-restricted",
+        "claim-boundary   : metadata-only-loading",
+    ] {
+        assert!(output.contains(required), "missing {required:?}:\n{output}");
+    }
+
+    for forbidden in [
+        "host=enabled",
+        "host-execution   : enabled",
+        "execution-state  : executed",
+        "sandbox-claim    : hardened",
+        "malware-safe",
+        "production forensic",
+    ] {
+        assert!(
+            !output.contains(forbidden),
+            "forbidden {forbidden:?}:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn analyze_load_rejects_missing_and_directory_paths_without_execution() {
+    let output = run_phase1("analyze load missing.bin\nanalyze load /home\nexit\n");
+
+    for required in [
+        "status           : missing",
+        "error            : no-such-vfs-file",
+        "path             : /home/missing.bin",
+        "status           : unsupported",
+        "error            : directory-not-sample",
+        "path             : /home",
+        "execution-state  : not-executed",
+        "host-execution   : disabled",
+        "sandbox-claim    : not-claimed",
+    ] {
+        assert!(output.contains(required), "missing {required:?}:\n{output}");
+    }
+}


### PR DESCRIPTION
## Summary

Implements the next Program Loading + Analysis slice: metadata-only sample loading for `analyze load <path>`.

This builds on the merged no-execute analyze stub and keeps the analysis surface conservative and evidence-bound.

## Added

- `src/analysis.rs`
  - native `analyze` command surface
  - metadata-only `analyze load <path>`
  - VFS file metadata extraction
  - deterministic SHA-256 digest and `sha256-<prefix>` sample id
  - session-local duplicate detection
  - missing-path and directory rejection paths
- `tests/analysis_load_metadata.rs`
  - existing VFS file load
  - duplicate load behavior
  - missing file behavior
  - directory rejection behavior
  - no-execute/non-claim guardrails
- `tests/analysis_command_stub.rs`
  - updated to validate the native metadata-only status surface after `analyze` stopped falling through to the WASI-lite fallback
- `src/commands.rs`
  - routes native `analyze` to the analysis module

## Boundary preserved

This PR does **not** implement target execution, host command execution, dynamic analysis, PE/ELF/Mach-O parsing, disassembly, sandbox integration, malware-safety claims, or production forensic admissibility claims.

Required rows remain present:

```text
execution-state  : not-executed
host-execution   : disabled
sandbox-claim    : not-claimed
dynamic-analysis : future-restricted
claim-boundary   : metadata-only-loading
```

## Validation

Operator reported:

```bash
cargo fmt --all -- --check
cargo test -p phase1 --test analysis_command_stub
cargo test -p phase1 --test analysis_load_metadata
cargo clippy --all-targets -- -D warnings
cargo test --all-targets
```

The pasted run shows the full suite completing successfully after the native analyzer wiring and test updates.

## Tracks

- Closes #342
- Follows #340 and merged PR #341