### PR TITLE
Clarify Optics execution routes

### DIFF
--- a/docs/ui/OPTICS_COMMAND_SURFACE.md
+++ b/docs/ui/OPTICS_COMMAND_SURFACE.md
@@ -18,6 +18,13 @@ optics preview
 optics rails
 ```
 
+The current registry aliases are:
+
+```text
+pro
+hudrails
+```
+
 The commands are available because `optics` is exposed as a WASI-lite plugin with capability `none`.
 
 ## Command behavior
@@ -41,6 +48,38 @@ The commands are available because `optics` is exposed as a WASI-lite plugin wit
 - context, nest, portal, ghost, integrity, crypto, Base1, and Fyr summaries;
 - read-only runtime status;
 - non-claims.
+
+`pro` should resolve through the Optics registry entry and execute the read-only Optics preview route.
+
+`hudrails` should resolve through the Optics registry entry and execute the read-only HUD rail preview route.
+
+## Discovery versus execution
+
+Completion commands only print possible command names or aliases.
+
+Examples:
+
+```text
+complete opt
+complete pro
+complete hud
+```
+
+Those are discovery checks. They do not execute the preview surface.
+
+To see the rails output, run one of these execution routes:
+
+```text
+optics rails
+hudrails
+```
+
+To see the PRO preview output, run one of these execution routes:
+
+```text
+optics preview
+pro
+```
 
 ## Help and registry expectation
 

--- a/tests/optics_alias_runtime_routes.rs
+++ b/tests/optics_alias_runtime_routes.rs
@@ -1,0 +1,94 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str) -> String {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_PERSISTENT_STATE", "0")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_NO_COLOR", "1")
+        .env("PHASE1_ASCII", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("phase1 output");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn optics_rails_execution_shows_hud_rail_render_not_completion_only() {
+    let output = run_phase1("optics rails\nexit\n");
+
+    for required in [
+        "phase1 wasi run",
+        "plugin : optics",
+        "args   : rails",
+        "OPTICS HUD RAIL RENDER",
+        "TOP product=Phase1 channel=edge profile=PRO",
+        "CENTER role=command-output chrome=none-permanent",
+        "BOT color=bright-blue input=active mutation=none",
+        "not-security-boundary",
+        "not-crypto-enforcement",
+        "not-system-integrity-guarantee",
+    ] {
+        assert!(output.contains(required), "missing {required:?}:\n{output}");
+    }
+}
+
+#[test]
+fn optics_registry_aliases_execute_preview_surfaces() {
+    let output = run_phase1("pro\nhudrails\nexit\n");
+
+    for required in [
+        "phase1 wasi run",
+        "plugin : optics",
+        "OPTICS PRO PREVIEW",
+        "OPTICS HUD RAIL RENDER",
+        "TOP product=Phase1 channel=edge profile=PRO",
+        "BOT color=bright-blue input=active mutation=none",
+        "status : ok",
+        "exit   : 0",
+    ] {
+        assert!(output.contains(required), "missing {required:?}:\n{output}");
+    }
+
+    for forbidden in [
+        "command not found: pro",
+        "command not found: hudrails",
+        "security-boundary claimed",
+        "crypto-enforcement claimed",
+        "system-integrity-guarantee claimed",
+    ] {
+        assert!(
+            !output.contains(forbidden),
+            "forbidden {forbidden:?}:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn completion_routes_remain_discovery_only() {
+    let output = run_phase1("complete opt\ncomplete pro\ncomplete hud\nexit\n");
+
+    assert!(output.contains("optics"), "{output}");
+    assert!(output.contains("pro"), "{output}");
+    assert!(output.contains("hudrails"), "{output}");
+    assert!(
+        !output.contains("OPTICS HUD RAIL RENDER"),
+        "completion should not execute rails: {output}"
+    );
+}


### PR DESCRIPTION
## Summary

- Clarifies the difference between Optics discovery commands and Optics execution commands.
- Documents that `complete opt`, `complete pro`, and `complete hud` only print completions and do not execute the preview surface.
- Documents the execution routes operators should use:
  - `optics rails` or `hudrails` for the HUD rail render preview.
  - `optics preview` or `pro` for the PRO preview.
- Adds runtime tests proving `optics rails` prints the HUD rail render through the read-only WASI-lite path and that completion routes do not execute rails.

## Validation

Recommended local validation:

```sh
git fetch origin
git switch feature/ui-optics-alias-runtime
cargo fmt --all -- --check
cargo test -p phase1 --test optics_alias_runtime_routes
cargo test -p phase1 --test optics_command_surface_docs
cargo test -p phase1 --test optics_registry_promotion_docs
cargo test -p phase1 --test optics_hud_rails_runtime_preview
```

## Non-claims

This PR does not activate live Optics PRO rails. It preserves read-only preview behavior and clarifies operator routes.