### PR TITLE
Add system integrity layer planning and SHA verifier

### DIFF
--- a/docs/security/SYSTEM_INTEGRITY_LAYER.md
+++ b/docs/security/SYSTEM_INTEGRITY_LAYER.md
@@ -1,0 +1,83 @@
+# Phase1 System Integrity Layer
+
+Status: planning
+Scope: native file integrity records, SHA-256 manifests, read-only validation, and operator-visible integrity reports
+
+## Purpose
+
+The system integrity layer defines how Phase1/Base1 can record and validate known file checksums for important project, runtime, documentation, fixture, and release surfaces.
+
+The goal is evidence-bound integrity reporting, not a broad claim that the entire system is secure.
+
+## Core model
+
+The planned integrity layer should use explicit manifests that list files, expected SHA-256 values, size information, source path, generation time, and validation status.
+
+A manifest can support:
+
+- release artifact review;
+- docs and fixture integrity checks;
+- Base1 recovery bundle review;
+- portal fixture review;
+- crypto policy document review;
+- future signed integrity reports.
+
+## Planned operator commands
+
+Future commands may include:
+
+```text
+integrity status
+integrity manifest create --dry-run
+integrity manifest verify --dry-run
+integrity file <path>
+integrity report
+```
+
+The first safe implementation should be read-only validation and report generation.
+
+## Validation behavior
+
+Integrity validation should report:
+
+- file path;
+- expected SHA-256;
+- observed SHA-256;
+- expected byte length;
+- observed byte length;
+- result label;
+- manifest source;
+- validation scope;
+- non-claims.
+
+Result labels should include:
+
+- ok;
+- changed;
+- missing;
+- extra;
+- unreadable;
+- manifest-invalid;
+- not-checked.
+
+## Safety rules
+
+- Prefer SHA-256 or stronger reviewed digest algorithms.
+- Do not use non-cryptographic checksums for security claims.
+- Do not silently repair changed files.
+- Do not delete extra files.
+- Do not rewrite manifests unless the operator explicitly requests a generation flow.
+- Keep validation read-only by default.
+- Fail closed when a required manifest is missing or malformed.
+
+## Relationship to Crypto Chains
+
+Crypto Chain status should eventually identify which integrity manifest was used to verify policy files, provider/service matrix files, fixtures, and chain records.
+
+A valid digest report does not prove runtime cryptographic enforcement.
+
+## Non-claims
+
+This document does not claim total system integrity, tamper-proof execution, hardware-backed measurement, secure boot, production hardening, certification, or complete compromise detection.
+
+It defines a planned native integrity reporting layer based on explicit manifests and SHA-256 validation.

--- a/docs/security/TEST_PLACEHOLDER.md
+++ b/docs/security/TEST_PLACEHOLDER.md
@@ -1,3 +1,0 @@
-# Test Placeholder
-
-Planning note.

--- a/docs/security/TEST_PLACEHOLDER.md
+++ b/docs/security/TEST_PLACEHOLDER.md
@@ -1,0 +1,3 @@
+# Test Placeholder
+
+Planning note.

--- a/scripts/phase1-integrity-verify.sh
+++ b/scripts/phase1-integrity-verify.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'HELP'
+phase1-integrity-verify.sh
+
+Read-only SHA-256 integrity report helper.
+
+Usage:
+  sh scripts/phase1-integrity-verify.sh --manifest <file>
+  sh scripts/phase1-integrity-verify.sh --file <path>
+
+Manifest format:
+  <sha256>  <relative-path>
+
+Safety:
+  - read-only
+  - no repair
+  - no deletion
+  - no manifest rewrite
+  - local files only
+HELP
+}
+
+if [ "$#" -eq 0 ]; then
+  usage
+  exit 0
+fi
+
+mode=""
+target=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --manifest|--file)
+      mode="$1"
+      shift
+      if [ "$#" -eq 0 ]; then
+        echo "error: missing value for $mode" >&2
+        exit 2
+      fi
+      target="$1"
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+sha_tool=""
+if command -v sha256sum >/dev/null 2>&1; then
+  sha_tool="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  sha_tool="shasum -a 256"
+else
+  echo "error: no SHA-256 tool found" >&2
+  exit 3
+fi
+
+hash_file() {
+  # shellcheck disable=SC2086
+  $sha_tool "$1" | awk '{print $1}'
+}
+
+case "$mode" in
+  --file)
+    if [ ! -f "$target" ]; then
+      echo "path: $target"
+      echo "result: missing"
+      exit 1
+    fi
+    echo "path: $target"
+    echo "sha256: $(hash_file "$target")"
+    echo "result: ok"
+    ;;
+  --manifest)
+    if [ ! -f "$target" ]; then
+      echo "manifest: $target"
+      echo "result: manifest-missing"
+      exit 1
+    fi
+    echo "manifest: $target"
+    failures=0
+    checked=0
+    while IFS= read -r line || [ -n "$line" ]; do
+      case "$line" in
+        ''|'#'*) continue ;;
+      esac
+      expected=$(printf '%s\n' "$line" | awk '{print $1}')
+      path=$(printf '%s\n' "$line" | cut -d' ' -f3-)
+      if ! printf '%s' "$expected" | grep -Eq '^[0-9a-fA-F]{64}$'; then
+        echo "result: manifest-invalid"
+        echo "line: $line"
+        exit 2
+      fi
+      if [ ! -f "$path" ]; then
+        echo "missing: $path"
+        failures=$((failures + 1))
+        continue
+      fi
+      observed=$(hash_file "$path")
+      checked=$((checked + 1))
+      if [ "$observed" = "$expected" ]; then
+        echo "ok: $path"
+      else
+        echo "changed: $path"
+        failures=$((failures + 1))
+      fi
+    done < "$target"
+    echo "checked: $checked"
+    echo "failures: $failures"
+    if [ "$failures" -eq 0 ]; then
+      echo "result: ok"
+    else
+      echo "result: changed"
+      exit 1
+    fi
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/scripts/phase1-integrity-verify.sh
+++ b/scripts/phase1-integrity-verify.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 usage() {
   cat <<'HELP'

--- a/tests/security_system_integrity_layer_docs.rs
+++ b/tests/security_system_integrity_layer_docs.rs
@@ -1,0 +1,76 @@
+use std::fs;
+
+const INTEGRITY_DOC: &str = "docs/security/SYSTEM_INTEGRITY_LAYER.md";
+
+#[test]
+fn system_integrity_layer_doc_exists_and_defines_scope() {
+    let doc = fs::read_to_string(INTEGRITY_DOC).expect("system integrity layer doc should exist");
+
+    for required in [
+        "Phase1 System Integrity Layer",
+        "Status: planning",
+        "native file integrity records",
+        "SHA-256 manifests",
+        "read-only validation",
+        "operator-visible integrity reports",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn system_integrity_layer_doc_defines_manifest_model() {
+    let doc = fs::read_to_string(INTEGRITY_DOC).expect("system integrity layer doc should exist");
+
+    for required in [
+        "expected SHA-256",
+        "observed SHA-256",
+        "expected byte length",
+        "observed byte length",
+        "manifest source",
+        "validation scope",
+        "release artifact review",
+        "Base1 recovery bundle review",
+        "future signed integrity reports",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn system_integrity_layer_doc_preserves_result_labels_and_safety_rules() {
+    let doc = fs::read_to_string(INTEGRITY_DOC).expect("system integrity layer doc should exist");
+
+    for required in [
+        "ok",
+        "changed",
+        "missing",
+        "extra",
+        "unreadable",
+        "manifest-invalid",
+        "not-checked",
+        "Do not silently repair changed files.",
+        "Do not delete extra files.",
+        "Keep validation read-only by default.",
+        "Fail closed when a required manifest is missing or malformed.",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn system_integrity_layer_doc_preserves_non_claims() {
+    let doc = fs::read_to_string(INTEGRITY_DOC).expect("system integrity layer doc should exist");
+
+    for required in [
+        "does not claim total system integrity",
+        "tamper-proof execution",
+        "hardware-backed measurement",
+        "secure boot",
+        "production hardening",
+        "certification",
+        "complete compromise detection",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}

--- a/tests/security_system_integrity_script.rs
+++ b/tests/security_system_integrity_script.rs
@@ -65,7 +65,10 @@ fn integrity_verify_file_reports_sha256_without_mutating_file() {
     assert!(ok, "script should pass: {output}");
     assert_eq!(before, after, "script must not mutate target file");
     assert!(output.contains("path:"), "{output}");
-    assert!(output.contains("sha256: 583c40a164e83290fdbf230004b813d4782ee3a128aba11bfeddb2c793ffbc3c"), "{output}");
+    assert!(
+        output.contains("sha256: 583c40a164e83290fdbf230004b813d4782ee3a128aba11bfeddb2c793ffbc3c"),
+        "{output}"
+    );
     assert!(output.contains("result: ok"), "{output}");
 }
 
@@ -103,7 +106,11 @@ fn integrity_verify_manifest_rejects_malformed_expected_hash() {
     let file = dir.join("sample.txt");
     let manifest = dir.join("manifest.sha256");
     fs::write(&file, "phase1\n").expect("write sample");
-    fs::write(&manifest, format!("not-a-sha256  {}\n", file.display())).expect("write manifest");
+    fs::write(
+        &manifest,
+        format!("not-a-sha256  {}\n", file.display()),
+    )
+    .expect("write manifest");
 
     let manifest_path = manifest.to_string_lossy().to_string();
     let (ok, output) = run_script(&["--manifest", &manifest_path]);

--- a/tests/security_system_integrity_script.rs
+++ b/tests/security_system_integrity_script.rs
@@ -1,0 +1,114 @@
+use std::fs;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn temp_dir(name: &str) -> std::path::PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let seq = RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("phase1-{name}-{nonce}-{seq}"));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+fn run_script(args: &[&str]) -> (bool, String) {
+    let output = Command::new("sh")
+        .arg("scripts/phase1-integrity-verify.sh")
+        .args(args)
+        .output()
+        .expect("run integrity script");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    (output.status.success(), text)
+}
+
+#[test]
+fn integrity_verify_script_exists_and_documents_read_only_scope() {
+    let script = fs::read_to_string("scripts/phase1-integrity-verify.sh")
+        .expect("integrity verifier script should exist");
+
+    for required in [
+        "Read-only SHA-256 integrity report helper.",
+        "--manifest <file>",
+        "--file <path>",
+        "read-only",
+        "no repair",
+        "no deletion",
+        "no manifest rewrite",
+        "local files only",
+    ] {
+        assert!(script.contains(required), "missing {required:?}: {script}");
+    }
+}
+
+#[test]
+fn integrity_verify_file_reports_sha256_without_mutating_file() {
+    let dir = temp_dir("integrity-file");
+    let file = dir.join("sample.txt");
+    fs::write(&file, "phase1\n").expect("write sample");
+
+    let before = fs::read(&file).expect("read before");
+    let path = file.to_string_lossy().to_string();
+    let (ok, output) = run_script(&["--file", &path]);
+    let after = fs::read(&file).expect("read after");
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(ok, "script should pass: {output}");
+    assert_eq!(before, after, "script must not mutate target file");
+    assert!(output.contains("path:"), "{output}");
+    assert!(output.contains("sha256: 583c40a164e83290fdbf230004b813d4782ee3a128aba11bfeddb2c793ffbc3c"), "{output}");
+    assert!(output.contains("result: ok"), "{output}");
+}
+
+#[test]
+fn integrity_verify_manifest_reports_changed_without_repair() {
+    let dir = temp_dir("integrity-manifest");
+    let file = dir.join("sample.txt");
+    let manifest = dir.join("manifest.sha256");
+    fs::write(&file, "changed\n").expect("write changed sample");
+    fs::write(
+        &manifest,
+        format!(
+            "583c40a164e83290fdbf230004b813d4782ee3a128aba11bfeddb2c793ffbc3c  {}\n",
+            file.display()
+        ),
+    )
+    .expect("write manifest");
+
+    let before = fs::read(&file).expect("read before");
+    let manifest_path = manifest.to_string_lossy().to_string();
+    let (ok, output) = run_script(&["--manifest", &manifest_path]);
+    let after = fs::read(&file).expect("read after");
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(!ok, "changed manifest should fail closed: {output}");
+    assert_eq!(before, after, "script must not repair changed target file");
+    assert!(output.contains("changed:"), "{output}");
+    assert!(output.contains("failures: 1"), "{output}");
+    assert!(output.contains("result: changed"), "{output}");
+}
+
+#[test]
+fn integrity_verify_manifest_rejects_malformed_expected_hash() {
+    let dir = temp_dir("integrity-invalid-manifest");
+    let file = dir.join("sample.txt");
+    let manifest = dir.join("manifest.sha256");
+    fs::write(&file, "phase1\n").expect("write sample");
+    fs::write(&manifest, format!("not-a-sha256  {}\n", file.display())).expect("write manifest");
+
+    let manifest_path = manifest.to_string_lossy().to_string();
+    let (ok, output) = run_script(&["--manifest", &manifest_path]);
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(!ok, "malformed manifest should fail: {output}");
+    assert!(output.contains("result: manifest-invalid"), "{output}");
+}

--- a/tests/security_system_integrity_script.rs
+++ b/tests/security_system_integrity_script.rs
@@ -106,11 +106,7 @@ fn integrity_verify_manifest_rejects_malformed_expected_hash() {
     let file = dir.join("sample.txt");
     let manifest = dir.join("manifest.sha256");
     fs::write(&file, "phase1\n").expect("write sample");
-    fs::write(
-        &manifest,
-        format!("not-a-sha256  {}\n", file.display()),
-    )
-    .expect("write manifest");
+    fs::write(&manifest, format!("not-a-sha256  {}\n", file.display())).expect("write manifest");
 
     let manifest_path = manifest.to_string_lossy().to_string();
     let (ok, output) = run_script(&["--manifest", &manifest_path]);


### PR DESCRIPTION
## Summary

- Adds `docs/security/SYSTEM_INTEGRITY_LAYER.md` for a planning-bound native integrity layer using explicit SHA-256 manifests.
- Adds `scripts/phase1-integrity-verify.sh`, a read-only local verifier for single files and manifest checks.
- Adds docs and script tests preserving read-only behavior, SHA-256 reporting, changed-file detection, malformed-manifest failure, and non-claims.

## Validation

Recommended local validation:

```sh
git fetch origin
git switch feature/crypto-chain-status-command
cargo fmt --all -- --check
cargo test -p phase1 --test security_system_integrity_layer_docs
cargo test -p phase1 --test security_system_integrity_script
```

## Non-claims

This PR does not claim total system integrity, tamper-proof execution, secure boot, hardware-backed measurement, production hardening, certification, or complete compromise detection. It adds a read-only integrity reporting foundation and keeps validation evidence-bound.