### PR TITLE
Promote Optics into command registry

### DIFF
--- a/docs/ui/OPTICS_REGISTRY_PROMOTION.md
+++ b/docs/ui/OPTICS_REGISTRY_PROMOTION.md
@@ -1,13 +1,13 @@
 # Optics Registry Promotion
 
-Status: promotion plan
+Status: initial registry promotion
 Scope: moving Optics from WASI-lite preview-only routing into Phase1 command registry, help, completion, and manual visibility.
 
 ## Purpose
 
 Optics currently works through the read-only WASI-lite plugin route.
 
-The next promotion step is to make Optics discoverable from the normal Phase1 command registry without changing live UI behavior.
+The initial registry promotion makes Optics discoverable from the normal Phase1 command registry without changing live UI behavior.
 
 ## Current safe routes
 
@@ -18,19 +18,19 @@ optics rails
 
 These routes remain preview-only and run through the existing `optics` WASI-lite plugin with capability `none`.
 
-## Target registry shape
+## Registry shape
 
-The future registry entry should use this command shape:
+The initial registry entry uses this command shape:
 
 ```text
 optics [preview|rails|help]
 ```
 
-Expected properties:
+Properties:
 
 - name: `optics`
 - aliases: `pro`, `hudrails`
-- category: `user` or `misc`
+- category: `user`
 - capability: `none`
 - description: read-only Optics PRO preview and HUD rail preview surface
 
@@ -47,13 +47,13 @@ complete hud
 capabilities
 ```
 
-The command map should make the Optics surface discoverable without implying live UI activation.
+The command map makes the Optics surface discoverable without implying live UI activation.
 
 ## Runtime boundary
 
-Registry promotion must not activate live HUD rails.
+Registry promotion does not activate live HUD rails.
 
-The command should keep routing to the existing read-only preview behavior until a separate renderer-backed shell command is explicitly added and tested.
+The command keeps routing to the existing read-only preview behavior until a separate renderer-backed shell command is explicitly added and tested.
 
 ## Safety rules
 
@@ -74,7 +74,7 @@ Registry promotion must not:
 
 ## Acceptance target
 
-A future implementation patch should add tests preserving:
+The initial implementation patch adds tests preserving:
 
 - `lookup("optics")` resolves to `optics`;
 - `canonical_name("pro")` resolves to `optics`;
@@ -86,6 +86,6 @@ A future implementation patch should add tests preserving:
 
 ## Current status
 
-This document defines the registry-promotion contract only.
+Optics is now initially promoted into the command registry for discovery.
 
-Code-level registry promotion remains future work.
+Live Optics PRO HUD activation remains future work.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -104,6 +104,7 @@ pub const COMMANDS: &[CommandSpec] = &[
     cmd!("security", &["sec", "policy"], "user", "security", "Show safe mode, host tool gates, persistence, and privacy status.", "user.read"),
     cmd!("theme", &["style"], "user", "theme [show|list|rainbow|matrix|cyber|amber|ice|synthwave|crimson|mono|ascii|reset]", "Switch or inspect selectable terminal palettes. Rainbow remains the default.", "user.env"),
     cmd!("banner", &["splash"], "user", "banner [mobile|desktop|mono|rainbow|matrix|cyber|amber|ice|synthwave|crimson|ascii|safe|host|persist]", "Preview boot splash profile and color palette choices without changing saved config.", "user.read"),
+    cmd!("optics", &["pro", "hudrails"], "user", "optics [preview|rails|help]", "Read-only Optics PRO preview and HUD rail preview surface.", "none"),
     cmd!("tips", &["hint", "hints"], "user", "tips", "Show rotating operator tips for useful phase1 commands.", "user.read"),
     cmd!("help", &["commands"], "misc", "help", "Show grouped command map.", "none"),
     cmd!("man", &[], "misc", "man <command>", "Show generated command manual page.", "none"),
@@ -244,18 +245,22 @@ fn command_palette() -> String {
     out.push_str("phase1 command palette\n");
     out.push_str("hot zones\n");
     out.push_str("  CORE   dash sysinfo security opslog\n");
-    out.push_str("  BUILD  dev repo fyr lang cargo rustc\n");
+    out.push_str("  BUILD  dev repo fyr lang\n");
+    out.push_str("  OPTICS optics preview | optics rails\n");
+    out.push_str("  HOST   cargo rustc git gh\n");
     out.push_str("  TEXT   grep find head tail wc pipeline\n");
     out.push_str("  VFS    ls tree cat touch mkdir cp mv rm\n");
     out.push_str("  STYLE  theme banner matrix tips clear\n");
     out.push_str("  SAFE   capabilities sandbox audit update\n\n");
 
     out.push_str("launch examples\n");
-    out.push_str("  help host     guarded host-tool deck\n");
-    out.push_str("  help dev      development command deck\n");
-    out.push_str("  help update   update manual card\n");
-    out.push_str("  complete th   discover theme aliases\n");
-    out.push_str("  man security  full manual page\n");
+    out.push_str("  optics preview read-only Optics PRO preview\n");
+    out.push_str("  optics rails   read-only HUD rails preview\n");
+    out.push_str("  help host      guarded host-tool deck\n");
+    out.push_str("  help dev       development command deck\n");
+    out.push_str("  help update    update manual card\n");
+    out.push_str("  complete th    discover theme aliases\n");
+    out.push_str("  man security   full manual page\n");
     out
 }
 
@@ -350,7 +355,7 @@ fn compact_command_map() -> String {
     for category in CATEGORIES {
         out.push_str(&format!("{:<7}: {}\n", category, command_names(category)));
     }
-    out.push_str("\ntry: help ui | help flows | help host | help update | help security | help --compact | complete th\n");
+    out.push_str("\ntry: help ui | help flows | help host | help update | help security | help --compact | complete opt\n");
     out
 }
 
@@ -481,6 +486,8 @@ mod tests {
         assert_eq!(lookup("branches").map(|cmd| cmd.name), Some("repo"));
         assert_eq!(lookup("doctrine").map(|cmd| cmd.name), Some("repo"));
         assert_eq!(lookup("phase1lang").map(|cmd| cmd.name), Some("fyr"));
+        assert_eq!(lookup("pro").map(|cmd| cmd.name), Some("optics"));
+        assert_eq!(lookup("hudrails").map(|cmd| cmd.name), Some("optics"));
     }
 
     #[test]
@@ -506,6 +513,8 @@ mod tests {
         assert_eq!(canonical_name("runlang"), Some("lang"));
         assert_eq!(canonical_name("channels"), Some("repo"));
         assert_eq!(canonical_name("forge"), Some("fyr"));
+        assert_eq!(canonical_name("pro"), Some("optics"));
+        assert_eq!(canonical_name("hudrails"), Some("optics"));
     }
 
     #[test]
@@ -526,6 +535,7 @@ mod tests {
         assert!(map.contains("theme list"));
         assert!(map.contains("banner"));
         assert!(map.contains("tips"));
+        assert!(map.contains("optics"));
         assert!(map.contains("grep"));
         assert!(map.contains("find"));
         assert!(map.contains("update"));
@@ -558,11 +568,17 @@ mod tests {
         assert!(compact.contains("phase1 help // compact"));
         assert!(compact.contains("host"));
         assert!(compact.contains("dev"));
+        assert!(compact.contains("optics"));
 
         let host = help(&[String::from("host")]);
         assert!(host.contains("phase1 help // host"));
         assert!(host.contains("git"));
         assert!(host.contains("cargo"));
+
+        let optics = help(&[String::from("optics")]);
+        assert!(optics.contains("phase1 help // optics"));
+        assert!(optics.contains("optics [preview|rails|help]"));
+        assert!(optics.contains("capability : none"));
 
         let update = help(&[String::from("update")]);
         assert!(update.contains("phase1 help // update"));
@@ -575,6 +591,7 @@ mod tests {
         assert!(ui.contains("launch examples"));
         assert!(ui.contains("CORE"));
         assert!(ui.contains("BUILD"));
+        assert!(ui.contains("OPTICS"));
 
         let flows = help(&[String::from("flows")]);
         assert!(flows.contains("phase1 help // workflows"));
@@ -589,6 +606,10 @@ mod tests {
         assert!(page.contains("protocol"));
         assert!(page.contains("validation suites"));
         assert!(page.contains("host.exec"));
+        let optics = man_page("optics").expect("optics man page");
+        assert!(optics.contains("optics [preview|rails|help]"));
+        assert!(optics.contains("capability : none"));
+        assert!(optics.contains("Read-only Optics PRO preview"));
         let pipeline = man_page("pipeline").expect("pipeline man page");
         assert!(pipeline.contains("structured text pipeline"));
         let wasm = man_page("wasm").expect("wasm man page");
@@ -617,6 +638,9 @@ mod tests {
         assert!(completions("sec").contains(&"security"));
         assert!(completions("st").contains(&"status"));
         assert!(completions("the").contains(&"theme"));
+        assert!(completions("opt").contains(&"optics"));
+        assert!(completions("pro").contains(&"pro"));
+        assert!(completions("hud").contains(&"hudrails"));
         assert!(completions("f").contains(&"find"));
         assert!(completions("f").contains(&"fyr"));
         assert!(completions("fo").contains(&"forge"));
@@ -663,6 +687,7 @@ mod tests {
         assert!(report.contains("network-change opt-in"));
         assert!(report.contains("PHASE1_ALLOW_HOST_TOOLS"));
         assert!(report.contains("theme"));
+        assert!(report.contains("optics"));
         assert!(report.contains("grep"));
         assert!(report.contains("update"));
         assert!(report.contains("pipeline"));

--- a/tests/help_ui_alignment_docs.rs
+++ b/tests/help_ui_alignment_docs.rs
@@ -70,10 +70,12 @@ fn help_ui_hot_zones_are_compact_for_mobile_terminals() {
         registry.contains("CORE   dash sysinfo security opslog"),
         "{registry}"
     );
+    assert!(registry.contains("BUILD  dev repo fyr lang"), "{registry}");
     assert!(
-        registry.contains("BUILD  dev repo fyr lang cargo rustc"),
+        registry.contains("OPTICS optics preview | optics rails"),
         "{registry}"
     );
+    assert!(registry.contains("HOST   cargo rustc git gh"), "{registry}");
     assert!(
         registry.contains("SAFE   capabilities sandbox audit update"),
         "{registry}"

--- a/tests/optics_registry_promotion_docs.rs
+++ b/tests/optics_registry_promotion_docs.rs
@@ -11,9 +11,10 @@ fn optics_registry_promotion_doc_exists_and_is_linked() {
 
     for required in [
         "Optics Registry Promotion",
-        "Status: promotion plan",
+        "Status: initial registry promotion",
         "command registry, help, completion, and manual visibility",
         "Optics currently works through the read-only WASI-lite plugin route.",
+        "Optics is now initially promoted into the command registry for discovery.",
     ] {
         assert!(doc.contains(required), "missing {required:?}: {doc}");
     }
@@ -33,6 +34,7 @@ fn optics_registry_promotion_doc_preserves_target_command_shape() {
         "optics rails",
         "optics [preview|rails|help]",
         "aliases: `pro`, `hudrails`",
+        "category: `user`",
         "capability: `none`",
         "read-only Optics PRO preview and HUD rail preview surface",
     ] {
@@ -56,6 +58,7 @@ fn optics_registry_promotion_doc_preserves_discovery_targets() {
         "`canonical_name(\"pro\")` resolves to `optics`",
         "`canonical_name(\"hudrails\")` resolves to `optics`",
         "`completions(\"opt\")` contains `optics`",
+        "`completions(\"pro\")` contains `pro`",
         "`man_page(\"optics\")` contains `optics [preview|rails|help]`",
         "`capabilities_report()` lists `optics` with capability `none`",
     ] {
@@ -69,7 +72,7 @@ fn optics_registry_promotion_doc_preserves_safety_rules_and_non_claims() {
         fs::read_to_string(PROMOTION_DOC).expect("Optics registry promotion doc should exist");
 
     for required in [
-        "Registry promotion must not activate live HUD rails.",
+        "Registry promotion does not activate live HUD rails.",
         "enable live HUD rails",
         "mutate shell state",
         "change parser behavior",
@@ -82,7 +85,7 @@ fn optics_registry_promotion_doc_preserves_safety_rules_and_non_claims() {
         "claim crypto enforcement",
         "claim a system integrity guarantee",
         "claim a Base1 boot environment",
-        "Code-level registry promotion remains future work.",
+        "Live Optics PRO HUD activation remains future work.",
     ] {
         assert!(doc.contains(required), "missing {required:?}: {doc}");
     }


### PR DESCRIPTION
## Summary

- Promotes `optics` into the normal Phase1 command registry with aliases `pro` and `hudrails`.
- Makes `help optics`, `man optics`, `complete opt`, `complete pro`, `complete hud`, and `capabilities` discover the Optics surface.
- Keeps capability as `none` and preserves the preview-only/non-live-activation boundary.
- Updates the Optics registry promotion document from a future plan to initial registry promotion status.

## Validation

Recommended local validation:

```sh
git fetch origin
git switch feature/ui-optics-discovery
cargo fmt --all -- --check
cargo test -p phase1 --test optics_registry_promotion_docs
cargo test -p phase1 --test optics_command_surface_docs
cargo test -p phase1 --test optics_hud_rails_runtime_preview
cargo test -p phase1 --test optics_hud_rail_renderer
cargo test -p phase1 registry
```

## Non-claims

This PR does not activate live Optics PRO HUD rails. It only promotes Optics into the registry/help/manual/completion discovery surface.