### PR TITLE
Add crypto provider service and chains planning docs

### DIFF
--- a/docs/security/CRYPTO_CHAINS.md
+++ b/docs/security/CRYPTO_CHAINS.md
@@ -1,0 +1,95 @@
+# Crypto Chains
+
+Status: planning  
+Scope: scoped cryptographic policy chaining across Phase1/Base1 floors, nests, portals, analysis workspaces, recovery workspaces, and future service contexts
+
+## Purpose
+
+Crypto Chains define how Phase1/Base1 can assign cryptographic profiles, providers, and services to different operating contexts without claiming that runtime cryptographic isolation is complete.
+
+The goal is operator-selectable cryptographic separation by scope.
+
+## Core idea
+
+A crypto chain is a declared relationship between a parent context and a child context.
+
+Context examples:
+
+- floor
+- nest
+- portal
+- analysis workspace
+- recovery workspace
+- Base1 service scope
+- future Fyr automation scope
+
+## Example concept
+
+```text
+floor1
+  crypto-profile: compatibility/blowfish-lab
+  crypto-provider: documented-provider-a
+  scope: local metadata only
+
+portal alpha
+  crypto-profile: safe-default
+  crypto-provider: documented-provider-b
+  scope: portal-local records
+
+nest forensic-lab
+  crypto-profile: high-security
+  crypto-provider: documented-provider-c
+  scope: isolated analysis records
+```
+
+## Planned chain fields
+
+Each crypto chain should eventually declare:
+
+- parent context
+- child context
+- selected crypto profile
+- selected crypto provider
+- selected crypto service family
+- allowed data scope
+- denied data scope
+- audit behavior
+- downgrade behavior
+- fail-closed behavior
+- verification status
+
+## Guardrails
+
+Crypto Chains are planning records only until runtime enforcement exists.
+
+A documented crypto chain must not be presented as:
+
+- completed cryptographic isolation
+- hardware-backed secrecy
+- formal sandboxing
+- production-grade key management
+- certified cryptographic compliance
+- post-quantum security
+- broad system hardening
+
+## Safety model
+
+Crypto Chains should prefer fail-closed behavior.
+
+If a requested provider, profile, or service is unavailable, the chain should deny the operation instead of silently falling back to a weaker mode.
+
+## Relationship to existing crypto docs
+
+Crypto Chains depend on:
+
+- `CRYPTO_POLICY_ROADMAP.md`
+- `CRYPTO_PROVIDER_REGISTRY.md`
+- `CRYPTO_PROVIDER_SERVICE_MATRIX.md`
+- crypto profile planning docs
+- operator command planning docs
+
+## Current status
+
+This document defines the planning model only.
+
+Runtime chain selection, provider enforcement, service binding, audit logging, and Base1/Fyr integration remain future work.

--- a/docs/security/CRYPTO_POLICY_ROADMAP.md
+++ b/docs/security/CRYPTO_POLICY_ROADMAP.md
@@ -116,6 +116,16 @@ crypto status
 
 Unknown profiles and scopes should fail closed.
 
+## Crypto chains
+
+The future scoped crypto chain model is planned in [`CRYPTO_CHAINS.md`](CRYPTO_CHAINS.md).
+
+Crypto Chains describe how profiles, providers, and services may eventually be assigned across floors, nests, portals, analysis workspaces, recovery workspaces, Base1 service scopes, and future Fyr automation scopes.
+
+Crypto Chains remain planning records until runtime chain selection, provider enforcement, service binding, audit logging, and Base1/Fyr integration exist.
+
+Unknown chain contexts, unavailable providers, missing services, and unsupported profile combinations should fail closed.
+
 ## Implementation plan
 
 The implementation sequence is defined in [`CRYPTO_IMPLEMENTATION_PLAN.md`](CRYPTO_IMPLEMENTATION_PLAN.md).
@@ -181,9 +191,13 @@ Every supported algorithm page should use [`CRYPTO_ALGORITHM_TEMPLATE.md`](CRYPT
 
 Every provider entry should follow [`CRYPTO_PROVIDER_REGISTRY.md`](CRYPTO_PROVIDER_REGISTRY.md) before it is connected to runtime behavior.
 
+Every provider/service mapping should follow [`CRYPTO_PROVIDER_SERVICE_MATRIX.md`](CRYPTO_PROVIDER_SERVICE_MATRIX.md) before it is connected to profile selection, service behavior, or runtime enforcement.
+
 Every profile should follow the structure in [`crypto-profiles/README.md`](crypto-profiles/README.md) before it is connected to runtime behavior.
 
 Every config schema change should follow [`CRYPTO_CONFIG_SCHEMA.md`](CRYPTO_CONFIG_SCHEMA.md) before it is connected to runtime behavior.
+
+Every crypto chain should follow [`CRYPTO_CHAINS.md`](CRYPTO_CHAINS.md) before it is connected to runtime scope selection, provider enforcement, service binding, or Base1/Fyr integration.
 
 Every implementation phase should follow [`CRYPTO_IMPLEMENTATION_PLAN.md`](CRYPTO_IMPLEMENTATION_PLAN.md) before it is connected to runtime behavior.
 
@@ -205,6 +219,8 @@ Crypto profile changes should:
 
 - Create registry format: [`CRYPTO_REGISTRY.md`](CRYPTO_REGISTRY.md).
 - Create provider registry: [`CRYPTO_PROVIDER_REGISTRY.md`](CRYPTO_PROVIDER_REGISTRY.md).
+- Create provider/service matrix: [`CRYPTO_PROVIDER_SERVICE_MATRIX.md`](CRYPTO_PROVIDER_SERVICE_MATRIX.md).
+- Create crypto chains planning doc: [`CRYPTO_CHAINS.md`](CRYPTO_CHAINS.md).
 - Create algorithm documentation template: [`CRYPTO_ALGORITHM_TEMPLATE.md`](CRYPTO_ALGORITHM_TEMPLATE.md).
 - Create profile planning index: [`crypto-profiles/README.md`](crypto-profiles/README.md).
 - Create operator command plan: [`CRYPTO_OPERATOR_COMMANDS.md`](CRYPTO_OPERATOR_COMMANDS.md).
@@ -231,6 +247,7 @@ Crypto profile changes should:
 ### Phase 4: advanced controls
 
 - Scoped profile selection.
+- Chain-aware profile and provider selection.
 - Policy export and verification.
 - Migration and rotation commands.
 

--- a/docs/security/CRYPTO_POLICY_ROADMAP.md
+++ b/docs/security/CRYPTO_POLICY_ROADMAP.md
@@ -253,3 +253,7 @@ Base1 crypto planning should prioritize image provenance, recovery media verific
 This roadmap does not make Phase1 or Base1 cryptographically complete, audited, quantum-safe, certified, hardware-validated, installer-ready, or daily-driver ready.
 
 It defines a plan for safer cryptographic capability, documentation, and operator-selectable policy.
+
+## Provider service matrix
+
+- [`CRYPTO_PROVIDER_SERVICE_MATRIX.md`](CRYPTO_PROVIDER_SERVICE_MATRIX.md) — planning matrix for open-source crypto provider families, service families, profile selection, and non-claiming provider/service boundaries.

--- a/docs/security/CRYPTO_PROVIDER_REGISTRY.md
+++ b/docs/security/CRYPTO_PROVIDER_REGISTRY.md
@@ -127,3 +127,7 @@ The first implementation work should create documentation-only provider entries 
 This provider registry does not make Phase1 or Base1 cryptographically complete, audited, certified, quantum-safe, hardware-validated, installer-ready, or daily-driver ready.
 
 It defines the planned provider metadata and review structure for future cryptographic implementation work.
+
+## Related provider/service planning
+
+- [`CRYPTO_PROVIDER_SERVICE_MATRIX.md`](CRYPTO_PROVIDER_SERVICE_MATRIX.md) — maps provider categories to planned Phase1/Base1 crypto service families and operator-selectable profile boundaries.

--- a/docs/security/CRYPTO_PROVIDER_SERVICE_MATRIX.md
+++ b/docs/security/CRYPTO_PROVIDER_SERVICE_MATRIX.md
@@ -1,0 +1,62 @@
+# Phase1/Base1 crypto provider service matrix
+
+Status: planning matrix
+Scope: open-source cryptographic providers, algorithm families, security services, operator-selectable profiles, and future Phase1/Base1 control points
+
+## Purpose
+
+Phase1 and Base1 should support major reviewed open-source cryptographic systems, providers, algorithms, modes, and profile families through an operator-selectable policy layer.
+
+The goal is broad native crypto capability with safe defaults, explicit provider choice, explicit profile choice, test-vector evidence, and no unsupported security claims.
+
+## Boundary
+
+This matrix is documentation-first.
+
+It does not approve runtime cryptographic protection, production hardening, compliance posture, national-security suitability, or secure deployment claims.
+
+No provider, algorithm, profile, or service is runtime-approved until documentation, tests, vectors, failure behavior, and review are complete.
+
+## Standing rules
+
+- Prefer reviewed open-source providers.
+- Reject custom security-critical primitives.
+- Reject unknown providers.
+- Reject undocumented providers.
+- Fail closed on unsupported profile/provider/scope combinations.
+- Avoid silent provider substitution.
+- Require test vectors before provider-backed runtime behavior protects real data.
+- Require explicit operator selection for advanced profiles.
+- Preserve non-claims until evidence supports promotion.
+
+## Security service families
+
+| Service family | Purpose | Default posture |
+| --- | --- | --- |
+| identity | identity, signing, attestation, and trust records | planned |
+| storage | file, VFS, artifact, and backup protection | planned |
+| transport | local and future network transport protection | planned |
+| update | release metadata, update verification, and provenance | planned |
+| logs-evidence | audit logs, evidence bundles, and integrity records | planned |
+| recovery | Base1 recovery bundle verification and rollback evidence | planned |
+| analysis | metadata-only analysis records and report signing | planned |
+| developer | build, test, and package verification | planned |
+
+## Provider categories
+
+| Provider category | Examples | Status |
+| --- | --- | --- |
+| RustCrypto ecosystem | hashes, AEADs, signatures, KDFs where appropriate | candidate |
+| ring/aws-lc family | TLS-adjacent and primitive-backed provider options | candidate |
+| OpenSSL/LibreSSL/BoringSSL family | compatibility and platform-provider options | candidate |
+| libsodium family | modern high-level crypto APIs | candidate |
+| age/minisign/signify family | file encryption and signing workflows | candidate |
+| TPM/platform keystore | hardware-backed key storage where available | candidate |
+| kernel/platform crypto APIs | platform capability provider | candidate |
+| post-quantum provider family | ML-KEM, ML-DSA, SLH-DSA capable providers after review | candidate |
+
+These examples are not approvals.
+
+## Non-claims
+
+This document does not claim that Phase1 or Base1 currently provides finished cryptographic hardening, approved national-security crypto, compliance posture, secure communications, secure storage, or production-ready cryptographic enforcement.

--- a/docs/security/CRYPTO_PROVIDER_SERVICE_MATRIX.md
+++ b/docs/security/CRYPTO_PROVIDER_SERVICE_MATRIX.md
@@ -57,6 +57,27 @@ No provider, algorithm, profile, or service is runtime-approved until documentat
 
 These examples are not approvals.
 
+## Relationship to Crypto Chains
+
+Crypto Chains are planned in [`CRYPTO_CHAINS.md`](CRYPTO_CHAINS.md).
+
+The provider service matrix defines service families and candidate provider families.
+
+Crypto Chains define how a future parent or child context may request a scoped combination of:
+
+- crypto profile;
+- provider family;
+- service family;
+- data scope;
+- audit behavior;
+- fail-closed behavior.
+
+A chain must not bind to a provider/service pairing unless the pairing is documented in this matrix, reviewed, and compatible with the selected profile and scope.
+
+Unknown chain contexts, undocumented provider/service pairings, unavailable providers, missing services, and unsupported profile combinations should fail closed.
+
 ## Non-claims
 
 This document does not claim that Phase1 or Base1 currently provides finished cryptographic hardening, approved national-security crypto, compliance posture, secure communications, secure storage, or production-ready cryptographic enforcement.
+
+This document also does not claim that Crypto Chains currently provide runtime isolation, provider enforcement, service binding, hardware-backed secrecy, certified cryptographic compliance, or production-grade key management.

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -2,7 +2,7 @@
 
 > **Status:** Documentation index and review entry point.
 >
-> **Validation:** Links to the trust model, crypto policy roadmap, crypto implementation plan, crypto registry, crypto provider registry, crypto provider template, crypto profiles index, crypto operator command plan, crypto config schema, crypto algorithm template, claims policy, review guide, and manual roadmap added in this repository.
+> **Validation:** Links to the trust model, crypto policy roadmap, crypto implementation plan, crypto registry, crypto provider registry, crypto provider service matrix, crypto chains, crypto provider template, crypto profiles index, crypto operator command plan, crypto config schema, crypto algorithm template, claims policy, review guide, and manual roadmap added in this repository.
 >
 > **Non-claims:** Phase1 is not currently a finished secure OS replacement, Base1 is not currently a released bootable daily-driver image, and this documentation index does not prove a security property by itself.
 
@@ -21,18 +21,20 @@ Security docs should preserve safe defaults, explicit trust gates, read-only and
 3. [`CRYPTO_IMPLEMENTATION_PLAN.md`](CRYPTO_IMPLEMENTATION_PLAN.md) — implementation sequence for registry, commands, config validation, provider abstraction, test vectors, policy engine, scoped integrations, migration, and review.
 4. [`CRYPTO_REGISTRY.md`](CRYPTO_REGISTRY.md) — planning registry for crypto profiles, control points, algorithm families, status labels, and review requirements.
 5. [`CRYPTO_PROVIDER_REGISTRY.md`](CRYPTO_PROVIDER_REGISTRY.md) — planning registry for cryptographic implementation providers, metadata, selection rules, and review requirements.
-6. [`CRYPTO_PROVIDER_TEMPLATE.md`](CRYPTO_PROVIDER_TEMPLATE.md) — required template for documenting cryptographic providers, libraries, crates, and platform capabilities.
-7. [`crypto-profiles/README.md`](crypto-profiles/README.md) — planning index for operator-selectable cryptographic profiles.
-8. [`CRYPTO_OPERATOR_COMMANDS.md`](CRYPTO_OPERATOR_COMMANDS.md) — planning design for future operator-facing crypto policy commands.
-9. [`CRYPTO_CONFIG_SCHEMA.md`](CRYPTO_CONFIG_SCHEMA.md) — planning schema for future scoped crypto policy configuration.
-10. [`CRYPTO_ALGORITHM_TEMPLATE.md`](CRYPTO_ALGORITHM_TEMPLATE.md) — required template for documenting cryptographic algorithms, designs, providers, and profile components.
-11. [`DOCS_CLAIMS.md`](DOCS_CLAIMS.md) — allowed wording, disallowed wording, status labels, and required evidence.
-12. [`REVIEW_GUIDE.md`](REVIEW_GUIDE.md) — practical reviewer checklist for safety-sensitive documentation.
-13. [`../MANUAL_ROADMAP.md`](../MANUAL_ROADMAP.md) — full Codex architecture, safety model, glossary, and launch plan.
+6. [`CRYPTO_PROVIDER_SERVICE_MATRIX.md`](CRYPTO_PROVIDER_SERVICE_MATRIX.md) — planning matrix for provider families, service families, profile selection, and non-claiming provider/service boundaries.
+7. [`CRYPTO_CHAINS.md`](CRYPTO_CHAINS.md) — planning model for scoped cryptographic policy chaining across floors, nests, portals, workspaces, Base1 service scopes, and future Fyr automation scopes.
+8. [`CRYPTO_PROVIDER_TEMPLATE.md`](CRYPTO_PROVIDER_TEMPLATE.md) — required template for documenting cryptographic providers, libraries, crates, and platform capabilities.
+9. [`crypto-profiles/README.md`](crypto-profiles/README.md) — planning index for operator-selectable cryptographic profiles.
+10. [`CRYPTO_OPERATOR_COMMANDS.md`](CRYPTO_OPERATOR_COMMANDS.md) — planning design for future operator-facing crypto policy commands.
+11. [`CRYPTO_CONFIG_SCHEMA.md`](CRYPTO_CONFIG_SCHEMA.md) — planning schema for future scoped crypto policy configuration.
+12. [`CRYPTO_ALGORITHM_TEMPLATE.md`](CRYPTO_ALGORITHM_TEMPLATE.md) — required template for documenting cryptographic algorithms, designs, providers, and profile components.
+13. [`DOCS_CLAIMS.md`](DOCS_CLAIMS.md) — allowed wording, disallowed wording, status labels, and required evidence.
+14. [`REVIEW_GUIDE.md`](REVIEW_GUIDE.md) — practical reviewer checklist for safety-sensitive documentation.
+15. [`../MANUAL_ROADMAP.md`](../MANUAL_ROADMAP.md) — full Codex architecture, safety model, glossary, and launch plan.
 
 ## Review order for safety-sensitive docs
 
-Use this order when reviewing pages about host tools, Base1, recovery, rollback, hardware, installers, image writing, cryptographic policy, cryptographic algorithms, cryptographic providers, cryptographic profiles, crypto operator commands, crypto configuration, crypto implementation, or security claims:
+Use this order when reviewing pages about host tools, Base1, recovery, rollback, hardware, installers, image writing, cryptographic policy, cryptographic algorithms, cryptographic providers, crypto provider/service mappings, cryptographic profiles, crypto chains, crypto operator commands, crypto configuration, crypto implementation, or security claims:
 
 1. Confirm the page has a status block.
 2. Confirm the page names the current implementation status.
@@ -44,13 +46,15 @@ Use this order when reviewing pages about host tools, Base1, recovery, rollback,
 8. Confirm algorithm pages use [`CRYPTO_ALGORITHM_TEMPLATE.md`](CRYPTO_ALGORITHM_TEMPLATE.md).
 9. Confirm registry entries are listed or planned through [`CRYPTO_REGISTRY.md`](CRYPTO_REGISTRY.md) before they are connected to profiles.
 10. Confirm provider entries are listed or planned through [`CRYPTO_PROVIDER_REGISTRY.md`](CRYPTO_PROVIDER_REGISTRY.md) before they are connected to runtime behavior.
-11. Confirm provider entries use [`CRYPTO_PROVIDER_TEMPLATE.md`](CRYPTO_PROVIDER_TEMPLATE.md) before they are connected to runtime behavior.
-12. Confirm profile docs follow [`crypto-profiles/README.md`](crypto-profiles/README.md) before they are connected to runtime behavior.
-13. Confirm crypto operator commands follow [`CRYPTO_OPERATOR_COMMANDS.md`](CRYPTO_OPERATOR_COMMANDS.md) before they are connected to runtime behavior.
-14. Confirm crypto configuration follows [`CRYPTO_CONFIG_SCHEMA.md`](CRYPTO_CONFIG_SCHEMA.md) before it is connected to runtime behavior.
-15. Confirm crypto implementation follows [`CRYPTO_IMPLEMENTATION_PLAN.md`](CRYPTO_IMPLEMENTATION_PLAN.md) before it protects real data or runtime control points.
-16. Confirm no page claims secure OS replacement, bootable Base1 release, installer readiness, daily-driver readiness, recovery completion, cryptographic completeness, audit completion, certification, or quantum safety without linked evidence.
-17. Use [`REVIEW_GUIDE.md`](REVIEW_GUIDE.md) before approving safety-sensitive documentation.
+11. Confirm provider/service mappings follow [`CRYPTO_PROVIDER_SERVICE_MATRIX.md`](CRYPTO_PROVIDER_SERVICE_MATRIX.md) before they are connected to profile selection, service behavior, or runtime enforcement.
+12. Confirm crypto chains follow [`CRYPTO_CHAINS.md`](CRYPTO_CHAINS.md) before they are connected to runtime scope selection, provider enforcement, service binding, or Base1/Fyr integration.
+13. Confirm provider entries use [`CRYPTO_PROVIDER_TEMPLATE.md`](CRYPTO_PROVIDER_TEMPLATE.md) before they are connected to runtime behavior.
+14. Confirm profile docs follow [`crypto-profiles/README.md`](crypto-profiles/README.md) before they are connected to runtime behavior.
+15. Confirm crypto operator commands follow [`CRYPTO_OPERATOR_COMMANDS.md`](CRYPTO_OPERATOR_COMMANDS.md) before they are connected to runtime behavior.
+16. Confirm crypto configuration follows [`CRYPTO_CONFIG_SCHEMA.md`](CRYPTO_CONFIG_SCHEMA.md) before it is connected to runtime behavior.
+17. Confirm crypto implementation follows [`CRYPTO_IMPLEMENTATION_PLAN.md`](CRYPTO_IMPLEMENTATION_PLAN.md) before it protects real data or runtime control points.
+18. Confirm no page claims secure OS replacement, bootable Base1 release, installer readiness, daily-driver readiness, recovery completion, cryptographic completeness, audit completion, certification, or quantum safety without linked evidence.
+19. Use [`REVIEW_GUIDE.md`](REVIEW_GUIDE.md) before approving safety-sensitive documentation.
 
 ## Security documentation rule
 

--- a/tests/security_crypto_chains_docs.rs
+++ b/tests/security_crypto_chains_docs.rs
@@ -1,0 +1,59 @@
+use std::fs;
+
+const CHAINS_DOC: &str = "docs/security/CRYPTO_CHAINS.md";
+
+#[test]
+fn crypto_chains_doc_exists_and_defines_scope() {
+    let doc = fs::read_to_string(CHAINS_DOC).expect("CRYPTO_CHAINS.md should exist");
+
+    assert!(doc.contains("# Crypto Chains"));
+    assert!(doc.contains("Status: planning"));
+    assert!(doc.contains("floors"));
+    assert!(doc.contains("nests"));
+    assert!(doc.contains("portals"));
+    assert!(doc.contains("future service contexts"));
+}
+
+#[test]
+fn crypto_chains_doc_defines_chain_relationships() {
+    let doc = fs::read_to_string(CHAINS_DOC).expect("CRYPTO_CHAINS.md should exist");
+
+    assert!(doc.contains("parent context"));
+    assert!(doc.contains("child context"));
+    assert!(doc.contains("selected crypto profile"));
+    assert!(doc.contains("selected crypto provider"));
+    assert!(doc.contains("selected crypto service family"));
+    assert!(doc.contains("allowed data scope"));
+    assert!(doc.contains("denied data scope"));
+}
+
+#[test]
+fn crypto_chains_doc_preserves_guardrails_and_non_claims() {
+    let doc = fs::read_to_string(CHAINS_DOC).expect("CRYPTO_CHAINS.md should exist");
+
+    assert!(doc.contains("planning records only"));
+    assert!(doc.contains("completed cryptographic isolation"));
+    assert!(doc.contains("hardware-backed secrecy"));
+    assert!(doc.contains("formal sandboxing"));
+    assert!(doc.contains("production-grade key management"));
+    assert!(doc.contains("certified cryptographic compliance"));
+    assert!(doc.contains("post-quantum security"));
+}
+
+#[test]
+fn crypto_chains_doc_defines_fail_closed_behavior() {
+    let doc = fs::read_to_string(CHAINS_DOC).expect("CRYPTO_CHAINS.md should exist");
+
+    assert!(doc.contains("fail-closed"));
+    assert!(doc.contains("deny the operation"));
+    assert!(doc.contains("silently falling back"));
+}
+
+#[test]
+fn crypto_chains_doc_links_related_crypto_docs() {
+    let doc = fs::read_to_string(CHAINS_DOC).expect("CRYPTO_CHAINS.md should exist");
+
+    assert!(doc.contains("CRYPTO_POLICY_ROADMAP.md"));
+    assert!(doc.contains("CRYPTO_PROVIDER_REGISTRY.md"));
+    assert!(doc.contains("CRYPTO_PROVIDER_SERVICE_MATRIX.md"));
+}

--- a/tests/security_crypto_policy_roadmap_docs.rs
+++ b/tests/security_crypto_policy_roadmap_docs.rs
@@ -149,6 +149,27 @@ fn crypto_policy_roadmap_links_all_profile_planning_docs() {
 }
 
 #[test]
+fn crypto_policy_roadmap_documents_crypto_chains() {
+    let roadmap = std::fs::read_to_string("docs/security/CRYPTO_POLICY_ROADMAP.md")
+        .expect("crypto policy roadmap");
+
+    for text in [
+        "Crypto chains",
+        "CRYPTO_CHAINS.md",
+        "profiles, providers, and services",
+        "floors, nests, portals",
+        "future Fyr automation scopes",
+        "planning records until runtime chain selection",
+        "Unknown chain contexts, unavailable providers, missing services, and unsupported profile combinations should fail closed.",
+        "Every crypto chain should follow [`CRYPTO_CHAINS.md`](CRYPTO_CHAINS.md)",
+        "Create crypto chains planning doc: [`CRYPTO_CHAINS.md`](CRYPTO_CHAINS.md).",
+        "Chain-aware profile and provider selection.",
+    ] {
+        assert!(roadmap.contains(text), "missing crypto chains roadmap text {text}: {roadmap}");
+    }
+}
+
+#[test]
 fn crypto_algorithm_template_defines_required_sections() {
     let template = std::fs::read_to_string("docs/security/CRYPTO_ALGORITHM_TEMPLATE.md")
         .expect("crypto algorithm template");
@@ -219,11 +240,17 @@ fn security_index_links_crypto_policy_surface() {
         "CRYPTO_POLICY_ROADMAP.md",
         "CRYPTO_REGISTRY.md",
         "CRYPTO_PROVIDER_REGISTRY.md",
+        "CRYPTO_PROVIDER_SERVICE_MATRIX.md",
+        "CRYPTO_CHAINS.md",
         "CRYPTO_OPERATOR_COMMANDS.md",
         "CRYPTO_CONFIG_SCHEMA.md",
         "CRYPTO_ALGORITHM_TEMPLATE.md",
         "crypto-profiles/README.md",
         "cryptographic completeness",
+        "crypto provider/service mappings",
+        "crypto chains",
+        "provider/service mappings follow [`CRYPTO_PROVIDER_SERVICE_MATRIX.md`](CRYPTO_PROVIDER_SERVICE_MATRIX.md)",
+        "crypto chains follow [`CRYPTO_CHAINS.md`](CRYPTO_CHAINS.md)",
         "algorithm pages use [`CRYPTO_ALGORITHM_TEMPLATE.md`](CRYPTO_ALGORITHM_TEMPLATE.md)",
         "provider entries are listed or planned through [`CRYPTO_PROVIDER_REGISTRY.md`](CRYPTO_PROVIDER_REGISTRY.md)",
         "crypto configuration follows [`CRYPTO_CONFIG_SCHEMA.md`](CRYPTO_CONFIG_SCHEMA.md)",

--- a/tests/security_crypto_provider_service_matrix_docs.rs
+++ b/tests/security_crypto_provider_service_matrix_docs.rs
@@ -1,0 +1,61 @@
+use std::fs;
+
+#[test]
+fn crypto_provider_service_matrix_exists_and_preserves_scope() {
+    let doc = fs::read_to_string("docs/security/CRYPTO_PROVIDER_SERVICE_MATRIX.md")
+        .expect("read crypto provider service matrix");
+
+    for required in [
+        "Phase1 and Base1",
+        "major reviewed open-source cryptographic systems",
+        "operator-selectable policy layer",
+        "documentation-first",
+        "does not approve runtime cryptographic protection",
+        "No provider, algorithm, profile, or service is runtime-approved",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}");
+    }
+}
+
+#[test]
+fn crypto_provider_service_matrix_lists_service_and_provider_families() {
+    let doc = fs::read_to_string("docs/security/CRYPTO_PROVIDER_SERVICE_MATRIX.md")
+        .expect("read crypto provider service matrix");
+
+    for required in [
+        "identity",
+        "storage",
+        "transport",
+        "update",
+        "logs-evidence",
+        "recovery",
+        "analysis",
+        "developer",
+        "RustCrypto ecosystem",
+        "OpenSSL/LibreSSL/BoringSSL family",
+        "libsodium family",
+        "post-quantum provider family",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}");
+    }
+}
+
+#[test]
+fn crypto_provider_service_matrix_preserves_guardrails_and_non_claims() {
+    let doc = fs::read_to_string("docs/security/CRYPTO_PROVIDER_SERVICE_MATRIX.md")
+        .expect("read crypto provider service matrix");
+
+    for required in [
+        "Prefer reviewed open-source providers",
+        "Reject custom security-critical primitives",
+        "Reject unknown providers",
+        "Fail closed",
+        "Avoid silent provider substitution",
+        "Require test vectors",
+        "does not claim",
+        "approved national-security crypto",
+        "production-ready cryptographic enforcement",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}");
+    }
+}

--- a/tests/security_crypto_provider_service_matrix_docs.rs
+++ b/tests/security_crypto_provider_service_matrix_docs.rs
@@ -41,6 +41,28 @@ fn crypto_provider_service_matrix_lists_service_and_provider_families() {
 }
 
 #[test]
+fn crypto_provider_service_matrix_links_crypto_chains() {
+    let doc = fs::read_to_string("docs/security/CRYPTO_PROVIDER_SERVICE_MATRIX.md")
+        .expect("read crypto provider service matrix");
+
+    for required in [
+        "Relationship to Crypto Chains",
+        "CRYPTO_CHAINS.md",
+        "The provider service matrix defines service families and candidate provider families.",
+        "Crypto Chains define how a future parent or child context may request a scoped combination",
+        "crypto profile",
+        "provider family",
+        "service family",
+        "data scope",
+        "audit behavior",
+        "fail-closed behavior",
+        "A chain must not bind to a provider/service pairing unless the pairing is documented in this matrix",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}");
+    }
+}
+
+#[test]
 fn crypto_provider_service_matrix_preserves_guardrails_and_non_claims() {
     let doc = fs::read_to_string("docs/security/CRYPTO_PROVIDER_SERVICE_MATRIX.md")
         .expect("read crypto provider service matrix");
@@ -55,6 +77,13 @@ fn crypto_provider_service_matrix_preserves_guardrails_and_non_claims() {
         "does not claim",
         "approved national-security crypto",
         "production-ready cryptographic enforcement",
+        "Unknown chain contexts, undocumented provider/service pairings, unavailable providers, missing services, and unsupported profile combinations should fail closed.",
+        "does not claim that Crypto Chains currently provide runtime isolation",
+        "provider enforcement",
+        "service binding",
+        "hardware-backed secrecy",
+        "certified cryptographic compliance",
+        "production-grade key management",
     ] {
         assert!(doc.contains(required), "missing {required:?}");
     }


### PR DESCRIPTION
## Summary

- Add the crypto provider service matrix planning surface.
- Add the Crypto Chains planning document for scoped cryptographic policy chaining.
- Link Crypto Chains from the crypto roadmap, security index, and provider/service matrix.
- Add docs tests that preserve navigation, guardrails, fail-closed behavior, and non-claims.

## Validation

Run locally before PR creation:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p phase1 --test security_crypto_provider_service_matrix_docs`
- `cargo test -p phase1 --test security_crypto_provider_registry_docs`
- `cargo test -p phase1 --test security_crypto_policy_roadmap_docs`
- `cargo test -p phase1 --test security_crypto_profiles_docs`
- `cargo test -p phase1 --test security_crypto_operator_commands_docs`

Additional docs tests added on branch:

- `cargo test -p phase1 --test security_crypto_chains_docs`

## Non-claims

This PR preserves the planning boundary. It does not claim runtime cryptographic isolation, provider enforcement, service binding, production-grade key management, certified cryptographic compliance, hardware-backed secrecy, post-quantum security, or production-ready cryptographic enforcement.