### PR TITLE
Add Optics HUD rail renderer

### DIFF
--- a/src/optics.rs
+++ b/src/optics.rs
@@ -1,0 +1,144 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OpticsDeviceProfile {
+    Mobile,
+    Laptop,
+    Desktop,
+    Terminal,
+}
+
+impl OpticsDeviceProfile {
+    pub fn as_label(self) -> &'static str {
+        match self {
+            Self::Mobile => "mobile",
+            Self::Laptop => "laptop",
+            Self::Desktop => "desktop",
+            Self::Terminal => "terminal",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OpticsRailState {
+    pub product: String,
+    pub channel: String,
+    pub profile: String,
+    pub context: String,
+    pub trust: String,
+    pub security: String,
+    pub integrity: String,
+    pub crypto: String,
+    pub base1: String,
+    pub fyr: String,
+    pub device: OpticsDeviceProfile,
+    pub input: String,
+    pub mutation: String,
+    pub command_family: String,
+    pub active_task: String,
+    pub last_result: String,
+    pub warning: String,
+}
+
+impl OpticsRailState {
+    pub fn pro_static(device: OpticsDeviceProfile) -> Self {
+        Self {
+            product: "Phase1".to_string(),
+            channel: "edge".to_string(),
+            profile: "PRO".to_string(),
+            context: "root > nest:0/1 > portal:none > ghost:none".to_string(),
+            trust: "safe/armed".to_string(),
+            security: "safe-mode host-gated".to_string(),
+            integrity: "not-checked".to_string(),
+            crypto: "chain-planned".to_string(),
+            base1: "evidence-planned".to_string(),
+            fyr: "idle".to_string(),
+            device,
+            input: "active".to_string(),
+            mutation: "none".to_string(),
+            command_family: "none".to_string(),
+            active_task: "idle".to_string(),
+            last_result: "ok".to_string(),
+            warning: "none".to_string(),
+        }
+    }
+}
+
+pub fn render_top_rail(state: &OpticsRailState) -> String {
+    match state.device {
+        OpticsDeviceProfile::Mobile => format!(
+            "TOP product={} channel={} profile={} ctx={} trust={}\n",
+            state.product, state.channel, state.profile, state.context, state.trust
+        ),
+        OpticsDeviceProfile::Laptop | OpticsDeviceProfile::Terminal => format!(
+            "TOP product={} channel={} profile={} ctx={} trust={} security={}\nTOP integrity={} crypto={} base1={} fyr={} device={}\n",
+            state.product,
+            state.channel,
+            state.profile,
+            state.context,
+            state.trust,
+            state.security,
+            state.integrity,
+            state.crypto,
+            state.base1,
+            state.fyr,
+            state.device.as_label()
+        ),
+        OpticsDeviceProfile::Desktop => format!(
+            "TOP product={} channel={} profile={} ctx={} trust={} security={}\nTOP integrity={} crypto={} base1={} fyr={} device={} evidence=planned\n",
+            state.product,
+            state.channel,
+            state.profile,
+            state.context,
+            state.trust,
+            state.security,
+            state.integrity,
+            state.crypto,
+            state.base1,
+            state.fyr,
+            state.device.as_label()
+        ),
+    }
+}
+
+pub fn render_center_viewport(sample: &str) -> String {
+    format!(
+        "CENTER role=command-output chrome=none-permanent\nCENTER rule=center-remains-primary-workspace\nCENTER sample={}\n",
+        sample
+    )
+}
+
+pub fn render_bottom_rail(state: &OpticsRailState) -> String {
+    match state.device {
+        OpticsDeviceProfile::Mobile => format!(
+            "BOT color=bright-blue input={} mutation={} result={}\n",
+            state.input, state.mutation, state.last_result
+        ),
+        OpticsDeviceProfile::Laptop | OpticsDeviceProfile::Terminal => format!(
+            "BOT color=bright-blue input={} mutation={} command={} task={} result={}\nBOT warning={} copy-safe=raw-command-preserved\n",
+            state.input,
+            state.mutation,
+            state.command_family,
+            state.active_task,
+            state.last_result,
+            state.warning
+        ),
+        OpticsDeviceProfile::Desktop => format!(
+            "BOT color=bright-blue input={} mutation={} command={} task={} result={}\nBOT warning={} copy-safe=raw-command-preserved labels=no-color/ascii-visible\n",
+            state.input,
+            state.mutation,
+            state.command_family,
+            state.active_task,
+            state.last_result,
+            state.warning
+        ),
+    }
+}
+
+pub fn render_static_preview(device: OpticsDeviceProfile) -> String {
+    let state = OpticsRailState::pro_static(device);
+    let mut out = String::from("OPTICS HUD RAIL RENDER\nstatus=static-render\nruntime=not-wired\n");
+    out.push_str(&render_top_rail(&state));
+    out.push_str(&render_center_viewport("phase1://edge/root > optics rails preview"));
+    out.push_str(&render_bottom_rail(&state));
+    out.push_str("NON-CLAIMS not-compositor not-terminal-emulator not-sandbox not-security-boundary not-crypto-enforcement not-system-integrity-guarantee not-base1-boot-environment\n");
+    out
+}

--- a/src/optics.rs
+++ b/src/optics.rs
@@ -137,7 +137,9 @@ pub fn render_static_preview(device: OpticsDeviceProfile) -> String {
     let state = OpticsRailState::pro_static(device);
     let mut out = String::from("OPTICS HUD RAIL RENDER\nstatus=static-render\nruntime=not-wired\n");
     out.push_str(&render_top_rail(&state));
-    out.push_str(&render_center_viewport("phase1://edge/root > optics rails preview"));
+    out.push_str(&render_center_viewport(
+        "phase1://edge/root > optics rails preview",
+    ));
     out.push_str(&render_bottom_rail(&state));
     out.push_str("NON-CLAIMS not-compositor not-terminal-emulator not-sandbox not-security-boundary not-crypto-enforcement not-system-integrity-guarantee not-base1-boot-environment\n");
     out

--- a/tests/optics_hud_rail_renderer.rs
+++ b/tests/optics_hud_rail_renderer.rs
@@ -1,7 +1,10 @@
 #[path = "../src/optics.rs"]
 mod optics;
 
-use optics::{render_bottom_rail, render_static_preview, render_top_rail, OpticsDeviceProfile, OpticsRailState};
+use optics::{
+    render_bottom_rail, render_static_preview, render_top_rail, OpticsDeviceProfile,
+    OpticsRailState,
+};
 
 #[test]
 fn optics_renderer_static_preview_preserves_top_center_bottom_contract() {
@@ -21,7 +24,10 @@ fn optics_renderer_static_preview_preserves_top_center_bottom_contract() {
         "copy-safe=raw-command-preserved",
         "labels=no-color/ascii-visible",
     ] {
-        assert!(preview.contains(required), "missing {required:?}: {preview}");
+        assert!(
+            preview.contains(required),
+            "missing {required:?}: {preview}"
+        );
     }
 }
 
@@ -31,9 +37,18 @@ fn optics_renderer_keeps_rails_deterministic_and_ascii_safe() {
     let second = render_static_preview(OpticsDeviceProfile::Terminal);
 
     assert_eq!(first, second, "static renderer must be deterministic");
-    assert!(first.is_ascii(), "static renderer should be ASCII-safe: {first}");
-    assert!(!first.contains('\u{1b}'), "renderer should not emit ANSI escapes by default");
-    assert!(!first.contains('╭'), "renderer should not emit box drawing by default");
+    assert!(
+        first.is_ascii(),
+        "static renderer should be ASCII-safe: {first}"
+    );
+    assert!(
+        !first.contains('\u{1b}'),
+        "renderer should not emit ANSI escapes by default"
+    );
+    assert!(
+        !first.contains('╭'),
+        "renderer should not emit box drawing by default"
+    );
 }
 
 #[test]
@@ -43,13 +58,25 @@ fn optics_renderer_adapts_device_density_without_changing_state_meaning() {
     let desktop = render_static_preview(OpticsDeviceProfile::Desktop);
 
     assert!(mobile.contains("BOT color=bright-blue input=active mutation=none result=ok"));
-    assert!(!mobile.contains("BOT warning="), "mobile should stay one-line bottom rail: {mobile}");
+    assert!(
+        !mobile.contains("BOT warning="),
+        "mobile should stay one-line bottom rail: {mobile}"
+    );
 
     assert!(laptop.contains("device=laptop"), "{laptop}");
-    assert!(laptop.contains("BOT warning=none copy-safe=raw-command-preserved"), "{laptop}");
+    assert!(
+        laptop.contains("BOT warning=none copy-safe=raw-command-preserved"),
+        "{laptop}"
+    );
 
-    assert!(desktop.contains("device=desktop evidence=planned"), "{desktop}");
-    assert!(desktop.contains("labels=no-color/ascii-visible"), "{desktop}");
+    assert!(
+        desktop.contains("device=desktop evidence=planned"),
+        "{desktop}"
+    );
+    assert!(
+        desktop.contains("labels=no-color/ascii-visible"),
+        "{desktop}"
+    );
 }
 
 #[test]
@@ -67,7 +94,10 @@ fn optics_renderer_custom_state_preserves_command_and_safety_labels() {
     let top = render_top_rail(&state);
     let bottom = render_bottom_rail(&state);
 
-    assert!(top.contains("ctx=root > portal:alpha > ghost:watch"), "{top}");
+    assert!(
+        top.contains("ctx=root > portal:alpha > ghost:watch"),
+        "{top}"
+    );
     assert!(top.contains("integrity=changed"), "{top}");
     assert!(top.contains("crypto=denied"), "{top}");
     assert!(bottom.contains("mutation=typing"), "{bottom}");
@@ -90,6 +120,9 @@ fn optics_renderer_preserves_non_claims() {
         "not-system-integrity-guarantee",
         "not-base1-boot-environment",
     ] {
-        assert!(preview.contains(required), "missing {required:?}: {preview}");
+        assert!(
+            preview.contains(required),
+            "missing {required:?}: {preview}"
+        );
     }
 }

--- a/tests/optics_hud_rail_renderer.rs
+++ b/tests/optics_hud_rail_renderer.rs
@@ -1,0 +1,95 @@
+#[path = "../src/optics.rs"]
+mod optics;
+
+use optics::{render_bottom_rail, render_static_preview, render_top_rail, OpticsDeviceProfile, OpticsRailState};
+
+#[test]
+fn optics_renderer_static_preview_preserves_top_center_bottom_contract() {
+    let preview = render_static_preview(OpticsDeviceProfile::Desktop);
+
+    for required in [
+        "OPTICS HUD RAIL RENDER",
+        "status=static-render",
+        "runtime=not-wired",
+        "TOP product=Phase1 channel=edge profile=PRO",
+        "ctx=root > nest:0/1 > portal:none > ghost:none",
+        "integrity=not-checked",
+        "crypto=chain-planned",
+        "CENTER role=command-output chrome=none-permanent",
+        "CENTER rule=center-remains-primary-workspace",
+        "BOT color=bright-blue input=active mutation=none",
+        "copy-safe=raw-command-preserved",
+        "labels=no-color/ascii-visible",
+    ] {
+        assert!(preview.contains(required), "missing {required:?}: {preview}");
+    }
+}
+
+#[test]
+fn optics_renderer_keeps_rails_deterministic_and_ascii_safe() {
+    let first = render_static_preview(OpticsDeviceProfile::Terminal);
+    let second = render_static_preview(OpticsDeviceProfile::Terminal);
+
+    assert_eq!(first, second, "static renderer must be deterministic");
+    assert!(first.is_ascii(), "static renderer should be ASCII-safe: {first}");
+    assert!(!first.contains('\u{1b}'), "renderer should not emit ANSI escapes by default");
+    assert!(!first.contains('╭'), "renderer should not emit box drawing by default");
+}
+
+#[test]
+fn optics_renderer_adapts_device_density_without_changing_state_meaning() {
+    let mobile = render_static_preview(OpticsDeviceProfile::Mobile);
+    let laptop = render_static_preview(OpticsDeviceProfile::Laptop);
+    let desktop = render_static_preview(OpticsDeviceProfile::Desktop);
+
+    assert!(mobile.contains("BOT color=bright-blue input=active mutation=none result=ok"));
+    assert!(!mobile.contains("BOT warning="), "mobile should stay one-line bottom rail: {mobile}");
+
+    assert!(laptop.contains("device=laptop"), "{laptop}");
+    assert!(laptop.contains("BOT warning=none copy-safe=raw-command-preserved"), "{laptop}");
+
+    assert!(desktop.contains("device=desktop evidence=planned"), "{desktop}");
+    assert!(desktop.contains("labels=no-color/ascii-visible"), "{desktop}");
+}
+
+#[test]
+fn optics_renderer_custom_state_preserves_command_and_safety_labels() {
+    let mut state = OpticsRailState::pro_static(OpticsDeviceProfile::Laptop);
+    state.context = "root > portal:alpha > ghost:watch".to_string();
+    state.integrity = "changed".to_string();
+    state.crypto = "denied".to_string();
+    state.mutation = "typing".to_string();
+    state.command_family = "crypto".to_string();
+    state.active_task = "verify".to_string();
+    state.last_result = "warning".to_string();
+    state.warning = "guarded-operation".to_string();
+
+    let top = render_top_rail(&state);
+    let bottom = render_bottom_rail(&state);
+
+    assert!(top.contains("ctx=root > portal:alpha > ghost:watch"), "{top}");
+    assert!(top.contains("integrity=changed"), "{top}");
+    assert!(top.contains("crypto=denied"), "{top}");
+    assert!(bottom.contains("mutation=typing"), "{bottom}");
+    assert!(bottom.contains("command=crypto"), "{bottom}");
+    assert!(bottom.contains("task=verify"), "{bottom}");
+    assert!(bottom.contains("result=warning"), "{bottom}");
+    assert!(bottom.contains("warning=guarded-operation"), "{bottom}");
+}
+
+#[test]
+fn optics_renderer_preserves_non_claims() {
+    let preview = render_static_preview(OpticsDeviceProfile::Desktop);
+
+    for required in [
+        "not-compositor",
+        "not-terminal-emulator",
+        "not-sandbox",
+        "not-security-boundary",
+        "not-crypto-enforcement",
+        "not-system-integrity-guarantee",
+        "not-base1-boot-environment",
+    ] {
+        assert!(preview.contains(required), "missing {required:?}: {preview}");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `src/optics.rs`, a deterministic Optics HUD rail renderer for top rail, center viewport, and bottom rail strings.
- Keeps the renderer no-color and ASCII-safe by default.
- Adds tests for deterministic output, device density behavior, custom context/command state, and non-claims.

## Validation

Recommended local validation:

```sh
git fetch origin
git switch feature/ui-rail-renderer
cargo fmt --all -- --check
cargo test -p phase1 --test optics_hud_rail_renderer
cargo test -p phase1 --test optics_hud_rails_preview_fixture_docs
cargo test -p phase1 --test optics_hud_rails_docs
cargo test -p phase1 --test optics_pro_runtime_preview
```

## Non-claims

This PR does not activate live Optics PRO rails in the shell. It adds a deterministic renderer module and test coverage only. It does not claim a compositor, terminal emulator, sandbox, security boundary, cryptographic enforcement layer, system integrity guarantee, or Base1 boot environment.