### PR TITLE
Add Optics HUD rail screen model

### DIFF
--- a/docs/ui/OPTICS_HUD_RAILS.md
+++ b/docs/ui/OPTICS_HUD_RAILS.md
@@ -1,0 +1,182 @@
+# Optics HUD Rails
+
+Status: design contract
+Scope: PRO screen real estate model, top HUD rail, bottom HUD rail, command viewport, and feature-density rules for Phase1, Base1, Fyr, nests, portals, ghosts, crypto chains, and integrity status.
+
+## Purpose
+
+Optics HUD Rails define how the PRO interface should use screen space without returning to a large boot-card or banner-heavy layout.
+
+The goal is more live information per screen while preserving a clean professional operator surface.
+
+## Core decision
+
+Optics PRO should use two persistent HUD rails:
+
+- a top HUD rail for global system state;
+- a bottom HUD rail for command input, mutation state, and active operation feedback.
+
+The center of the screen should remain the command/output viewport.
+
+## Top HUD rail
+
+The top rail should carry stable context that operators need at all times.
+
+Planned top rail fields:
+
+- product: Phase1, Base1, or Fyr;
+- channel: edge or stable;
+- profile: PRO;
+- context: root, nest, portal, ghost, analysis, recovery, Base1, or Fyr package;
+- trust: safe, armed, denied, or host-gated;
+- integrity: ok, changed, missing, not-checked, or planned;
+- crypto chain: active, planned, denied, or not-checked;
+- device: mobile, laptop, desktop, or terminal;
+- evidence level when Base1 validation is in view.
+
+The top rail should be compact, one or two text rows, and never consume the primary workspace.
+
+## Bottom HUD rail
+
+The bottom rail should carry live input and command activity.
+
+Planned bottom rail fields:
+
+- raw command input;
+- command family;
+- mutation state;
+- guarded-operation warning;
+- active task state;
+- last result state;
+- copy-safe command echo;
+- no-color fallback labels.
+
+The bottom rail is where bright-blue PRO HUD styling should be strongest.
+
+## Center viewport
+
+The center viewport is reserved for command output, reports, diagnostics, analysis, Fyr output, portal output, nest output, Base1 evidence, and integrity reports.
+
+The center viewport should not be crowded with permanent chrome.
+
+Persistent information belongs in the top or bottom rail unless it is directly part of command output.
+
+## Feature density model
+
+Optics PRO needs to surface many Phase1 features without flooding the screen.
+
+Feature state should be grouped by family:
+
+| Family | Examples | Rail placement |
+| --- | --- | --- |
+| context | root, nest, portal, ghost, analysis, recovery | top rail |
+| security | safe mode, host gate, trust state, denial state | top and bottom rail |
+| integrity | manifest status, file status, evidence status | top rail summary, center report detail |
+| crypto | crypto profile, chain status, provider/service status | top rail summary, center report detail |
+| Base1 | hardware, recovery, validation, artifact evidence | top rail summary, center report detail |
+| Fyr | package, check, build, test, run, automation | top rail summary, bottom active task |
+| command | typed command, command family, mutation color | bottom rail |
+| result | ok, changed, denied, failed, warning | bottom rail and center detail |
+
+## Nests, portals, and ghosts
+
+Nests, portals, and ghosts should appear as context indicators, not decorative panels.
+
+Examples:
+
+```text
+TOP  Phase1 edge | PRO | ctx=root > nest:0/1 | portal:none | ghost:none | trust=safe
+BOT  ready | input=active | mutation=none | command=none
+```
+
+When a portal, nest, or ghost becomes active, the top rail should update the context path.
+
+The bottom rail should only change when the operator is typing, executing, or receiving a result.
+
+## Crypto chains and integrity
+
+Crypto chain and integrity indicators should be compact by default.
+
+Examples:
+
+```text
+crypto=chain-planned integrity=not-checked
+crypto=denied integrity=changed
+crypto=active integrity=ok
+```
+
+A rail indicator must not imply runtime enforcement unless the backing implementation and tests exist.
+
+Detailed crypto or integrity output belongs in the center viewport.
+
+## Mobile, laptop, and desktop behavior
+
+Optics HUD Rails must adapt to device profile.
+
+- mobile: use one-line top rail and one-line bottom rail;
+- laptop: use one compact top rail and one or two bottom rows;
+- desktop: allow a two-row top rail and two-row bottom rail;
+- ASCII/no-color: preserve all labels without color.
+
+The center viewport remains the largest area on all device profiles.
+
+## Color model
+
+The default rail color is bright blue.
+
+Mutation colors are allowed only as visible state cues:
+
+- cyan for typing;
+- violet for command-family recognition;
+- amber for guarded or confirmation-needed operations;
+- red for denied, failed, unsafe, invalid, or changed integrity state;
+- green for successful completion;
+- gray for inactive, disabled, unavailable, or not checked.
+
+Every color cue must also have a text label.
+
+## Safety rules
+
+HUD rails must not:
+
+- hide command output;
+- rewrite command input;
+- change parser behavior;
+- change command history;
+- hide dangerous commands;
+- imply security hardening by visual style;
+- imply crypto enforcement from a planned crypto chain;
+- imply total system integrity from a hash check;
+- imply Base1 boot readiness without evidence.
+
+## Runtime integration phases
+
+### Phase 1: HUD rail contract
+
+- Add this document.
+- Add tests for screen real estate, rail responsibilities, feature grouping, and non-claims.
+
+### Phase 2: static rail preview
+
+- Add a static top/bottom rail fixture.
+- Keep output deterministic and read-only.
+
+### Phase 3: renderer module
+
+- Add a small renderer that can produce no-color, ASCII-safe top and bottom rail strings.
+- Keep it test-only or explicitly gated.
+
+### Phase 4: shell preview command
+
+- Add a preview command that prints the rail layout without changing the active shell UI.
+
+### Phase 5: live activation gate
+
+- Gate live PRO rail activation behind explicit config or environment flags.
+- Keep default behavior unchanged until the rail renderer has coverage across Phase1, Base1, and Fyr flows.
+
+## Non-claims
+
+Optics HUD Rails are not a compositor, terminal emulator, sandbox, security boundary, cryptographic enforcement layer, system integrity guarantee, or Base1 boot environment.
+
+They are a screen real estate and rendering contract for the Optics PRO interface.

--- a/docs/ui/OPTICS_PRO_UI.md
+++ b/docs/ui/OPTICS_PRO_UI.md
@@ -1,7 +1,7 @@
 # Optics PRO UI overhaul
 
 Status: design contract
-Scope: Phase1 PRO operator interface, bottom HUD model, input mutation visuals, and integration boundaries for Phase1, Base1, and Fyr.
+Scope: Phase1 PRO operator interface, top and bottom HUD rail model, input mutation visuals, and integration boundaries for Phase1, Base1, and Fyr.
 
 ## Codename
 
@@ -15,7 +15,7 @@ Optics PRO defines a minimal professional advanced-operator interface for Phase1
 
 The interface should start clean with Phase1 edge enabled and keep the main screen quiet until the operator issues a command.
 
-The primary persistent visual element should be a bottom HUD.
+The primary persistent visual elements should be top and bottom HUD rails that preserve the center command/output viewport.
 
 ## Visual intent
 
@@ -28,7 +28,7 @@ The default screen should be minimal:
 - no constant full-screen animation by default;
 - no command-output distortion;
 - no unnecessary prompt clutter;
-- only the bottom HUD remains persistent.
+- only compact top and bottom HUD rails remain persistent.
 
 ## Starting state
 
@@ -40,19 +40,26 @@ The first visual state should communicate:
 - safe operator mode visible;
 - current context visible;
 - command input active;
-- bottom HUD online;
+- top HUD rail online;
+- bottom HUD rail online;
 - no broad security or hardening claim.
 
-## Bottom HUD
+## HUD rails
 
-The bottom HUD is the center of Optics PRO.
+The HUD rail screen real estate model is defined in [`OPTICS_HUD_RAILS.md`](OPTICS_HUD_RAILS.md).
 
-It should be bright blue by default and text-first for accessibility.
+Optics PRO should use:
+
+- a top HUD rail for global system state, context, trust, integrity, crypto chain, Base1, Fyr, nest, portal, and ghost summaries;
+- a center viewport for command output and detailed reports;
+- a bottom HUD rail for command input, mutation state, command family, active task, guarded-operation warnings, and last result state.
+
+The bottom HUD rail should be bright blue by default and text-first for accessibility.
 
 The HUD should eventually show:
 
 - active product: Phase1, Base1, or Fyr;
-- active context: root, portal, nest, analysis workspace, recovery workspace, or Fyr package;
+- active context: root, portal, nest, ghost, analysis workspace, recovery workspace, or Fyr package;
 - edge/stable channel;
 - safe mode / host tools status;
 - current command family;
@@ -111,8 +118,8 @@ Optics PRO must integrate with the current Phase1, Base1, and Fyr schemes.
 
 Phase1 integration:
 
-- shell prompt and bottom HUD share context state;
-- portal, nest, analysis, and security contexts remain visible;
+- shell prompt and HUD rails share context state;
+- portal, nest, ghost, analysis, and security contexts remain visible;
 - safe mode and host-tool gates stay explicit;
 - existing commands remain readable.
 
@@ -165,9 +172,10 @@ Fallback must retain all state labels without relying on color.
 - Show bottom HUD rows and fallback rows.
 - Keep output deterministic.
 
-### Phase 3: prompt and HUD adapter
+### Phase 3: HUD rails and renderer
 
-- Add a small rendering adapter for the PRO HUD.
+- Add the [`OPTICS_HUD_RAILS.md`](OPTICS_HUD_RAILS.md) design contract.
+- Add a small rendering adapter for top and bottom HUD rails.
 - Keep existing prompt modes available.
 - Gate activation behind explicit config or environment flags.
 
@@ -179,7 +187,7 @@ Fallback must retain all state labels without relying on color.
 
 ### Phase 5: Phase1/Base1/Fyr integration
 
-- Connect portal/nest/analysis context labels.
+- Connect portal/nest/ghost/analysis context labels.
 - Connect Base1 readiness and integrity labels.
 - Connect Fyr package/check/build/test/run labels.
 - Keep all integrations evidence-bound and testable.
@@ -196,4 +204,5 @@ It is a Phase1 user-interface profile and rendering model.
 cargo fmt --all -- --check
 cargo test -p phase1 --test optics_pro_ui_plan_docs
 cargo test -p phase1 --test optics_pro_preview_fixture_docs
+cargo test -p phase1 --test optics_hud_rails_docs
 ```

--- a/tests/optics_hud_rails_docs.rs
+++ b/tests/optics_hud_rails_docs.rs
@@ -1,0 +1,118 @@
+use std::fs;
+
+const RAILS_DOC: &str = "docs/ui/OPTICS_HUD_RAILS.md";
+const OPTICS_DOC: &str = "docs/ui/OPTICS_PRO_UI.md";
+
+#[test]
+fn optics_hud_rails_doc_exists_and_defines_scope() {
+    let doc = fs::read_to_string(RAILS_DOC).expect("Optics HUD rails doc should exist");
+    let optics = fs::read_to_string(OPTICS_DOC).expect("Optics PRO UI doc should exist");
+
+    for required in [
+        "Optics HUD Rails",
+        "Status: design contract",
+        "PRO screen real estate model",
+        "top HUD rail",
+        "bottom HUD rail",
+        "command viewport",
+        "nests, portals, ghosts, crypto chains, and integrity status",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+    assert!(optics.contains("OPTICS_HUD_RAILS.md"), "{optics}");
+}
+
+#[test]
+fn optics_hud_rails_doc_defines_top_bottom_and_center_responsibilities() {
+    let doc = fs::read_to_string(RAILS_DOC).expect("Optics HUD rails doc should exist");
+
+    for required in [
+        "a top HUD rail for global system state",
+        "a bottom HUD rail for command input",
+        "The center of the screen should remain the command/output viewport.",
+        "The top rail should carry stable context",
+        "The bottom rail should carry live input and command activity.",
+        "The center viewport is reserved for command output",
+        "Persistent information belongs in the top or bottom rail",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn optics_hud_rails_doc_preserves_feature_density_groups() {
+    let doc = fs::read_to_string(RAILS_DOC).expect("Optics HUD rails doc should exist");
+
+    for required in [
+        "Feature density model",
+        "root, nest, portal, ghost, analysis, recovery",
+        "safe mode, host gate, trust state, denial state",
+        "manifest status, file status, evidence status",
+        "crypto profile, chain status, provider/service status",
+        "hardware, recovery, validation, artifact evidence",
+        "package, check, build, test, run, automation",
+        "typed command, command family, mutation color",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn optics_hud_rails_doc_covers_contexts_crypto_integrity_and_devices() {
+    let doc = fs::read_to_string(RAILS_DOC).expect("Optics HUD rails doc should exist");
+
+    for required in [
+        "Nests, portals, and ghosts",
+        "TOP  Phase1 edge | PRO | ctx=root > nest:0/1 | portal:none | ghost:none | trust=safe",
+        "Crypto chain and integrity indicators should be compact by default.",
+        "crypto=chain-planned integrity=not-checked",
+        "A rail indicator must not imply runtime enforcement",
+        "mobile: use one-line top rail and one-line bottom rail",
+        "laptop: use one compact top rail and one or two bottom rows",
+        "desktop: allow a two-row top rail and two-row bottom rail",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn optics_hud_rails_doc_preserves_color_accessibility_and_safety_rules() {
+    let doc = fs::read_to_string(RAILS_DOC).expect("Optics HUD rails doc should exist");
+
+    for required in [
+        "The default rail color is bright blue.",
+        "Every color cue must also have a text label.",
+        "hide command output",
+        "rewrite command input",
+        "change parser behavior",
+        "change command history",
+        "hide dangerous commands",
+        "imply security hardening by visual style",
+        "imply crypto enforcement from a planned crypto chain",
+        "imply total system integrity from a hash check",
+        "imply Base1 boot readiness without evidence",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn optics_hud_rails_doc_preserves_runtime_phases_and_non_claims() {
+    let doc = fs::read_to_string(RAILS_DOC).expect("Optics HUD rails doc should exist");
+
+    for required in [
+        "Phase 1: HUD rail contract",
+        "Phase 2: static rail preview",
+        "Phase 3: renderer module",
+        "Phase 4: shell preview command",
+        "Phase 5: live activation gate",
+        "not a compositor",
+        "terminal emulator",
+        "security boundary",
+        "cryptographic enforcement layer",
+        "system integrity guarantee",
+        "Base1 boot environment",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}

--- a/tests/optics_pro_ui_plan_docs.rs
+++ b/tests/optics_pro_ui_plan_docs.rs
@@ -12,7 +12,7 @@ fn optics_pro_doc_exists_and_defines_codename_scope() {
         "Optics is the codename",
         "PRO is the operator-facing interface profile",
         "Phase1 PRO operator interface",
-        "bottom HUD model",
+        "top and bottom HUD rail model",
         "Phase1, Base1, and Fyr",
     ] {
         assert!(doc.contains(required), "missing {required:?}: {doc}");
@@ -25,24 +25,29 @@ fn optics_pro_doc_preserves_minimal_ui_and_start_state() {
 
     for required in [
         "start clean with Phase1 edge enabled",
-        "only the bottom HUD remains persistent",
+        "only compact top and bottom HUD rails remain persistent",
         "no large boot card by default",
         "no wide decorative banners by default",
         "no constant full-screen animation by default",
         "no command-output distortion",
         "Phase1 edge active",
         "safe operator mode visible",
+        "top HUD rail online",
+        "bottom HUD rail online",
     ] {
         assert!(doc.contains(required), "missing {required:?}: {doc}");
     }
 }
 
 #[test]
-fn optics_pro_doc_defines_bottom_hud_and_mutation_colors() {
+fn optics_pro_doc_defines_hud_rails_and_mutation_colors() {
     let doc = fs::read_to_string(OPTICS_DOC).expect("Optics PRO UI doc should exist");
 
     for required in [
-        "The bottom HUD is the center of Optics PRO.",
+        "OPTICS_HUD_RAILS.md",
+        "a top HUD rail for global system state",
+        "a center viewport for command output and detailed reports",
+        "a bottom HUD rail for command input",
         "bright blue by default",
         "active product: Phase1, Base1, or Fyr",
         "input mutation state",
@@ -86,7 +91,7 @@ fn optics_pro_doc_defines_phase1_base1_fyr_integration() {
         "Phase1 integration",
         "Base1 integration",
         "Fyr integration",
-        "portal, nest, analysis, and security contexts remain visible",
+        "portal, nest, ghost, analysis, and security contexts remain visible",
         "Base1 state appears as readiness, recovery, validation, artifact, hardware, or evidence context",
         "Base1 non-claims remain visible",
         "Fyr package, check, build, test, and run phases can light the HUD",


### PR DESCRIPTION
## Summary

- Adds `docs/ui/OPTICS_HUD_RAILS.md` as the screen real estate model for Optics PRO.
- Updates the Optics PRO plan from a bottom-HUD-only model to compact top and bottom HUD rails with a protected center command/output viewport.
- Defines rail responsibilities for root/nest/portal/ghost context, security/trust, integrity, crypto chains, Base1, Fyr, command mutation, and result state.
- Adds tests preserving feature density, device behavior, color/text fallback, safety rules, runtime phases, and non-claims.

## Validation

Recommended local validation:

```sh
git fetch origin
git switch feature/ui-hud-rails
cargo fmt --all -- --check
cargo test -p phase1 --test optics_hud_rails_docs
cargo test -p phase1 --test optics_pro_ui_plan_docs
cargo test -p phase1 --test optics_pro_preview_fixture_docs
cargo test -p phase1 --test optics_pro_runtime_preview
```

## Non-claims

This PR does not activate the live UI rails yet. It is a rendering and screen real estate contract only. It does not claim a compositor, terminal emulator, sandbox, security boundary, cryptographic enforcement layer, total system integrity guarantee, or Base1 boot environment.