### PR TITLE
Add Optics device preview routes

### DIFF
--- a/docs/ui/OPTICS_COMMAND_SURFACE.md
+++ b/docs/ui/OPTICS_COMMAND_SURFACE.md
@@ -17,6 +17,10 @@ The current preview commands are routed through the existing WASI-lite plugin pa
 optics preview
 optics rails
 optics status
+optics device mobile
+optics device laptop
+optics device desktop
+optics device terminal
 ```
 
 The current registry aliases are:
@@ -61,6 +65,17 @@ The commands are available because `optics` is exposed as a WASI-lite plugin wit
 - input, history, and parser non-mutation labels;
 - non-claims.
 
+`optics device <profile>` should render a read-only Optics HUD rail preview for a selected device profile.
+
+Supported device profiles:
+
+```text
+mobile
+laptop
+desktop
+terminal
+```
+
 `pro` should resolve through the Optics registry entry and execute the read-only Optics preview route.
 
 `hudrails` should resolve through the Optics registry entry and execute the read-only HUD rail preview route.
@@ -99,6 +114,15 @@ To see the Optics status output, run:
 optics status
 ```
 
+To see device-specific rail previews, run:
+
+```text
+optics device mobile
+optics device laptop
+optics device desktop
+optics device terminal
+```
+
 ## Help and registry expectation
 
 Future work should promote Optics into the regular command registry so it appears in help, completions, and manuals.
@@ -108,7 +132,7 @@ The registry-promotion plan is [`OPTICS_REGISTRY_PROMOTION.md`](OPTICS_REGISTRY_
 The planned registry row should preserve this shape:
 
 ```text
-optics [preview|rails|status|help]
+optics [preview|rails|status|device|help]
 ```
 
 Until that registry row exists, the WASI-lite route remains the safe preview path.

--- a/src/optics.rs
+++ b/src/optics.rs
@@ -82,8 +82,13 @@ impl OpticsRailState {
 pub fn render_top_rail(state: &OpticsRailState) -> String {
     match state.device {
         OpticsDeviceProfile::Mobile => format!(
-            "TOP product={} channel={} profile={} ctx={} trust={}\n",
-            state.product, state.channel, state.profile, state.context, state.trust
+            "TOP product={} channel={} profile={} ctx={} trust={} device={}\n",
+            state.product,
+            state.channel,
+            state.profile,
+            state.context,
+            state.trust,
+            state.device.as_label()
         ),
         OpticsDeviceProfile::Laptop | OpticsDeviceProfile::Terminal => format!(
             "TOP product={} channel={} profile={} ctx={} trust={} security={}\nTOP integrity={} crypto={} base1={} fyr={} device={}\n",

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -65,6 +65,9 @@ pub fn execute_plugin(plugins_dir: &Path, name: &str, args: &[String]) -> String
     if is_optics_status(name, args) {
         return optics_status(args);
     }
+    if is_optics_device(name, args) {
+        return optics_device_preview(args);
+    }
     if is_optics_rails(name, args) {
         return optics_rails_preview(args);
     }
@@ -114,6 +117,10 @@ fn is_optics_status(name: &str, args: &[String]) -> bool {
     name == "optics" && args.first().is_some_and(|arg| arg == "status")
 }
 
+fn is_optics_device(name: &str, args: &[String]) -> bool {
+    name == "optics" && args.first().is_some_and(|arg| arg == "device")
+}
+
 fn is_optics_rails(name: &str, args: &[String]) -> bool {
     name == "optics" && args.first().is_some_and(|arg| arg == "rails")
 }
@@ -143,6 +150,62 @@ fn optics_status(args: &[String]) -> String {
     out.push_str("status : ok\n");
     out.push_str("exit   : 0\n");
     out
+}
+
+fn optics_device_preview(args: &[String]) -> String {
+    let mut out = String::from("phase1 wasi run\n");
+    out.push_str("plugin : optics\n");
+    out.push_str(&format!("runtime: {RUNTIME}\n"));
+    out.push_str("sandbox: fs=virtual net=disabled host=blocked\n");
+    out.push_str("cap    : none\n");
+    out.push_str(&format!("args   : {}\n", redact_args(args).join(" ")));
+
+    let Some(raw_device) = args.get(1).map(String::as_str) else {
+        out.push_str("OPTICS DEVICE PREVIEW\n");
+        out.push_str("result      : missing-device\n");
+        out.push_str("usage       : optics device mobile|laptop|desktop|terminal\n");
+        out.push_str(&format!(
+            "supported   : {}\n",
+            optics::supported_device_labels()
+        ));
+        out.push_str("status : failed\n");
+        out.push_str("exit   : 1\n");
+        return out;
+    };
+
+    let Some(device) = optics_device_profile(raw_device) else {
+        out.push_str("OPTICS DEVICE PREVIEW\n");
+        out.push_str("result      : invalid-device\n");
+        out.push_str(&format!("requested   : {}\n", redact_text(raw_device)));
+        out.push_str("usage       : optics device mobile|laptop|desktop|terminal\n");
+        out.push_str(&format!(
+            "supported   : {}\n",
+            optics::supported_device_labels()
+        ));
+        out.push_str("status : failed\n");
+        out.push_str("exit   : 1\n");
+        return out;
+    };
+
+    out.push_str("OPTICS DEVICE PREVIEW\n");
+    out.push_str(&format!("device      : {}\n", device.as_label()));
+    out.push_str("mode        : preview-only\n");
+    out.push_str("renderer    : rust-static-renderer\n");
+    out.push_str("live-hud    : disabled\n");
+    out.push_str(&optics::render_static_preview(device));
+    out.push_str("status : ok\n");
+    out.push_str("exit   : 0\n");
+    out
+}
+
+fn optics_device_profile(raw: &str) -> Option<optics::OpticsDeviceProfile> {
+    match raw {
+        "mobile" => Some(optics::OpticsDeviceProfile::Mobile),
+        "laptop" => Some(optics::OpticsDeviceProfile::Laptop),
+        "desktop" => Some(optics::OpticsDeviceProfile::Desktop),
+        "terminal" => Some(optics::OpticsDeviceProfile::Terminal),
+        _ => None,
+    }
 }
 
 fn optics_rails_preview(args: &[String]) -> String {
@@ -444,6 +507,48 @@ mod tests {
         assert!(out.contains("parser      : unchanged"));
         assert!(out.contains("not-security-boundary"));
         assert!(out.contains("status : ok"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn optics_device_route_renders_requested_profile() {
+        let dir = temp_plugins();
+        fs::write(dir.join("optics.wasm"), b"\0asm\x01\0\0\0").unwrap();
+        for device in ["mobile", "laptop", "desktop", "terminal"] {
+            let out = execute_plugin(
+                &dir,
+                "optics",
+                &["device".to_string(), device.to_string()],
+            );
+            assert!(out.contains("plugin : optics"));
+            assert!(out.contains(&format!("args   : device {device}")));
+            assert!(out.contains("OPTICS DEVICE PREVIEW"));
+            assert!(out.contains(&format!("device      : {device}")));
+            assert!(out.contains("mode        : preview-only"));
+            assert!(out.contains("live-hud    : disabled"));
+            assert!(out.contains("OPTICS HUD RAIL RENDER"));
+            assert!(out.contains(&format!("device={device}")));
+            assert!(out.contains("status : ok"));
+        }
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn optics_device_route_rejects_invalid_profile_without_live_activation() {
+        let dir = temp_plugins();
+        fs::write(dir.join("optics.wasm"), b"\0asm\x01\0\0\0").unwrap();
+        let out = execute_plugin(
+            &dir,
+            "optics",
+            &["device".to_string(), "wallpaper".to_string()],
+        );
+        assert!(out.contains("OPTICS DEVICE PREVIEW"));
+        assert!(out.contains("result      : invalid-device"));
+        assert!(out.contains("requested   : wallpaper"));
+        assert!(out.contains("supported   : mobile,laptop,desktop,terminal"));
+        assert!(out.contains("status : failed"));
+        assert!(out.contains("exit   : 1"));
+        assert!(!out.contains("live-hud    : enabled"));
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -515,11 +515,7 @@ mod tests {
         let dir = temp_plugins();
         fs::write(dir.join("optics.wasm"), b"\0asm\x01\0\0\0").unwrap();
         for device in ["mobile", "laptop", "desktop", "terminal"] {
-            let out = execute_plugin(
-                &dir,
-                "optics",
-                &["device".to_string(), device.to_string()],
-            );
+            let out = execute_plugin(&dir, "optics", &["device".to_string(), device.to_string()]);
             assert!(out.contains("plugin : optics"));
             assert!(out.contains(&format!("args   : device {device}")));
             assert!(out.contains("OPTICS DEVICE PREVIEW"));

--- a/tests/optics_command_surface_docs.rs
+++ b/tests/optics_command_surface_docs.rs
@@ -28,6 +28,10 @@ fn optics_command_surface_preserves_current_preview_routes() {
         "optics preview",
         "optics rails",
         "optics status",
+        "optics device mobile",
+        "optics device laptop",
+        "optics device desktop",
+        "optics device terminal",
         "WASI-lite plugin path",
         "capability `none`",
         "minimal main screen",
@@ -40,6 +44,27 @@ fn optics_command_surface_preserves_current_preview_routes() {
         "Rust static renderer source",
         "live HUD disabled state",
         "explicit activation gate requirement",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn optics_command_surface_preserves_device_preview_profiles() {
+    let doc = fs::read_to_string(COMMAND_DOC).expect("Optics command surface doc should exist");
+
+    for required in [
+        "`optics device <profile>` should render a read-only Optics HUD rail preview for a selected device profile.",
+        "Supported device profiles",
+        "mobile",
+        "laptop",
+        "desktop",
+        "terminal",
+        "To see device-specific rail previews, run:",
+        "optics device mobile",
+        "optics device laptop",
+        "optics device desktop",
+        "optics device terminal",
     ] {
         assert!(doc.contains(required), "missing {required:?}: {doc}");
     }
@@ -60,6 +85,7 @@ fn optics_command_surface_preserves_discovery_and_execution_boundaries() {
         "optics preview",
         "pro",
         "optics status",
+        "optics device mobile",
     ] {
         assert!(doc.contains(required), "missing {required:?}: {doc}");
     }
@@ -72,7 +98,7 @@ fn optics_command_surface_preserves_registry_expectation() {
     for required in [
         "Future work should promote Optics into the regular command registry",
         "help, completions, and manuals",
-        "optics [preview|rails|status|help]",
+        "optics [preview|rails|status|device|help]",
         "Until that registry row exists, the WASI-lite route remains the safe preview path.",
     ] {
         assert!(doc.contains(required), "missing {required:?}: {doc}");

--- a/tests/optics_device_runtime.rs
+++ b/tests/optics_device_runtime.rs
@@ -52,8 +52,14 @@ fn optics_device_preview_routes_render_all_profiles() {
         ] {
             assert!(output.contains(required), "missing {required:?}:\n{output}");
         }
-        assert!(output.contains(&format!("args   : device {device}")), "{output}");
-        assert!(output.contains(&format!("device      : {device}")), "{output}");
+        assert!(
+            output.contains(&format!("args   : device {device}")),
+            "{output}"
+        );
+        assert!(
+            output.contains(&format!("device      : {device}")),
+            "{output}"
+        );
         assert!(output.contains(&format!("device={device}")), "{output}");
     }
 }

--- a/tests/optics_device_runtime.rs
+++ b/tests/optics_device_runtime.rs
@@ -1,0 +1,91 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str) -> String {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_PERSISTENT_STATE", "0")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_NO_COLOR", "1")
+        .env("PHASE1_ASCII", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("phase1 output");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn optics_device_preview_routes_render_all_profiles() {
+    let output = run_phase1(
+        "optics device mobile\noptics device laptop\noptics device desktop\noptics device terminal\nexit\n",
+    );
+
+    for device in ["mobile", "laptop", "desktop", "terminal"] {
+        for required in [
+            "phase1 wasi run",
+            "plugin : optics",
+            "runtime: phase1-wasi-lite",
+            "sandbox: fs=virtual net=disabled host=blocked",
+            "cap    : none",
+            "OPTICS DEVICE PREVIEW",
+            "mode        : preview-only",
+            "renderer    : rust-static-renderer",
+            "live-hud    : disabled",
+            "OPTICS HUD RAIL RENDER",
+            "status : ok",
+            "exit   : 0",
+        ] {
+            assert!(output.contains(required), "missing {required:?}:\n{output}");
+        }
+        assert!(output.contains(&format!("args   : device {device}")), "{output}");
+        assert!(output.contains(&format!("device      : {device}")), "{output}");
+        assert!(output.contains(&format!("device={device}")), "{output}");
+    }
+}
+
+#[test]
+fn optics_device_preview_rejects_missing_and_invalid_profiles() {
+    let output = run_phase1("optics device\noptics device wallpaper\nexit\n");
+
+    for required in [
+        "OPTICS DEVICE PREVIEW",
+        "result      : missing-device",
+        "result      : invalid-device",
+        "requested   : wallpaper",
+        "usage       : optics device mobile|laptop|desktop|terminal",
+        "supported   : mobile,laptop,desktop,terminal",
+        "status : failed",
+        "exit   : 1",
+    ] {
+        assert!(output.contains(required), "missing {required:?}:\n{output}");
+    }
+
+    for forbidden in [
+        "live-hud    : enabled",
+        "runtime=wired",
+        "security-boundary claimed",
+        "crypto-enforcement claimed",
+        "system-integrity-guarantee claimed",
+        "host=enabled",
+    ] {
+        assert!(
+            !output.contains(forbidden),
+            "forbidden {forbidden:?}:\n{output}"
+        );
+    }
+}


### PR DESCRIPTION
Adds read-only Optics device preview routes for mobile, laptop, desktop, and terminal. These routes render the existing Rust HUD rail preview for a selected device profile through the WASI-lite path, preserve capability none, and keep live HUD activation disabled. Also documents the device routes and adds runtime coverage for valid, missing, and invalid device profiles.