### PR TITLE
Add Optics command surface contract

### DIFF
--- a/docs/ui/OPTICS_COMMAND_SURFACE.md
+++ b/docs/ui/OPTICS_COMMAND_SURFACE.md
@@ -1,0 +1,88 @@
+# Optics Command Surface
+
+Status: command surface contract
+Scope: read-only Optics commands, WASI-lite preview routing, help/registry expectations, and non-claims for Optics PRO.
+
+## Purpose
+
+The Optics command surface defines how operators should discover and use Optics preview commands before live UI activation exists.
+
+The current command surface is intentionally read-only.
+
+## Current commands
+
+The current preview commands are routed through the existing WASI-lite plugin path:
+
+```text
+optics preview
+optics rails
+```
+
+The commands are available because `optics` is exposed as a WASI-lite plugin with capability `none`.
+
+## Command behavior
+
+`optics preview` should show the original Optics PRO static preview:
+
+- minimal main screen;
+- Phase1 edge enabled;
+- PRO profile;
+- bottom HUD preview;
+- mutation labels;
+- typing safety labels;
+- fallback labels;
+- non-claims.
+
+`optics rails` should show the rail preview surface:
+
+- top HUD rail;
+- center viewport;
+- bottom HUD rail;
+- context, nest, portal, ghost, integrity, crypto, Base1, and Fyr summaries;
+- read-only runtime status;
+- non-claims.
+
+## Help and registry expectation
+
+Future work should promote Optics into the regular command registry so it appears in help, completions, and manuals.
+
+The planned registry row should preserve this shape:
+
+```text
+optics [preview|rails|help]
+```
+
+Until that registry row exists, the WASI-lite route remains the safe preview path.
+
+## Safety rules
+
+Optics preview commands must not:
+
+- activate live HUD rails;
+- mutate shell state;
+- change parser behavior;
+- change command history;
+- hide command output;
+- claim a compositor;
+- claim a terminal emulator;
+- claim a sandbox;
+- claim a security boundary;
+- claim crypto enforcement;
+- claim a system integrity guarantee;
+- claim a Base1 boot environment.
+
+## Integration path
+
+The command surface should progress in this order:
+
+1. WASI-lite read-only preview.
+2. Command surface documentation and tests.
+3. Registry/help/manual visibility.
+4. Renderer-backed shell preview command.
+5. Explicitly gated live activation.
+
+## Current status
+
+This document preserves the command surface contract only.
+
+Live Optics PRO HUD activation remains future work.

--- a/docs/ui/OPTICS_PRO_UI.md
+++ b/docs/ui/OPTICS_PRO_UI.md
@@ -69,6 +69,19 @@ The HUD should eventually show:
 - crypto chain status when that surface exists;
 - error or denial state in plain text.
 
+## Command surface
+
+The current read-only command surface is defined in [`OPTICS_COMMAND_SURFACE.md`](OPTICS_COMMAND_SURFACE.md).
+
+Current preview routes are:
+
+```text
+optics preview
+optics rails
+```
+
+These routes are currently exposed through the WASI-lite plugin path and remain preview-only.
+
 ## Mutation colors
 
 Optics PRO may use mutation colors for active command activity.
@@ -205,4 +218,5 @@ cargo fmt --all -- --check
 cargo test -p phase1 --test optics_pro_ui_plan_docs
 cargo test -p phase1 --test optics_pro_preview_fixture_docs
 cargo test -p phase1 --test optics_hud_rails_docs
+cargo test -p phase1 --test optics_command_surface_docs
 ```

--- a/tests/optics_command_surface_docs.rs
+++ b/tests/optics_command_surface_docs.rs
@@ -1,0 +1,78 @@
+use std::fs;
+
+const COMMAND_DOC: &str = "docs/ui/OPTICS_COMMAND_SURFACE.md";
+const OPTICS_DOC: &str = "docs/ui/OPTICS_PRO_UI.md";
+
+#[test]
+fn optics_command_surface_doc_exists_and_is_linked() {
+    let doc = fs::read_to_string(COMMAND_DOC).expect("Optics command surface doc should exist");
+    let optics = fs::read_to_string(OPTICS_DOC).expect("Optics PRO UI doc should exist");
+
+    for required in [
+        "Optics Command Surface",
+        "Status: command surface contract",
+        "read-only Optics commands",
+        "WASI-lite preview routing",
+        "Optics PRO",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+    assert!(optics.contains("OPTICS_COMMAND_SURFACE.md"), "{optics}");
+}
+
+#[test]
+fn optics_command_surface_preserves_current_preview_routes() {
+    let doc = fs::read_to_string(COMMAND_DOC).expect("Optics command surface doc should exist");
+
+    for required in [
+        "optics preview",
+        "optics rails",
+        "WASI-lite plugin path",
+        "capability `none`",
+        "minimal main screen",
+        "Phase1 edge enabled",
+        "bottom HUD preview",
+        "top HUD rail",
+        "center viewport",
+        "bottom HUD rail",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn optics_command_surface_preserves_registry_expectation() {
+    let doc = fs::read_to_string(COMMAND_DOC).expect("Optics command surface doc should exist");
+
+    for required in [
+        "Future work should promote Optics into the regular command registry",
+        "help, completions, and manuals",
+        "optics [preview|rails|help]",
+        "Until that registry row exists, the WASI-lite route remains the safe preview path.",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn optics_command_surface_preserves_safety_rules_and_non_claims() {
+    let doc = fs::read_to_string(COMMAND_DOC).expect("Optics command surface doc should exist");
+
+    for required in [
+        "activate live HUD rails",
+        "mutate shell state",
+        "change parser behavior",
+        "change command history",
+        "hide command output",
+        "claim a compositor",
+        "claim a terminal emulator",
+        "claim a sandbox",
+        "claim a security boundary",
+        "claim crypto enforcement",
+        "claim a system integrity guarantee",
+        "claim a Base1 boot environment",
+        "Live Optics PRO HUD activation remains future work.",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}

--- a/tests/optics_pro_ui_plan_docs.rs
+++ b/tests/optics_pro_ui_plan_docs.rs
@@ -40,11 +40,15 @@ fn optics_pro_doc_preserves_minimal_ui_and_start_state() {
 }
 
 #[test]
-fn optics_pro_doc_defines_hud_rails_and_mutation_colors() {
+fn optics_pro_doc_defines_hud_rails_command_surface_and_mutation_colors() {
     let doc = fs::read_to_string(OPTICS_DOC).expect("Optics PRO UI doc should exist");
 
     for required in [
         "OPTICS_HUD_RAILS.md",
+        "OPTICS_COMMAND_SURFACE.md",
+        "optics preview",
+        "optics rails",
+        "WASI-lite plugin path",
         "a top HUD rail for global system state",
         "a center viewport for command output and detailed reports",
         "a bottom HUD rail for command input",


### PR DESCRIPTION
## Summary

- Adds `docs/ui/OPTICS_COMMAND_SURFACE.md` for the read-only Optics preview command surface.
- Links the command surface from the Optics PRO plan.
- Preserves the current WASI-lite preview routes: `optics preview` and `optics rails`.
- Documents the future registry/help/manual promotion path without claiming live HUD activation.
- Adds docs tests for routes, registry expectations, safety rules, and non-claims.

## Validation

Recommended local validation:

```sh
git fetch origin
git switch feature/ui-optics-help
cargo fmt --all -- --check
cargo test -p phase1 --test optics_command_surface_docs
cargo test -p phase1 --test optics_pro_ui_plan_docs
cargo test -p phase1 --test optics_hud_rails_runtime_preview
cargo test -p phase1 --test optics_hud_rail_renderer
```

## Non-claims

This PR does not activate live Optics PRO HUD rails, promote Optics into the registry yet, or claim a compositor, terminal emulator, sandbox, security boundary, crypto enforcement, system integrity guarantee, or Base1 boot environment.