### PR TITLE
Add Optics HUD rail preview fixture

### DIFF
--- a/docs/ui/OPTICS_HUD_RAILS.md
+++ b/docs/ui/OPTICS_HUD_RAILS.md
@@ -18,6 +18,14 @@ Optics PRO should use two persistent HUD rails:
 
 The center of the screen should remain the command/output viewport.
 
+## Static rail preview fixture
+
+The first static rail preview fixture is [`fixtures/optics-hud-rails-preview.txt`](fixtures/optics-hud-rails-preview.txt).
+
+The fixture shows the intended top rail, center viewport, bottom rail, feature groups, device rules, accessibility labels, and non-claims.
+
+The fixture is read-only design evidence. It is not runtime UI wiring.
+
 ## Top HUD rail
 
 The top rail should carry stable context that operators need at all times.

--- a/docs/ui/fixtures/optics-hud-rails-preview.txt
+++ b/docs/ui/fixtures/optics-hud-rails-preview.txt
@@ -1,0 +1,65 @@
+OPTICS HUD RAILS PREVIEW
+status      static-fixture
+mode        read-only-preview
+runtime     not-wired
+profile     PRO
+codename    Optics
+layout      top-rail center-viewport bottom-rail
+
+TOP HUD
+product     Phase1
+channel     edge
+profile     PRO
+context     root > nest:0/1 > portal:none > ghost:none
+trust       safe/armed
+security    safe-mode host-gated
+integrity   not-checked
+crypto      chain-planned
+base1       evidence-planned
+fyr         idle
+vehicle     terminal
+
+CENTER VIEWPORT
+role        command-output
+chrome      none-permanent
+content     reports diagnostics analysis portal nest Base1 Fyr integrity crypto
+rule        center remains primary workspace
+sample      phase1://edge/root > optics rails preview
+
+BOTTOM HUD
+hud-color   bright-blue
+input       active
+mutation    none
+command     none
+family      none
+active-task idle
+last-result ok
+warning     none
+copy-safe   raw-command-preserved
+
+FEATURE GROUPS
+context     root nest portal ghost analysis recovery
+security    safe-mode host-gate trust denial
+integrity   manifest file evidence
+crypto      profile chain provider-service
+base1       hardware recovery validation artifact evidence
+fyr         package check build test run automation
+command     typed-input family mutation
+result      ok changed denied failed warning
+
+DEVICE RULES
+mobile      one-line-top one-line-bottom
+laptop      compact-top one-or-two-bottom
+desktop     two-row-top two-row-bottom
+ascii       labels-visible
+no-color    labels-visible
+
+NON-CLAIMS
+not-runtime-wired
+not-compositor
+not-terminal-emulator
+not-sandbox
+not-security-boundary
+not-crypto-enforcement
+not-system-integrity-guarantee
+not-base1-boot-environment

--- a/tests/optics_hud_rails_preview_fixture_docs.rs
+++ b/tests/optics_hud_rails_preview_fixture_docs.rs
@@ -15,7 +15,10 @@ fn optics_hud_rails_preview_fixture_exists_and_is_linked() {
     );
     assert!(doc.contains("read-only design evidence"), "{doc}");
     assert!(fixture.contains("OPTICS HUD RAILS PREVIEW"), "{fixture}");
-    assert!(fixture.contains("layout      top-rail center-viewport bottom-rail"), "{fixture}");
+    assert!(
+        fixture.contains("layout      top-rail center-viewport bottom-rail"),
+        "{fixture}"
+    );
     assert!(fixture.contains("runtime     not-wired"), "{fixture}");
 }
 

--- a/tests/optics_hud_rails_preview_fixture_docs.rs
+++ b/tests/optics_hud_rails_preview_fixture_docs.rs
@@ -1,0 +1,104 @@
+use std::fs;
+
+const RAILS_DOC: &str = "docs/ui/OPTICS_HUD_RAILS.md";
+const RAILS_FIXTURE: &str = "docs/ui/fixtures/optics-hud-rails-preview.txt";
+
+#[test]
+fn optics_hud_rails_preview_fixture_exists_and_is_linked() {
+    let doc = fs::read_to_string(RAILS_DOC).expect("Optics HUD rails doc should exist");
+    let fixture =
+        fs::read_to_string(RAILS_FIXTURE).expect("Optics HUD rails preview fixture should exist");
+
+    assert!(
+        doc.contains("fixtures/optics-hud-rails-preview.txt"),
+        "{doc}"
+    );
+    assert!(doc.contains("read-only design evidence"), "{doc}");
+    assert!(fixture.contains("OPTICS HUD RAILS PREVIEW"), "{fixture}");
+    assert!(fixture.contains("layout      top-rail center-viewport bottom-rail"), "{fixture}");
+    assert!(fixture.contains("runtime     not-wired"), "{fixture}");
+}
+
+#[test]
+fn optics_hud_rails_preview_fixture_preserves_top_center_bottom_layout() {
+    let fixture =
+        fs::read_to_string(RAILS_FIXTURE).expect("Optics HUD rails preview fixture should exist");
+
+    for required in [
+        "TOP HUD",
+        "product     Phase1",
+        "channel     edge",
+        "profile     PRO",
+        "context     root > nest:0/1 > portal:none > ghost:none",
+        "trust       safe/armed",
+        "security    safe-mode host-gated",
+        "integrity   not-checked",
+        "crypto      chain-planned",
+        "CENTER VIEWPORT",
+        "role        command-output",
+        "chrome      none-permanent",
+        "rule        center remains primary workspace",
+        "BOTTOM HUD",
+        "hud-color   bright-blue",
+        "input       active",
+        "mutation    none",
+        "active-task idle",
+    ] {
+        assert!(
+            fixture.contains(required),
+            "missing {required:?}: {fixture}"
+        );
+    }
+}
+
+#[test]
+fn optics_hud_rails_preview_fixture_preserves_feature_groups() {
+    let fixture =
+        fs::read_to_string(RAILS_FIXTURE).expect("Optics HUD rails preview fixture should exist");
+
+    for required in [
+        "FEATURE GROUPS",
+        "context     root nest portal ghost analysis recovery",
+        "security    safe-mode host-gate trust denial",
+        "integrity   manifest file evidence",
+        "crypto      profile chain provider-service",
+        "base1       hardware recovery validation artifact evidence",
+        "fyr         package check build test run automation",
+        "command     typed-input family mutation",
+        "result      ok changed denied failed warning",
+    ] {
+        assert!(
+            fixture.contains(required),
+            "missing {required:?}: {fixture}"
+        );
+    }
+}
+
+#[test]
+fn optics_hud_rails_preview_fixture_preserves_device_rules_and_non_claims() {
+    let fixture =
+        fs::read_to_string(RAILS_FIXTURE).expect("Optics HUD rails preview fixture should exist");
+
+    for required in [
+        "DEVICE RULES",
+        "mobile      one-line-top one-line-bottom",
+        "laptop      compact-top one-or-two-bottom",
+        "desktop     two-row-top two-row-bottom",
+        "ascii       labels-visible",
+        "no-color    labels-visible",
+        "NON-CLAIMS",
+        "not-runtime-wired",
+        "not-compositor",
+        "not-terminal-emulator",
+        "not-sandbox",
+        "not-security-boundary",
+        "not-crypto-enforcement",
+        "not-system-integrity-guarantee",
+        "not-base1-boot-environment",
+    ] {
+        assert!(
+            fixture.contains(required),
+            "missing {required:?}: {fixture}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a static Optics HUD Rails preview fixture showing the top HUD, center viewport, and bottom HUD together.
- Links the fixture from `OPTICS_HUD_RAILS.md`.
- Adds tests preserving the rail layout, feature grouping, device rules, accessibility labels, and non-claims.

## Validation

Recommended local validation:

```sh
git fetch origin
git switch feature/ui-rail-preview
cargo fmt --all -- --check
cargo test -p phase1 --test optics_hud_rails_preview_fixture_docs
cargo test -p phase1 --test optics_hud_rails_docs
cargo test -p phase1 --test optics_pro_ui_plan_docs
cargo test -p phase1 --test optics_pro_preview_fixture_docs
cargo test -p phase1 --test optics_pro_runtime_preview
```

## Non-claims

This PR does not wire live HUD rails. It is read-only design evidence for screen real estate and layout behavior only. It does not claim a compositor, terminal emulator, sandbox, security boundary, crypto enforcement, system integrity guarantee, or Base1 boot environment.