### PR TITLE
Add Optics registry promotion plan

### DIFF
--- a/docs/ui/OPTICS_COMMAND_SURFACE.md
+++ b/docs/ui/OPTICS_COMMAND_SURFACE.md
@@ -46,6 +46,8 @@ The commands are available because `optics` is exposed as a WASI-lite plugin wit
 
 Future work should promote Optics into the regular command registry so it appears in help, completions, and manuals.
 
+The registry-promotion plan is [`OPTICS_REGISTRY_PROMOTION.md`](OPTICS_REGISTRY_PROMOTION.md).
+
 The planned registry row should preserve this shape:
 
 ```text
@@ -77,9 +79,10 @@ The command surface should progress in this order:
 
 1. WASI-lite read-only preview.
 2. Command surface documentation and tests.
-3. Registry/help/manual visibility.
-4. Renderer-backed shell preview command.
-5. Explicitly gated live activation.
+3. Registry-promotion contract: [`OPTICS_REGISTRY_PROMOTION.md`](OPTICS_REGISTRY_PROMOTION.md).
+4. Registry/help/manual visibility.
+5. Renderer-backed shell preview command.
+6. Explicitly gated live activation.
 
 ## Current status
 

--- a/docs/ui/OPTICS_REGISTRY_PROMOTION.md
+++ b/docs/ui/OPTICS_REGISTRY_PROMOTION.md
@@ -1,0 +1,91 @@
+# Optics Registry Promotion
+
+Status: promotion plan
+Scope: moving Optics from WASI-lite preview-only routing into Phase1 command registry, help, completion, and manual visibility.
+
+## Purpose
+
+Optics currently works through the read-only WASI-lite plugin route.
+
+The next promotion step is to make Optics discoverable from the normal Phase1 command registry without changing live UI behavior.
+
+## Current safe routes
+
+```text
+optics preview
+optics rails
+```
+
+These routes remain preview-only and run through the existing `optics` WASI-lite plugin with capability `none`.
+
+## Target registry shape
+
+The future registry entry should use this command shape:
+
+```text
+optics [preview|rails|help]
+```
+
+Expected properties:
+
+- name: `optics`
+- aliases: `pro`, `hudrails`
+- category: `user` or `misc`
+- capability: `none`
+- description: read-only Optics PRO preview and HUD rail preview surface
+
+## Required discovery behavior
+
+After promotion, these should work:
+
+```text
+help optics
+man optics
+complete opt
+complete pro
+complete hud
+capabilities
+```
+
+The command map should make the Optics surface discoverable without implying live UI activation.
+
+## Runtime boundary
+
+Registry promotion must not activate live HUD rails.
+
+The command should keep routing to the existing read-only preview behavior until a separate renderer-backed shell command is explicitly added and tested.
+
+## Safety rules
+
+Registry promotion must not:
+
+- enable live HUD rails;
+- mutate shell state;
+- change parser behavior;
+- change command history;
+- hide command output;
+- claim a compositor;
+- claim a terminal emulator;
+- claim a sandbox;
+- claim a security boundary;
+- claim crypto enforcement;
+- claim a system integrity guarantee;
+- claim a Base1 boot environment.
+
+## Acceptance target
+
+A future implementation patch should add tests preserving:
+
+- `lookup("optics")` resolves to `optics`;
+- `canonical_name("pro")` resolves to `optics`;
+- `canonical_name("hudrails")` resolves to `optics`;
+- `completions("opt")` contains `optics`;
+- `completions("pro")` contains `pro`;
+- `man_page("optics")` contains `optics [preview|rails|help]`;
+- `capabilities_report()` lists `optics` with capability `none`.
+
+## Current status
+
+This document defines the registry-promotion contract only.
+
+Code-level registry promotion remains future work.

--- a/tests/optics_registry_promotion_docs.rs
+++ b/tests/optics_registry_promotion_docs.rs
@@ -52,12 +52,12 @@ fn optics_registry_promotion_doc_preserves_discovery_targets() {
         "complete pro",
         "complete hud",
         "capabilities",
-        "lookup(\"optics\") resolves to `optics`",
-        "canonical_name(\"pro\") resolves to `optics`",
-        "canonical_name(\"hudrails\") resolves to `optics`",
-        "completions(\"opt\") contains `optics`",
-        "man_page(\"optics\") contains `optics [preview|rails|help]`",
-        "capabilities_report() lists `optics` with capability `none`",
+        "`lookup(\"optics\")` resolves to `optics`",
+        "`canonical_name(\"pro\")` resolves to `optics`",
+        "`canonical_name(\"hudrails\")` resolves to `optics`",
+        "`completions(\"opt\")` contains `optics`",
+        "`man_page(\"optics\")` contains `optics [preview|rails|help]`",
+        "`capabilities_report()` lists `optics` with capability `none`",
     ] {
         assert!(doc.contains(required), "missing {required:?}: {doc}");
     }

--- a/tests/optics_registry_promotion_docs.rs
+++ b/tests/optics_registry_promotion_docs.rs
@@ -1,0 +1,82 @@
+use std::fs;
+
+const PROMOTION_DOC: &str = "docs/ui/OPTICS_REGISTRY_PROMOTION.md";
+const COMMAND_DOC: &str = "docs/ui/OPTICS_COMMAND_SURFACE.md";
+
+#[test]
+fn optics_registry_promotion_doc_exists_and_is_linked() {
+    let doc = fs::read_to_string(PROMOTION_DOC).expect("Optics registry promotion doc should exist");
+    let command = fs::read_to_string(COMMAND_DOC).expect("Optics command surface doc should exist");
+
+    for required in [
+        "Optics Registry Promotion",
+        "Status: promotion plan",
+        "command registry, help, completion, and manual visibility",
+        "Optics currently works through the read-only WASI-lite plugin route.",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+    assert!(command.contains("OPTICS_REGISTRY_PROMOTION.md"), "{command}");
+}
+
+#[test]
+fn optics_registry_promotion_doc_preserves_target_command_shape() {
+    let doc = fs::read_to_string(PROMOTION_DOC).expect("Optics registry promotion doc should exist");
+
+    for required in [
+        "optics preview",
+        "optics rails",
+        "optics [preview|rails|help]",
+        "aliases: `pro`, `hudrails`",
+        "capability: `none`",
+        "read-only Optics PRO preview and HUD rail preview surface",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn optics_registry_promotion_doc_preserves_discovery_targets() {
+    let doc = fs::read_to_string(PROMOTION_DOC).expect("Optics registry promotion doc should exist");
+
+    for required in [
+        "help optics",
+        "man optics",
+        "complete opt",
+        "complete pro",
+        "complete hud",
+        "capabilities",
+        "lookup(\"optics\") resolves to `optics`",
+        "canonical_name(\"pro\") resolves to `optics`",
+        "canonical_name(\"hudrails\") resolves to `optics`",
+        "completions(\"opt\") contains `optics`",
+        "man_page(\"optics\") contains `optics [preview|rails|help]`",
+        "capabilities_report() lists `optics` with capability `none`",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn optics_registry_promotion_doc_preserves_safety_rules_and_non_claims() {
+    let doc = fs::read_to_string(PROMOTION_DOC).expect("Optics registry promotion doc should exist");
+
+    for required in [
+        "Registry promotion must not activate live HUD rails.",
+        "enable live HUD rails",
+        "mutate shell state",
+        "change parser behavior",
+        "change command history",
+        "hide command output",
+        "claim a compositor",
+        "claim a terminal emulator",
+        "claim a sandbox",
+        "claim a security boundary",
+        "claim crypto enforcement",
+        "claim a system integrity guarantee",
+        "claim a Base1 boot environment",
+        "Code-level registry promotion remains future work.",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}

--- a/tests/optics_registry_promotion_docs.rs
+++ b/tests/optics_registry_promotion_docs.rs
@@ -5,7 +5,8 @@ const COMMAND_DOC: &str = "docs/ui/OPTICS_COMMAND_SURFACE.md";
 
 #[test]
 fn optics_registry_promotion_doc_exists_and_is_linked() {
-    let doc = fs::read_to_string(PROMOTION_DOC).expect("Optics registry promotion doc should exist");
+    let doc =
+        fs::read_to_string(PROMOTION_DOC).expect("Optics registry promotion doc should exist");
     let command = fs::read_to_string(COMMAND_DOC).expect("Optics command surface doc should exist");
 
     for required in [
@@ -16,12 +17,16 @@ fn optics_registry_promotion_doc_exists_and_is_linked() {
     ] {
         assert!(doc.contains(required), "missing {required:?}: {doc}");
     }
-    assert!(command.contains("OPTICS_REGISTRY_PROMOTION.md"), "{command}");
+    assert!(
+        command.contains("OPTICS_REGISTRY_PROMOTION.md"),
+        "{command}"
+    );
 }
 
 #[test]
 fn optics_registry_promotion_doc_preserves_target_command_shape() {
-    let doc = fs::read_to_string(PROMOTION_DOC).expect("Optics registry promotion doc should exist");
+    let doc =
+        fs::read_to_string(PROMOTION_DOC).expect("Optics registry promotion doc should exist");
 
     for required in [
         "optics preview",
@@ -37,7 +42,8 @@ fn optics_registry_promotion_doc_preserves_target_command_shape() {
 
 #[test]
 fn optics_registry_promotion_doc_preserves_discovery_targets() {
-    let doc = fs::read_to_string(PROMOTION_DOC).expect("Optics registry promotion doc should exist");
+    let doc =
+        fs::read_to_string(PROMOTION_DOC).expect("Optics registry promotion doc should exist");
 
     for required in [
         "help optics",
@@ -59,7 +65,8 @@ fn optics_registry_promotion_doc_preserves_discovery_targets() {
 
 #[test]
 fn optics_registry_promotion_doc_preserves_safety_rules_and_non_claims() {
-    let doc = fs::read_to_string(PROMOTION_DOC).expect("Optics registry promotion doc should exist");
+    let doc =
+        fs::read_to_string(PROMOTION_DOC).expect("Optics registry promotion doc should exist");
 
     for required in [
         "Registry promotion must not activate live HUD rails.",


### PR DESCRIPTION
## Summary

- Adds `docs/ui/OPTICS_REGISTRY_PROMOTION.md` to define the safe promotion path from WASI-lite preview routing to registry/help/manual discoverability.
- Links the registry-promotion plan from `OPTICS_COMMAND_SURFACE.md`.
- Adds tests preserving the target `optics [preview|rails|help]` command shape, discovery targets, aliases, capability boundary, safety rules, and non-claims.

## Validation

Recommended local validation:

```sh
git fetch origin
git switch feature/ui-optics-registry
cargo fmt --all -- --check
cargo test -p phase1 --test optics_registry_promotion_docs
cargo test -p phase1 --test optics_command_surface_docs
cargo test -p phase1 --test optics_hud_rails_runtime_preview
cargo test -p phase1 --test optics_hud_rail_renderer
```

## Non-claims

This PR does not code-promote Optics into the registry yet and does not activate live HUD rails. It defines the registry-promotion contract only.