### PR TITLE
Add Optics PRO static preview fixture

### DIFF
--- a/docs/ui/OPTICS_PRO_UI.md
+++ b/docs/ui/OPTICS_PRO_UI.md
@@ -130,6 +130,14 @@ Fyr integration:
 - Fyr automation must not receive hidden UI-only state;
 - Fyr command output remains deterministic in tests.
 
+## Static preview fixture
+
+The first static preview fixture is [`fixtures/optics-pro-preview.txt`](fixtures/optics-pro-preview.txt).
+
+The fixture shows the intended minimal start state, bottom HUD rows, mutation-state labels, typing-safety boundaries, accessibility fallback labels, and non-claims.
+
+The fixture is read-only design evidence. It is not runtime UI wiring.
+
 ## Accessibility and fallback rules
 
 Optics PRO must preserve readable behavior when any of these are active:
@@ -187,4 +195,5 @@ It is a Phase1 user-interface profile and rendering model.
 ```sh
 cargo fmt --all -- --check
 cargo test -p phase1 --test optics_pro_ui_plan_docs
+cargo test -p phase1 --test optics_pro_preview_fixture_docs
 ```

--- a/docs/ui/fixtures/optics-pro-preview.txt
+++ b/docs/ui/fixtures/optics-pro-preview.txt
@@ -1,0 +1,60 @@
+OPTICS PRO PREVIEW
+status      static-fixture
+mode        read-only-preview
+runtime     not-wired
+profile     PRO
+codename    Optics
+channel     phase1 edge enabled
+surface     minimal-main-screen
+persistent  bottom-hud
+
+MAIN SCREEN
+phase1://edge/root >
+
+BOTTOM HUD
+product     Phase1
+context     root
+channel     edge
+hud-color   bright-blue
+state       ready
+input       active
+mutation    none
+command     none
+security    safe-mode visible
+host-tools  gated
+integrity   planned-read-only
+crypto      chain-status-planned
+base1       readiness/evidence context planned
+fyr         package/check/build/test/run context planned
+
+MUTATION STATES
+bright-blue ready
+cyan-pulse  command-being-typed
+violet      command-family-detected
+amber       guarded-operation-or-confirmation
+red         denied-failed-unsafe-invalid
+green       completed-successfully
+gray        inactive-disabled-unavailable
+
+TYPING PREVIEW
+raw-input   preserved
+history     preserves-operator-text
+parser      unchanged
+copy        unchanged
+hidden      none
+
+FALLBACK LABELS
+no-color    labels remain visible
+ascii       labels remain visible
+test-mode   deterministic output
+cooked      deterministic output
+
+NON-CLAIMS
+not-kernel
+not-compositor
+not-desktop
+not-terminal-emulator
+not-sandbox
+not-security-boundary
+not-crypto-enforcement
+not-base1-boot-environment

--- a/tests/optics_pro_preview_fixture_docs.rs
+++ b/tests/optics_pro_preview_fixture_docs.rs
@@ -1,0 +1,100 @@
+use std::fs;
+
+const OPTICS_DOC: &str = "docs/ui/OPTICS_PRO_UI.md";
+const PREVIEW_FIXTURE: &str = "docs/ui/fixtures/optics-pro-preview.txt";
+
+#[test]
+fn optics_preview_fixture_exists_and_is_linked() {
+    let doc = fs::read_to_string(OPTICS_DOC).expect("Optics PRO UI doc should exist");
+    let fixture = fs::read_to_string(PREVIEW_FIXTURE).expect("Optics PRO preview fixture should exist");
+
+    assert!(doc.contains("fixtures/optics-pro-preview.txt"), "{doc}");
+    assert!(doc.contains("read-only design evidence"), "{doc}");
+    assert!(fixture.contains("OPTICS PRO PREVIEW"), "{fixture}");
+    assert!(fixture.contains("runtime     not-wired"), "{fixture}");
+}
+
+#[test]
+fn optics_preview_fixture_preserves_minimal_start_state() {
+    let fixture = fs::read_to_string(PREVIEW_FIXTURE).expect("Optics PRO preview fixture should exist");
+
+    for required in [
+        "status      static-fixture",
+        "mode        read-only-preview",
+        "profile     PRO",
+        "codename    Optics",
+        "channel     phase1 edge enabled",
+        "surface     minimal-main-screen",
+        "persistent  bottom-hud",
+        "phase1://edge/root >",
+    ] {
+        assert!(fixture.contains(required), "missing {required:?}: {fixture}");
+    }
+}
+
+#[test]
+fn optics_preview_fixture_preserves_bottom_hud_rows() {
+    let fixture = fs::read_to_string(PREVIEW_FIXTURE).expect("Optics PRO preview fixture should exist");
+
+    for required in [
+        "BOTTOM HUD",
+        "product     Phase1",
+        "context     root",
+        "channel     edge",
+        "hud-color   bright-blue",
+        "state       ready",
+        "input       active",
+        "security    safe-mode visible",
+        "host-tools  gated",
+        "integrity   planned-read-only",
+        "crypto      chain-status-planned",
+        "base1       readiness/evidence context planned",
+        "fyr         package/check/build/test/run context planned",
+    ] {
+        assert!(fixture.contains(required), "missing {required:?}: {fixture}");
+    }
+}
+
+#[test]
+fn optics_preview_fixture_preserves_mutation_and_typing_labels() {
+    let fixture = fs::read_to_string(PREVIEW_FIXTURE).expect("Optics PRO preview fixture should exist");
+
+    for required in [
+        "MUTATION STATES",
+        "bright-blue ready",
+        "cyan-pulse  command-being-typed",
+        "violet      command-family-detected",
+        "amber       guarded-operation-or-confirmation",
+        "red         denied-failed-unsafe-invalid",
+        "green       completed-successfully",
+        "gray        inactive-disabled-unavailable",
+        "raw-input   preserved",
+        "history     preserves-operator-text",
+        "parser      unchanged",
+        "copy        unchanged",
+    ] {
+        assert!(fixture.contains(required), "missing {required:?}: {fixture}");
+    }
+}
+
+#[test]
+fn optics_preview_fixture_preserves_fallbacks_and_non_claims() {
+    let fixture = fs::read_to_string(PREVIEW_FIXTURE).expect("Optics PRO preview fixture should exist");
+
+    for required in [
+        "no-color    labels remain visible",
+        "ascii       labels remain visible",
+        "test-mode   deterministic output",
+        "cooked      deterministic output",
+        "not-kernel",
+        "not-compositor",
+        "not-desktop",
+        "not-terminal-emulator",
+        "not-sandbox",
+        "not-security-boundary",
+        "not-crypto-enforcement",
+        "not-base1-boot-environment",
+    ] {
+        assert!(fixture.contains(required), "missing {required:?}: {fixture}");
+    }
+}

--- a/tests/optics_pro_preview_fixture_docs.rs
+++ b/tests/optics_pro_preview_fixture_docs.rs
@@ -6,7 +6,8 @@ const PREVIEW_FIXTURE: &str = "docs/ui/fixtures/optics-pro-preview.txt";
 #[test]
 fn optics_preview_fixture_exists_and_is_linked() {
     let doc = fs::read_to_string(OPTICS_DOC).expect("Optics PRO UI doc should exist");
-    let fixture = fs::read_to_string(PREVIEW_FIXTURE).expect("Optics PRO preview fixture should exist");
+    let fixture =
+        fs::read_to_string(PREVIEW_FIXTURE).expect("Optics PRO preview fixture should exist");
 
     assert!(doc.contains("fixtures/optics-pro-preview.txt"), "{doc}");
     assert!(doc.contains("read-only design evidence"), "{doc}");
@@ -16,7 +17,8 @@ fn optics_preview_fixture_exists_and_is_linked() {
 
 #[test]
 fn optics_preview_fixture_preserves_minimal_start_state() {
-    let fixture = fs::read_to_string(PREVIEW_FIXTURE).expect("Optics PRO preview fixture should exist");
+    let fixture =
+        fs::read_to_string(PREVIEW_FIXTURE).expect("Optics PRO preview fixture should exist");
 
     for required in [
         "status      static-fixture",
@@ -28,13 +30,17 @@ fn optics_preview_fixture_preserves_minimal_start_state() {
         "persistent  bottom-hud",
         "phase1://edge/root >",
     ] {
-        assert!(fixture.contains(required), "missing {required:?}: {fixture}");
+        assert!(
+            fixture.contains(required),
+            "missing {required:?}: {fixture}"
+        );
     }
 }
 
 #[test]
 fn optics_preview_fixture_preserves_bottom_hud_rows() {
-    let fixture = fs::read_to_string(PREVIEW_FIXTURE).expect("Optics PRO preview fixture should exist");
+    let fixture =
+        fs::read_to_string(PREVIEW_FIXTURE).expect("Optics PRO preview fixture should exist");
 
     for required in [
         "BOTTOM HUD",
@@ -51,13 +57,17 @@ fn optics_preview_fixture_preserves_bottom_hud_rows() {
         "base1       readiness/evidence context planned",
         "fyr         package/check/build/test/run context planned",
     ] {
-        assert!(fixture.contains(required), "missing {required:?}: {fixture}");
+        assert!(
+            fixture.contains(required),
+            "missing {required:?}: {fixture}"
+        );
     }
 }
 
 #[test]
 fn optics_preview_fixture_preserves_mutation_and_typing_labels() {
-    let fixture = fs::read_to_string(PREVIEW_FIXTURE).expect("Optics PRO preview fixture should exist");
+    let fixture =
+        fs::read_to_string(PREVIEW_FIXTURE).expect("Optics PRO preview fixture should exist");
 
     for required in [
         "MUTATION STATES",
@@ -73,13 +83,17 @@ fn optics_preview_fixture_preserves_mutation_and_typing_labels() {
         "parser      unchanged",
         "copy        unchanged",
     ] {
-        assert!(fixture.contains(required), "missing {required:?}: {fixture}");
+        assert!(
+            fixture.contains(required),
+            "missing {required:?}: {fixture}"
+        );
     }
 }
 
 #[test]
 fn optics_preview_fixture_preserves_fallbacks_and_non_claims() {
-    let fixture = fs::read_to_string(PREVIEW_FIXTURE).expect("Optics PRO preview fixture should exist");
+    let fixture =
+        fs::read_to_string(PREVIEW_FIXTURE).expect("Optics PRO preview fixture should exist");
 
     for required in [
         "no-color    labels remain visible",
@@ -95,6 +109,9 @@ fn optics_preview_fixture_preserves_fallbacks_and_non_claims() {
         "not-crypto-enforcement",
         "not-base1-boot-environment",
     ] {
-        assert!(fixture.contains(required), "missing {required:?}: {fixture}");
+        assert!(
+            fixture.contains(required),
+            "missing {required:?}: {fixture}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds a static Optics PRO preview fixture for the minimal Phase1 edge start state and bright-blue bottom HUD model.
- Links the fixture from the Optics PRO design contract.
- Adds tests that preserve HUD rows, mutation labels, typed-command safety boundaries, fallback labels, and non-claims.

## Validation

Recommended local validation:

```sh
git fetch origin
git switch feature/ui-preview-contract
cargo fmt --all -- --check
cargo test -p phase1 --test optics_pro_ui_plan_docs
cargo test -p phase1 --test optics_pro_preview_fixture_docs
```

## Non-claims

This PR does not wire runtime UI behavior yet. The fixture is read-only design evidence and does not claim a new kernel, compositor, desktop, terminal emulator, sandbox, security boundary, cryptographic enforcement layer, or Base1 boot environment.