### PR TITLE
Add metadata-only analyze list command

### DIFF
--- a/docs/status/PROJECT_STATUS.md
+++ b/docs/status/PROJECT_STATUS.md
@@ -3,8 +3,8 @@
 Status kind: estimated roadmap progress
 Source marker: [`site/status.json`](../../site/status.json)
 Badge marker: [`site/status-badge.json`](../../site/status-badge.json)
-Generated from commit: `8a525f60b8fb630e41b1bf41b9f84cb819a1955a`
-Last updated UTC: `2026-05-14T09:19:56Z`
+Generated from commit: `61df4dcdbac3be270fab26096ae4aeb29c058fdb`
+Last updated UTC: `2026-05-14T18:41:16Z`
 
 ## Current estimate
 

--- a/site/status.json
+++ b/site/status.json
@@ -1,10 +1,10 @@
 {
   "name": "Phase1 public project status",
   "status_kind": "estimated roadmap progress",
-  "last_updated_utc": "2026-05-14T09:19:56Z",
+  "last_updated_utc": "2026-05-14T18:41:16Z",
   "repository": "Bryforge/phase1",
   "branch": "edge/stable",
-  "commit": "8a525f60b8fb630e41b1bf41b9f84cb819a1955a",
+  "commit": "61df4dcdbac3be270fab26096ae4aeb29c058fdb",
   "overall_estimated_completion_percent": 67,
   "public_state": "active edge development with reviewed B3 VM evidence, B6 X200 marker evidence, public status promotion, Base1 B6 X200 marker checkpoint release note, and Fyr black_arts staged-candidate evidence published",
   "important_boundary": "Percentages are planning estimates, not production-readiness, security-hardening, live-update, or autonomous self-modification claims. Fyr black_arts has staged-candidate design, fixtures, operator visuals, source-wiring checklist, and runtime-stub handoff evidence, but the first safe runtime stub remains pending under issue #317. Installer readiness, recovery-complete status, hardening, release-candidate readiness, daily-driver readiness, broad hardware validation, live-system mutation, and autonomous promotion remain not claimed.",

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -16,10 +16,11 @@ pub fn run(shell: &mut Phase1Shell, args: &[String]) -> String {
         None | Some("status") | Some("help") | Some("--help") | Some("-h") => status(),
         Some("load") => load(shell, &args[1..]),
         Some("inspect") => inspect(shell, &args[1..]),
+        Some("list") => list(shell),
         Some("report") => planned("report"),
         Some("forget") => planned("forget"),
         Some(other) => format!(
-            "phase1 analysis\nstatus           : unknown-action\naction           : {other}\nmode             : no-execute\nexecution-state  : not-executed\nhost-execution   : disabled\nsandbox-claim    : not-claimed\nhelp             : analyze status | analyze load <path> | analyze inspect <id>\n"
+            "phase1 analysis\nstatus           : unknown-action\naction           : {other}\nmode             : no-execute\nexecution-state  : not-executed\nhost-execution   : disabled\nsandbox-claim    : not-claimed\nhelp             : analyze status | analyze load <path> | analyze inspect <id> | analyze list\n"
         ),
     }
 }
@@ -39,7 +40,7 @@ fn status() -> String {
         "fyr-integration  : planned\n",
         "base1-evidence   : planned\n",
         "claim-boundary   : metadata-only-loading\n",
-        "usage            : analyze load <path> | analyze inspect <id>\n",
+        "usage            : analyze load <path> | analyze inspect <id> | analyze list\n",
     )
     .to_string()
 }
@@ -135,6 +136,32 @@ fn inspect(shell: &mut Phase1Shell, args: &[String]) -> String {
     };
 
     format_record("inspect", "found", record)
+}
+
+fn list(shell: &Phase1Shell) -> String {
+    let records = load_registry(shell);
+    let mut out = format!(
+        "phase1 analysis list\nstatus           : {}\nrecords          : {}\n",
+        if records.is_empty() { "empty" } else { "ok" },
+        records.len()
+    );
+
+    for record in &records {
+        out.push_str(&format!(
+            "record           : {} {} {}\n",
+            record.id, record.path, record.size_bytes
+        ));
+    }
+
+    out.push_str(concat!(
+        "execution-state  : not-executed\n",
+        "host-execution   : disabled\n",
+        "sandbox-claim    : not-claimed\n",
+        "dynamic-analysis : future-restricted\n",
+        "claim-boundary   : metadata-only-loading\n",
+    ));
+
+    out
 }
 
 fn format_record(action: &str, status: &str, record: &AnalysisRecord) -> String {

--- a/tests/analysis_list_metadata.rs
+++ b/tests/analysis_list_metadata.rs
@@ -1,0 +1,107 @@
+use std::fs;
+use std::io::Write;
+use std::process::{self, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn run_phase1(input: &str) -> String {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let seq = RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let run_dir = std::env::temp_dir().join(format!(
+        "phase1-analysis-list-metadata-{}-{nonce}-{seq}",
+        process::id()
+    ));
+    let _ = fs::remove_dir_all(&run_dir);
+    fs::create_dir_all(&run_dir).expect("create analysis list metadata test dir");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .current_dir(&run_dir)
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_PERSISTENT_STATE", "0")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_BLEEDING_EDGE", "1")
+        .env_remove("PHASE1_THEME")
+        .env_remove("PHASE1_ALLOW_HOST_TOOLS")
+        .env_remove("PHASE1_SAFE_MODE")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("phase1 output");
+    let _ = fs::remove_dir_all(&run_dir);
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn analyze_list_reports_empty_registry_without_execution() {
+    let output = run_phase1("analyze list\nexit\n");
+
+    for required in [
+        "phase1 analysis list",
+        "status           : empty",
+        "records          : 0",
+        "execution-state  : not-executed",
+        "host-execution   : disabled",
+        "sandbox-claim    : not-claimed",
+        "dynamic-analysis : future-restricted",
+        "claim-boundary   : metadata-only-loading",
+    ] {
+        assert!(output.contains(required), "missing {required:?}:\n{output}");
+    }
+
+    assert!(!output.contains("record           :"), "{output}");
+}
+
+#[test]
+fn analyze_list_reports_loaded_records_without_execution() {
+    let output = run_phase1(
+        "echo 'phase1-sample' > sample.bin\necho 'phase1-other' > other.bin\nanalyze load sample.bin\nanalyze load other.bin\nanalyze list\nexit\n",
+    );
+
+    for required in [
+        "phase1 analysis list",
+        "status           : ok",
+        "records          : 2",
+        "record           : sha256-016644b74537 /home/sample.bin 14",
+        "record           : sha256-fe9992b502e4 /home/other.bin 13",
+        "execution-state  : not-executed",
+        "host-execution   : disabled",
+        "sandbox-claim    : not-claimed",
+        "dynamic-analysis : future-restricted",
+        "claim-boundary   : metadata-only-loading",
+    ] {
+        assert!(output.contains(required), "missing {required:?}:\n{output}");
+    }
+
+    for forbidden in [
+        "host=enabled",
+        "host-execution   : enabled",
+        "execution-state  : executed",
+        "sandbox-claim    : hardened",
+        "malware-safe",
+        "production forensic",
+    ] {
+        assert!(
+            !output.contains(forbidden),
+            "forbidden {forbidden:?}:\n{output}"
+        );
+    }
+}

--- a/tests/analysis_list_metadata.rs
+++ b/tests/analysis_list_metadata.rs
@@ -81,7 +81,7 @@ fn analyze_list_reports_loaded_records_without_execution() {
         "status           : ok",
         "records          : 2",
         "record           : sha256-016644b74537 /home/sample.bin 14",
-        "record           : sha256-fe9992b502e4 /home/other.bin 13",
+        "record           : sha256-ad8692ba10b2 /home/other.bin 13",
         "execution-state  : not-executed",
         "host-execution   : disabled",
         "sandbox-claim    : not-claimed",


### PR DESCRIPTION
## Summary

Implements the next Program Loading + Analysis slice after `analyze load <path>` and `analyze inspect <id>`.

This adds a session-local metadata listing command so operators can see loaded sample IDs, paths, sizes, and count before inspecting a record.

## Added

- `analyze list`
  - reports empty session registry
  - reports loaded records from the session-local registry
  - includes deterministic ids, VFS paths, and size bytes
- `tests/analysis_list_metadata.rs`
  - empty registry behavior
  - loaded record listing behavior
  - no-execute/non-claim guardrails

## Boundary preserved

This PR does **not** implement target execution, host command execution, dynamic analysis, persistent evidence archive, report export, byte preview, PE/ELF/Mach-O parsing, disassembly, entropy scoring, sandbox integration, malware-safety claims, or production forensic admissibility claims.

Required rows remain present:

```text
execution-state  : not-executed
host-execution   : disabled
sandbox-claim    : not-claimed
dynamic-analysis : future-restricted
claim-boundary   : metadata-only-loading
```

## Validation

Operator reported focused and full validation passing:

```bash
cargo fmt --all -- --check
cargo test -p phase1 --test analysis_list_metadata
cargo test -p phase1 --test analysis_inspect_metadata
cargo test -p phase1 --test analysis_load_metadata
cargo clippy --all-targets -- -D warnings
cargo test --all-targets
```

The pasted run shows the full suite completing successfully after the list expectation was corrected.

## Tracks

- Closes #346
- Follows #344 / PR #345 and #342 / PR #343