### PR TITLE
Add Optics status preview

### DIFF
--- a/docs/ui/OPTICS_COMMAND_SURFACE.md
+++ b/docs/ui/OPTICS_COMMAND_SURFACE.md
@@ -16,6 +16,7 @@ The current preview commands are routed through the existing WASI-lite plugin pa
 ```text
 optics preview
 optics rails
+optics status
 ```
 
 The current registry aliases are:
@@ -47,6 +48,17 @@ The commands are available because `optics` is exposed as a WASI-lite plugin wit
 - bottom HUD rail;
 - context, nest, portal, ghost, integrity, crypto, Base1, and Fyr summaries;
 - read-only runtime status;
+- non-claims.
+
+`optics status` should show the Optics preview status surface:
+
+- preview-only mode;
+- Rust static renderer source;
+- top rail readiness;
+- bottom rail readiness;
+- live HUD disabled state;
+- explicit activation gate requirement;
+- input, history, and parser non-mutation labels;
 - non-claims.
 
 `pro` should resolve through the Optics registry entry and execute the read-only Optics preview route.
@@ -81,6 +93,12 @@ optics preview
 pro
 ```
 
+To see the Optics status output, run:
+
+```text
+optics status
+```
+
 ## Help and registry expectation
 
 Future work should promote Optics into the regular command registry so it appears in help, completions, and manuals.
@@ -90,7 +108,7 @@ The registry-promotion plan is [`OPTICS_REGISTRY_PROMOTION.md`](OPTICS_REGISTRY_
 The planned registry row should preserve this shape:
 
 ```text
-optics [preview|rails|help]
+optics [preview|rails|status|help]
 ```
 
 Until that registry row exists, the WASI-lite route remains the safe preview path.

--- a/docs/ui/OPTICS_REGISTRY_PROMOTION.md
+++ b/docs/ui/OPTICS_REGISTRY_PROMOTION.md
@@ -14,6 +14,7 @@ The initial registry promotion makes Optics discoverable from the normal Phase1 
 ```text
 optics preview
 optics rails
+optics status
 ```
 
 These routes remain preview-only and run through the existing `optics` WASI-lite plugin with capability `none`.
@@ -23,7 +24,7 @@ These routes remain preview-only and run through the existing `optics` WASI-lite
 The initial registry entry uses this command shape:
 
 ```text
-optics [preview|rails|help]
+optics [preview|rails|status|help]
 ```
 
 Properties:
@@ -55,6 +56,19 @@ Registry promotion does not activate live HUD rails.
 
 The command keeps routing to the existing read-only preview behavior until a separate renderer-backed shell command is explicitly added and tested.
 
+## Status surface
+
+`optics status` reports the current preview state:
+
+- preview-only mode;
+- Rust static renderer source;
+- top rail preview readiness;
+- bottom rail preview readiness;
+- live HUD disabled state;
+- explicit activation gate requirement;
+- input, history, and parser non-mutation labels;
+- non-claims.
+
 ## Safety rules
 
 Registry promotion must not:
@@ -81,7 +95,7 @@ The initial implementation patch adds tests preserving:
 - `canonical_name("hudrails")` resolves to `optics`;
 - `completions("opt")` contains `optics`;
 - `completions("pro")` contains `pro`;
-- `man_page("optics")` contains `optics [preview|rails|help]`;
+- `man_page("optics")` contains `optics [preview|rails|status|help]`;
 - `capabilities_report()` lists `optics` with capability `none`.
 
 ## Current status

--- a/src/optics.rs
+++ b/src/optics.rs
@@ -17,6 +17,23 @@ impl OpticsDeviceProfile {
     }
 }
 
+pub fn supported_device_profiles() -> [OpticsDeviceProfile; 4] {
+    [
+        OpticsDeviceProfile::Mobile,
+        OpticsDeviceProfile::Laptop,
+        OpticsDeviceProfile::Desktop,
+        OpticsDeviceProfile::Terminal,
+    ]
+}
+
+pub fn supported_device_labels() -> String {
+    supported_device_profiles()
+        .into_iter()
+        .map(OpticsDeviceProfile::as_label)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OpticsRailState {
     pub product: String,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -130,6 +130,10 @@ fn optics_status(args: &[String]) -> String {
     out.push_str("renderer    : rust-static-renderer\n");
     out.push_str("top-rail    : ready-preview\n");
     out.push_str("bottom-rail : ready-preview\n");
+    out.push_str(&format!(
+        "devices     : {}\n",
+        optics::supported_device_labels()
+    ));
     out.push_str("live-hud    : disabled\n");
     out.push_str("activation  : explicit-gate-required\n");
     out.push_str("input       : raw-command-preserved\n");
@@ -434,6 +438,7 @@ mod tests {
         assert!(out.contains("renderer    : rust-static-renderer"));
         assert!(out.contains("top-rail    : ready-preview"));
         assert!(out.contains("bottom-rail : ready-preview"));
+        assert!(out.contains("devices     : mobile,laptop,desktop,terminal"));
         assert!(out.contains("live-hud    : disabled"));
         assert!(out.contains("activation  : explicit-gate-required"));
         assert!(out.contains("parser      : unchanged"));

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -62,6 +62,9 @@ pub fn execute_plugin(plugins_dir: &Path, name: &str, args: &[String]) -> String
     if is_arena(name) {
         return launch_arena(args);
     }
+    if is_optics_status(name, args) {
+        return optics_status(args);
+    }
     if is_optics_rails(name, args) {
         return optics_rails_preview(args);
     }
@@ -107,8 +110,35 @@ pub fn execute_plugin(plugins_dir: &Path, name: &str, args: &[String]) -> String
     out
 }
 
+fn is_optics_status(name: &str, args: &[String]) -> bool {
+    name == "optics" && args.first().is_some_and(|arg| arg == "status")
+}
+
 fn is_optics_rails(name: &str, args: &[String]) -> bool {
     name == "optics" && args.first().is_some_and(|arg| arg == "rails")
+}
+
+fn optics_status(args: &[String]) -> String {
+    let mut out = String::from("phase1 wasi run\n");
+    out.push_str("plugin : optics\n");
+    out.push_str(&format!("runtime: {RUNTIME}\n"));
+    out.push_str("sandbox: fs=virtual net=disabled host=blocked\n");
+    out.push_str("cap    : none\n");
+    out.push_str(&format!("args   : {}\n", redact_args(args).join(" ")));
+    out.push_str("OPTICS STATUS\n");
+    out.push_str("mode        : preview-only\n");
+    out.push_str("renderer    : rust-static-renderer\n");
+    out.push_str("top-rail    : ready-preview\n");
+    out.push_str("bottom-rail : ready-preview\n");
+    out.push_str("live-hud    : disabled\n");
+    out.push_str("activation  : explicit-gate-required\n");
+    out.push_str("input       : raw-command-preserved\n");
+    out.push_str("history     : unchanged\n");
+    out.push_str("parser      : unchanged\n");
+    out.push_str("non-claims  : not-compositor not-terminal-emulator not-sandbox not-security-boundary not-crypto-enforcement not-system-integrity-guarantee not-base1-boot-environment\n");
+    out.push_str("status : ok\n");
+    out.push_str("exit   : 0\n");
+    out
 }
 
 fn optics_rails_preview(args: &[String]) -> String {
@@ -389,6 +419,26 @@ mod tests {
         assert!(out.contains("hello wasi"));
         assert!(out.contains("host=blocked"));
         assert!(out.contains("[redacted]"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn optics_status_route_reports_preview_mode_and_activation_gate() {
+        let dir = temp_plugins();
+        fs::write(dir.join("optics.wasm"), b"\0asm\x01\0\0\0").unwrap();
+        let out = execute_plugin(&dir, "optics", &["status".to_string()]);
+        assert!(out.contains("plugin : optics"));
+        assert!(out.contains("args   : status"));
+        assert!(out.contains("OPTICS STATUS"));
+        assert!(out.contains("mode        : preview-only"));
+        assert!(out.contains("renderer    : rust-static-renderer"));
+        assert!(out.contains("top-rail    : ready-preview"));
+        assert!(out.contains("bottom-rail : ready-preview"));
+        assert!(out.contains("live-hud    : disabled"));
+        assert!(out.contains("activation  : explicit-gate-required"));
+        assert!(out.contains("parser      : unchanged"));
+        assert!(out.contains("not-security-boundary"));
+        assert!(out.contains("status : ok"));
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/tests/optics_command_surface_docs.rs
+++ b/tests/optics_command_surface_docs.rs
@@ -27,6 +27,7 @@ fn optics_command_surface_preserves_current_preview_routes() {
     for required in [
         "optics preview",
         "optics rails",
+        "optics status",
         "WASI-lite plugin path",
         "capability `none`",
         "minimal main screen",
@@ -35,6 +36,30 @@ fn optics_command_surface_preserves_current_preview_routes() {
         "top HUD rail",
         "center viewport",
         "bottom HUD rail",
+        "preview-only mode",
+        "Rust static renderer source",
+        "live HUD disabled state",
+        "explicit activation gate requirement",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn optics_command_surface_preserves_discovery_and_execution_boundaries() {
+    let doc = fs::read_to_string(COMMAND_DOC).expect("Optics command surface doc should exist");
+
+    for required in [
+        "Discovery versus execution",
+        "complete opt",
+        "complete pro",
+        "complete hud",
+        "Those are discovery checks. They do not execute the preview surface.",
+        "optics rails",
+        "hudrails",
+        "optics preview",
+        "pro",
+        "optics status",
     ] {
         assert!(doc.contains(required), "missing {required:?}: {doc}");
     }
@@ -47,7 +72,7 @@ fn optics_command_surface_preserves_registry_expectation() {
     for required in [
         "Future work should promote Optics into the regular command registry",
         "help, completions, and manuals",
-        "optics [preview|rails|help]",
+        "optics [preview|rails|status|help]",
         "Until that registry row exists, the WASI-lite route remains the safe preview path.",
     ] {
         assert!(doc.contains(required), "missing {required:?}: {doc}");

--- a/tests/optics_hud_rail_renderer.rs
+++ b/tests/optics_hud_rail_renderer.rs
@@ -2,8 +2,8 @@
 mod optics;
 
 use optics::{
-    render_bottom_rail, render_static_preview, render_top_rail, OpticsDeviceProfile,
-    OpticsRailState,
+    render_bottom_rail, render_static_preview, render_top_rail, supported_device_labels,
+    supported_device_profiles, OpticsDeviceProfile, OpticsRailState,
 };
 
 #[test]
@@ -29,6 +29,19 @@ fn optics_renderer_static_preview_preserves_top_center_bottom_contract() {
             "missing {required:?}: {preview}"
         );
     }
+}
+
+#[test]
+fn optics_renderer_exposes_supported_device_profiles_without_dead_code() {
+    let profiles = supported_device_profiles();
+    let labels = supported_device_labels();
+
+    assert_eq!(profiles.len(), 4);
+    assert!(profiles.contains(&OpticsDeviceProfile::Mobile));
+    assert!(profiles.contains(&OpticsDeviceProfile::Laptop));
+    assert!(profiles.contains(&OpticsDeviceProfile::Desktop));
+    assert!(profiles.contains(&OpticsDeviceProfile::Terminal));
+    assert_eq!(labels, "mobile,laptop,desktop,terminal");
 }
 
 #[test]

--- a/tests/optics_registry_promotion_docs.rs
+++ b/tests/optics_registry_promotion_docs.rs
@@ -32,7 +32,8 @@ fn optics_registry_promotion_doc_preserves_target_command_shape() {
     for required in [
         "optics preview",
         "optics rails",
-        "optics [preview|rails|help]",
+        "optics status",
+        "optics [preview|rails|status|help]",
         "aliases: `pro`, `hudrails`",
         "category: `user`",
         "capability: `none`",
@@ -59,8 +60,28 @@ fn optics_registry_promotion_doc_preserves_discovery_targets() {
         "`canonical_name(\"hudrails\")` resolves to `optics`",
         "`completions(\"opt\")` contains `optics`",
         "`completions(\"pro\")` contains `pro`",
-        "`man_page(\"optics\")` contains `optics [preview|rails|help]`",
+        "`man_page(\"optics\")` contains `optics [preview|rails|status|help]`",
         "`capabilities_report()` lists `optics` with capability `none`",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn optics_registry_promotion_doc_preserves_status_surface() {
+    let doc =
+        fs::read_to_string(PROMOTION_DOC).expect("Optics registry promotion doc should exist");
+
+    for required in [
+        "Status surface",
+        "`optics status` reports the current preview state",
+        "preview-only mode",
+        "Rust static renderer source",
+        "top rail preview readiness",
+        "bottom rail preview readiness",
+        "live HUD disabled state",
+        "explicit activation gate requirement",
+        "input, history, and parser non-mutation labels",
     ] {
         assert!(doc.contains(required), "missing {required:?}: {doc}");
     }

--- a/tests/optics_status_runtime.rs
+++ b/tests/optics_status_runtime.rs
@@ -1,0 +1,78 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str) -> String {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_PERSISTENT_STATE", "0")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_NO_COLOR", "1")
+        .env("PHASE1_ASCII", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("phase1 output");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn optics_status_reports_preview_readiness_and_activation_gate() {
+    let output = run_phase1("optics status\nexit\n");
+
+    for required in [
+        "phase1 wasi run",
+        "plugin : optics",
+        "runtime: phase1-wasi-lite",
+        "sandbox: fs=virtual net=disabled host=blocked",
+        "cap    : none",
+        "args   : status",
+        "OPTICS STATUS",
+        "mode        : preview-only",
+        "renderer    : rust-static-renderer",
+        "top-rail    : ready-preview",
+        "bottom-rail : ready-preview",
+        "live-hud    : disabled",
+        "activation  : explicit-gate-required",
+        "input       : raw-command-preserved",
+        "history     : unchanged",
+        "parser      : unchanged",
+        "not-compositor",
+        "not-security-boundary",
+        "not-crypto-enforcement",
+        "not-system-integrity-guarantee",
+        "not-base1-boot-environment",
+        "status : ok",
+        "exit   : 0",
+    ] {
+        assert!(output.contains(required), "missing {required:?}:\n{output}");
+    }
+
+    for forbidden in [
+        "live-hud    : enabled",
+        "runtime=wired",
+        "security-boundary claimed",
+        "crypto-enforcement claimed",
+        "system-integrity-guarantee claimed",
+        "base1 boot environment claimed",
+        "host=enabled",
+    ] {
+        assert!(
+            !output.contains(forbidden),
+            "forbidden {forbidden:?}:\n{output}"
+        );
+    }
+}


### PR DESCRIPTION
Adds a read-only Optics status preview route for `optics status`. The new status surface reports preview-only mode, Rust renderer source, top and bottom rail readiness, live HUD disabled state, explicit activation gate requirement, and non-claims. It also updates Optics command surface and registry-promotion docs/tests, plus runtime coverage for the new status route. Live HUD activation remains out of scope.