### PR TITLE
Add Optics HUD rails runtime preview

### DIFF
--- a/plugins/optics.wasi
+++ b/plugins/optics.wasi
@@ -51,6 +51,18 @@ stdout=ascii       labels remain visible
 stdout=test-mode   deterministic output
 stdout=cooked      deterministic output
 stdout=
+stdout=OPTICS HUD RAIL RENDER
+stdout=status=static-render
+stdout=runtime=not-wired
+stdout=TOP product=Phase1 channel=edge profile=PRO ctx=root > nest:0/1 > portal:none > ghost:none trust=safe/armed security=safe-mode host-gated
+stdout=TOP integrity=not-checked crypto=chain-planned base1=evidence-planned fyr=idle device=terminal
+stdout=CENTER role=command-output chrome=none-permanent
+stdout=CENTER rule=center-remains-primary-workspace
+stdout=CENTER sample=phase1://edge/root > optics rails preview
+stdout=BOT color=bright-blue input=active mutation=none command=none task=idle result=ok
+stdout=BOT warning=none copy-safe=raw-command-preserved
+stdout=NON-CLAIMS not-compositor not-terminal-emulator not-sandbox not-security-boundary not-crypto-enforcement not-system-integrity-guarantee not-base1-boot-environment
+stdout=
 stdout=NON-CLAIMS
 stdout=not-kernel
 stdout=not-compositor

--- a/tests/optics_hud_rails_runtime_preview.rs
+++ b/tests/optics_hud_rails_runtime_preview.rs
@@ -1,0 +1,77 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str) -> String {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_PERSISTENT_STATE", "0")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_NO_COLOR", "1")
+        .env("PHASE1_ASCII", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("phase1 output");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn optics_rails_preview_runs_through_read_only_wasi_lite_surface() {
+    let output = run_phase1("optics rails\nexit\n");
+
+    for required in [
+        "phase1 wasi run",
+        "plugin : optics",
+        "runtime: phase1-wasi-lite",
+        "sandbox: fs=virtual net=disabled host=blocked",
+        "cap    : none",
+        "args   : rails",
+        "OPTICS HUD RAIL RENDER",
+        "status=static-render",
+        "runtime=not-wired",
+        "TOP product=Phase1 channel=edge profile=PRO",
+        "ctx=root > nest:0/1 > portal:none > ghost:none",
+        "TOP integrity=not-checked crypto=chain-planned",
+        "CENTER role=command-output chrome=none-permanent",
+        "CENTER rule=center-remains-primary-workspace",
+        "CENTER sample=phase1://edge/root > optics rails preview",
+        "BOT color=bright-blue input=active mutation=none command=none task=idle result=ok",
+        "BOT warning=none copy-safe=raw-command-preserved",
+        "not-security-boundary",
+        "not-crypto-enforcement",
+        "not-system-integrity-guarantee",
+        "not-base1-boot-environment",
+        "status : ok",
+        "exit   : 0",
+    ] {
+        assert!(output.contains(required), "missing {required:?}:\n{output}");
+    }
+
+    for forbidden in [
+        "runtime=wired",
+        "security-boundary claimed",
+        "crypto-enforcement claimed",
+        "system-integrity-guarantee claimed",
+        "base1 boot environment claimed",
+        "host=enabled",
+    ] {
+        assert!(
+            !output.contains(forbidden),
+            "forbidden {forbidden:?}:\n{output}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Extends the existing `optics` WASI-lite preview surface with a static Optics HUD rail render section.
- Adds a runtime smoke test for `optics rails` proving the top rail, center viewport, and bottom rail preview is exposed through the existing read-only WASI-lite path.
- Preserves non-claims around live UI activation, security boundaries, crypto enforcement, system integrity guarantees, and Base1 boot environment readiness.

## Validation

Recommended local validation:

```sh
git fetch origin
git switch feature/ui-rails-command
cargo fmt --all -- --check
cargo test -p phase1 --test optics_hud_rails_runtime_preview
cargo test -p phase1 --test optics_hud_rail_renderer
cargo test -p phase1 --test optics_hud_rails_preview_fixture_docs
cargo test -p phase1 --test optics_pro_runtime_preview
```

## Non-claims

This PR does not activate live HUD rails in the shell. It exposes a read-only runtime preview through the existing WASI-lite plugin path only.