### PR TITLE
Add Optics PRO rail color contract

### DIFF
--- a/src/optics.rs
+++ b/src/optics.rs
@@ -1,3 +1,12 @@
+pub const USER_INPUT_BRIGHT_YELLOW: &str = "\x1b[93m";
+const RESET: &str = "\x1b[0m";
+const BOLD: &str = "\x1b[1m";
+const CYAN: &str = "\x1b[36m";
+const BLUE: &str = "\x1b[34m";
+const GREEN: &str = "\x1b[32m";
+const MAGENTA: &str = "\x1b[35m";
+const RED: &str = "\x1b[31m";
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum OpticsDeviceProfile {
     Mobile,
@@ -77,6 +86,77 @@ impl OpticsRailState {
             warning: "none".to_string(),
         }
     }
+}
+
+pub fn colorize_user_input(input: &str, color: bool) -> String {
+    if color && !input.is_empty() {
+        format!("{BOLD}{USER_INPUT_BRIGHT_YELLOW}{input}{RESET}")
+    } else {
+        input.to_string()
+    }
+}
+
+fn colorize_layer(text: &str, color: bool, ansi: &str) -> String {
+    if color {
+        format!("{BOLD}{ansi}{text}{RESET}")
+    } else {
+        text.to_string()
+    }
+}
+
+pub fn render_pro_shell_layers(state: &OpticsRailState, typed_input: &str, color: bool) -> String {
+    let top_label = colorize_layer("A TOP RAIL", color, CYAN);
+    let command_label = colorize_layer("B COMMAND RAIL", color, BLUE);
+    let status_label = colorize_layer("C STATUS HUD", color, GREEN);
+    let bottom_label = colorize_layer("D BOTTOM HUD", color, MAGENTA);
+    let typed = colorize_user_input(typed_input, color);
+    let mutation = mutation_label_color(&state.mutation, color);
+    let result = result_label_color(&state.last_result, color);
+
+    format!(
+        "{top_label}\nproduct={} channel={} profile={} ctx={} trust={} security={} device={}\n\
+         {command_label}\nphase1://edge/root > {typed}\n\n\
+         {status_label}\nresult={} mutation={} integrity={} crypto={} base1={} fyr={}\n\
+         {bottom_label}\ninput={} command={} task={} warning={} copy-safe=raw-command-preserved\n",
+        state.product,
+        state.channel,
+        state.profile,
+        state.context,
+        state.trust,
+        state.security,
+        state.device.as_label(),
+        result,
+        mutation,
+        state.integrity,
+        state.crypto,
+        state.base1,
+        state.fyr,
+        state.input,
+        state.command_family,
+        state.active_task,
+        state.warning
+    )
+}
+
+fn mutation_label_color(value: &str, color: bool) -> String {
+    let ansi = match value {
+        "typing" | "command-family-detected" => CYAN,
+        "guarded" | "confirmation" => MAGENTA,
+        "denied" | "failed" | "unsafe" | "invalid" => RED,
+        "complete" | "success" => GREEN,
+        _ => BLUE,
+    };
+    colorize_layer(value, color, ansi)
+}
+
+fn result_label_color(value: &str, color: bool) -> String {
+    let ansi = match value {
+        "ok" | "success" => GREEN,
+        "warning" | "guarded" => MAGENTA,
+        "failed" | "denied" | "invalid" => RED,
+        _ => BLUE,
+    };
+    colorize_layer(value, color, ansi)
 }
 
 pub fn render_top_rail(state: &OpticsRailState) -> String {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -147,6 +147,12 @@ fn optics_status(args: &[String]) -> String {
     out.push_str("history     : unchanged\n");
     out.push_str("parser      : unchanged\n");
     out.push_str("non-claims  : not-compositor not-terminal-emulator not-sandbox not-security-boundary not-crypto-enforcement not-system-integrity-guarantee not-base1-boot-environment\n");
+    out.push_str("OPTICS PRO SHELL RAIL CONTRACT\n");
+    out.push_str(&optics::render_pro_shell_layers(
+        &optics::OpticsRailState::pro_static(optics::OpticsDeviceProfile::Terminal),
+        "optics status",
+        false,
+    ));
     out.push_str("status : ok\n");
     out.push_str("exit   : 0\n");
     out
@@ -504,6 +510,12 @@ mod tests {
         assert!(out.contains("devices     : mobile,laptop,desktop,terminal"));
         assert!(out.contains("live-hud    : disabled"));
         assert!(out.contains("activation  : explicit-gate-required"));
+        assert!(out.contains("OPTICS PRO SHELL RAIL CONTRACT"));
+        assert!(out.contains("A TOP RAIL"));
+        assert!(out.contains("B COMMAND RAIL"));
+        assert!(out.contains("C STATUS HUD"));
+        assert!(out.contains("D BOTTOM HUD"));
+        assert!(out.contains("phase1://edge/root > optics status\n\nC STATUS HUD"));
         assert!(out.contains("parser      : unchanged"));
         assert!(out.contains("not-security-boundary"));
         assert!(out.contains("status : ok"));

--- a/tests/optics_hud_rail_renderer.rs
+++ b/tests/optics_hud_rail_renderer.rs
@@ -60,16 +60,31 @@ fn optics_pro_shell_layers_color_code_without_reusing_bright_yellow() {
     let frame = render_pro_shell_layers(&state, "optics status", true);
 
     let highlighted = format!("{USER_INPUT_BRIGHT_YELLOW}optics status");
-    assert!(frame.contains(&highlighted), "typed text must be bright yellow: {frame:?}");
+    assert!(
+        frame.contains(&highlighted),
+        "typed text must be bright yellow: {frame:?}"
+    );
     assert_eq!(
         frame.matches(USER_INPUT_BRIGHT_YELLOW).count(),
         1,
         "bright yellow is reserved for typed/copied user input only: {frame:?}"
     );
-    assert!(frame.contains("\x1b[36mA TOP RAIL"), "top rail should be cyan: {frame:?}");
-    assert!(frame.contains("\x1b[34mB COMMAND RAIL"), "command rail label should be blue: {frame:?}");
-    assert!(frame.contains("\x1b[32mC STATUS HUD"), "status hud should be green: {frame:?}");
-    assert!(frame.contains("\x1b[35mD BOTTOM HUD"), "bottom hud should be magenta: {frame:?}");
+    assert!(
+        frame.contains("\x1b[36mA TOP RAIL"),
+        "top rail should be cyan: {frame:?}"
+    );
+    assert!(
+        frame.contains("\x1b[34mB COMMAND RAIL"),
+        "command rail label should be blue: {frame:?}"
+    );
+    assert!(
+        frame.contains("\x1b[32mC STATUS HUD"),
+        "status hud should be green: {frame:?}"
+    );
+    assert!(
+        frame.contains("\x1b[35mD BOTTOM HUD"),
+        "bottom hud should be magenta: {frame:?}"
+    );
 }
 
 #[test]

--- a/tests/optics_hud_rail_renderer.rs
+++ b/tests/optics_hud_rail_renderer.rs
@@ -2,8 +2,9 @@
 mod optics;
 
 use optics::{
-    render_bottom_rail, render_static_preview, render_top_rail, supported_device_labels,
-    supported_device_profiles, OpticsDeviceProfile, OpticsRailState,
+    colorize_user_input, render_bottom_rail, render_pro_shell_layers, render_static_preview,
+    render_top_rail, supported_device_labels, supported_device_profiles, OpticsDeviceProfile,
+    OpticsRailState, USER_INPUT_BRIGHT_YELLOW,
 };
 
 #[test]
@@ -29,6 +30,57 @@ fn optics_renderer_static_preview_preserves_top_center_bottom_contract() {
             "missing {required:?}: {preview}"
         );
     }
+}
+
+#[test]
+fn optics_pro_shell_layers_keep_a_b_blank_c_d_order() {
+    let mut state = OpticsRailState::pro_static(OpticsDeviceProfile::Terminal);
+    state.mutation = "typing".to_string();
+    state.command_family = "security".to_string();
+    let frame = render_pro_shell_layers(&state, "security status", false);
+
+    let top = frame.find("A TOP RAIL").expect("top rail");
+    let command = frame.find("B COMMAND RAIL").expect("command rail");
+    let status = frame.find("C STATUS HUD").expect("status hud");
+    let bottom = frame.find("D BOTTOM HUD").expect("bottom hud");
+
+    assert!(top < command, "{frame}");
+    assert!(command < status, "{frame}");
+    assert!(status < bottom, "{frame}");
+    assert!(
+        frame.contains("phase1://edge/root > security status\n\nC STATUS HUD"),
+        "B and C must be separated by a blank line: {frame}"
+    );
+}
+
+#[test]
+fn optics_pro_shell_layers_color_code_without_reusing_bright_yellow() {
+    let mut state = OpticsRailState::pro_static(OpticsDeviceProfile::Terminal);
+    state.mutation = "typing".to_string();
+    let frame = render_pro_shell_layers(&state, "optics status", true);
+
+    let highlighted = format!("{USER_INPUT_BRIGHT_YELLOW}optics status");
+    assert!(frame.contains(&highlighted), "typed text must be bright yellow: {frame:?}");
+    assert_eq!(
+        frame.matches(USER_INPUT_BRIGHT_YELLOW).count(),
+        1,
+        "bright yellow is reserved for typed/copied user input only: {frame:?}"
+    );
+    assert!(frame.contains("\x1b[36mA TOP RAIL"), "top rail should be cyan: {frame:?}");
+    assert!(frame.contains("\x1b[34mB COMMAND RAIL"), "command rail label should be blue: {frame:?}");
+    assert!(frame.contains("\x1b[32mC STATUS HUD"), "status hud should be green: {frame:?}");
+    assert!(frame.contains("\x1b[35mD BOTTOM HUD"), "bottom hud should be magenta: {frame:?}");
+}
+
+#[test]
+fn optics_user_input_highlight_reserves_bright_yellow() {
+    let colored = colorize_user_input("rm scratch", true);
+    assert!(colored.contains(USER_INPUT_BRIGHT_YELLOW));
+    assert!(colored.contains("rm scratch"));
+    assert_eq!(colored.matches(USER_INPUT_BRIGHT_YELLOW).count(), 1);
+
+    let plain = colorize_user_input("rm scratch", false);
+    assert_eq!(plain, "rm scratch");
 }
 
 #[test]


### PR DESCRIPTION
Adds the first Optics PRO shell rail color contract to the Rust renderer foundation.

Summary:
- Defines the A/B/C/D shell rail layer renderer: top rail, command rail, status HUD, bottom HUD.
- Preserves a blank line between the B command rail and C status HUD for readability.
- Adds a strict color rule reserving bright yellow only for user typed/copied input.
- Color-codes the non-input layers distinctly: top rail cyan, command rail label blue, status HUD green, bottom HUD magenta.
- Keeps this as renderer/test groundwork only; live Optics PRO shell activation remains a follow-up patch.

Validation:

```sh
git fetch origin
git switch feature/optics-pro-shell-rails
cargo fmt --all -- --check
cargo test -p phase1 --test optics_hud_rail_renderer
git status --short
```

Non-claims:
- Does not claim a compositor, terminal emulator, sandbox, security boundary, crypto enforcement, system integrity guarantee, or Base1 boot environment.
- Does not yet replace the active shell UI; that remains the next implementation slice.