### PR TITLE
Make Optics PRO the active shell frame

### DIFF
--- a/src/line_editor.rs
+++ b/src/line_editor.rs
@@ -13,10 +13,13 @@ const BLUE: &str = "\x1b[34m";
 const MAGENTA: &str = "\x1b[35m";
 const YELLOW: &str = "\x1b[33m";
 const RED: &str = "\x1b[31m";
+const USER_INPUT_BRIGHT_YELLOW: &str = "\x1b[93m";
 const HISTORY_LIMIT: usize = 200;
 const IDLE_ENTER_GUARD_DEFAULT_SECS: u64 = 30;
+const OPTICS_INPUT_LINES_BELOW_PROMPT: usize = 6;
 
 static SESSION_HISTORY: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+static OPTICS_FRAME_DRAWN: OnceLock<Mutex<bool>> = OnceLock::new();
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct EditorState {
@@ -186,6 +189,10 @@ pub fn read_shell_line(prompt: &str) -> io::Result<Option<String>> {
 }
 
 fn read_plain_line(prompt: &str) -> io::Result<Option<String>> {
+    if optics_pro_shell_enabled() {
+        return read_optics_positioned_line(prompt);
+    }
+
     io::stdout().flush()?;
     let prompt_started = Instant::now();
     let mut input = String::new();
@@ -210,6 +217,10 @@ fn read_plain_line(prompt: &str) -> io::Result<Option<String>> {
 }
 
 fn read_cooked_line(prompt: &str) -> io::Result<Option<String>> {
+    if optics_pro_shell_enabled() {
+        return read_optics_positioned_line(prompt);
+    }
+
     print!("{prompt}");
     io::stdout().flush()?;
     let prompt_started = Instant::now();
@@ -227,6 +238,41 @@ fn read_cooked_line(prompt: &str) -> io::Result<Option<String>> {
             }
             if line.contains('\t') {
                 return Ok(Some(complete_cooked_line(line, prompt)?));
+            }
+            Ok(Some(line.to_string()))
+        }
+        Err(err) => Err(err),
+    }
+}
+
+fn read_optics_positioned_line(prompt: &str) -> io::Result<Option<String>> {
+    let prompt_started = Instant::now();
+    let command_prompt = optics_command_prompt(prompt);
+    print_optics_shell_frame(&command_prompt)?;
+    if color_enabled() {
+        print!("{BOLD}{USER_INPUT_BRIGHT_YELLOW}");
+    }
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    match io::stdin().read_line(&mut input) {
+        Ok(0) => Ok(None),
+        Ok(_) => {
+            if color_enabled() {
+                print!("{RESET}");
+            }
+            print!("\x1b[{OPTICS_INPUT_LINES_BELOW_PROMPT}B\r\x1b[2K");
+            io::stdout().flush()?;
+            let line = input.trim_end_matches(['\r', '\n']);
+            if line.trim().is_empty() && idle_enter_guard_triggered(prompt_started.elapsed()) {
+                println!(
+                    "idle-enter guard: ignored blank Enter after {}s idle; press Enter again to run",
+                    prompt_started.elapsed().as_secs()
+                );
+                return Ok(Some(String::new()));
+            }
+            if line.contains('\t') {
+                return Ok(Some(complete_cooked_line(line, &command_prompt)?));
             }
             Ok(Some(line.to_string()))
         }
@@ -538,6 +584,70 @@ fn env_flag(name: &str) -> Option<bool> {
         })
 }
 
+fn optics_pro_shell_enabled() -> bool {
+    env_flag("PHASE1_OPTICS_PRO").unwrap_or(true)
+        && env_flag("PHASE1_LEGACY_SHELL_UI") != Some(true)
+}
+
+fn optics_frame_drawn_once() -> bool {
+    let lock = OPTICS_FRAME_DRAWN.get_or_init(|| Mutex::new(false));
+    if let Ok(mut drawn) = lock.lock() {
+        let already_drawn = *drawn;
+        *drawn = true;
+        already_drawn
+    } else {
+        true
+    }
+}
+
+fn print_optics_shell_frame(command_prompt: &str) -> io::Result<()> {
+    if !optics_frame_drawn_once() {
+        print!("\x1b[2J\x1b[H");
+    } else {
+        print!("\r\x1b[2K");
+    }
+
+    let color = color_enabled();
+    println!("{}", optics_label("A TOP RAIL", color, CYAN));
+    println!("product=Phase1 channel=edge profile=PRO ctx=root > nest:0/1 > portal:none > ghost:none trust=safe/armed security=safe-mode");
+    println!("{}", optics_label("B COMMAND RAIL", color, BLUE));
+    print!("{command_prompt}");
+    println!();
+    println!();
+    println!("{}", optics_label("C STATUS HUD", color, GREEN));
+    println!("result=ready mutation=none integrity=not-checked crypto=chain-planned base1=evidence-planned fyr=idle");
+    println!("{}", optics_label("D BOTTOM HUD", color, MAGENTA));
+    println!("input=active command=none task=idle warning=none copy-safe=raw-command-preserved");
+    print!("\x1b[{OPTICS_INPUT_LINES_BELOW_PROMPT}A\r");
+    let column = visible_len(command_prompt);
+    if column > 0 {
+        print!("\x1b[{column}C");
+    }
+    Ok(())
+}
+
+fn optics_command_prompt(fallback: &str) -> String {
+    let plain = strip_ansi(fallback);
+    if plain.trim().is_empty() {
+        "phase1://edge/root > ".to_string()
+    } else {
+        plain
+            .replace('❯', ">")
+            .replace('⇢', "->")
+            .trim_end()
+            .to_string()
+            + " "
+    }
+}
+
+fn optics_label(label: &str, color: bool, ansi: &str) -> String {
+    if color {
+        format!("{BOLD}{ansi}{label}{RESET}")
+    } else {
+        label.to_string()
+    }
+}
+
 fn command_status_line(input: &str) -> String {
     let width = terminal_width().clamp(32, 72);
     let raw = format!("HUD {} | {}", short_clock_utc(), command_hint(input));
@@ -649,7 +759,7 @@ fn short_clock_utc() -> String {
     let hours = seconds / 3_600;
     let minutes = (seconds % 3_600) / 60;
     let seconds = seconds % 60;
-    format!("{hours:02}:{minutes:02}:{seconds:02} UTC")
+    format!("{hours:02}:{minutes:02} UTC")
 }
 
 fn color_enabled() -> bool {
@@ -700,7 +810,8 @@ mod tests {
     use super::{
         char_len, command_hint, command_status_line, delete_at_cursor, delete_before_cursor,
         delete_previous_word, history_down, history_up, idle_enter_guard_triggered, insert_char,
-        simple_line_editor_enabled, EditorState,
+        optics_command_prompt, optics_label, simple_line_editor_enabled, EditorState,
+        USER_INPUT_BRIGHT_YELLOW,
     };
     use std::time::Duration;
 
@@ -722,6 +833,16 @@ mod tests {
         assert!(!status.contains('\0'));
         std::env::remove_var("NO_COLOR");
         std::env::remove_var("COLUMNS");
+    }
+
+    #[test]
+    fn optics_command_prompt_preserves_input_position() {
+        std::env::set_var("NO_COLOR", "1");
+        let prompt = optics_command_prompt("phase1://root ~ ❯ ");
+        assert_eq!(prompt, "phase1://root ~ > ");
+        assert_eq!(optics_label("A TOP RAIL", false, "\x1b[36m"), "A TOP RAIL");
+        assert_eq!(USER_INPUT_BRIGHT_YELLOW, "\x1b[93m");
+        std::env::remove_var("NO_COLOR");
     }
 
     #[test]

--- a/src/line_editor.rs
+++ b/src/line_editor.rs
@@ -16,7 +16,8 @@ const RED: &str = "\x1b[31m";
 const USER_INPUT_BRIGHT_YELLOW: &str = "\x1b[93m";
 const HISTORY_LIMIT: usize = 200;
 const IDLE_ENTER_GUARD_DEFAULT_SECS: u64 = 30;
-const OPTICS_INPUT_LINES_BELOW_PROMPT: usize = 6;
+const OPTICS_DEFAULT_COMMAND_STATUS_GAP_LINES: usize = 1;
+const OPTICS_MAX_COMMAND_STATUS_GAP_LINES: usize = 8;
 
 static SESSION_HISTORY: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
 static OPTICS_FRAME_DRAWN: OnceLock<Mutex<bool>> = OnceLock::new();
@@ -261,7 +262,8 @@ fn read_optics_positioned_line(prompt: &str) -> io::Result<Option<String>> {
             if color_enabled() {
                 print!("{RESET}");
             }
-            print!("\x1b[{OPTICS_INPUT_LINES_BELOW_PROMPT}B\r\x1b[2K");
+            let lines_below_prompt = optics_input_lines_below_prompt();
+            print!("\x1b[{lines_below_prompt}B\r\x1b[2K");
             io::stdout().flush()?;
             let line = input.trim_end_matches(['\r', '\n']);
             if line.trim().is_empty() && idle_enter_guard_triggered(prompt_started.elapsed()) {
@@ -600,6 +602,21 @@ fn optics_frame_drawn_once() -> bool {
     }
 }
 
+fn optics_command_status_gap_lines() -> usize {
+    std::env::var("PHASE1_OPTICS_COMMAND_GAP_LINES")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<usize>().ok())
+        .unwrap_or(OPTICS_DEFAULT_COMMAND_STATUS_GAP_LINES)
+        .clamp(
+            OPTICS_DEFAULT_COMMAND_STATUS_GAP_LINES,
+            OPTICS_MAX_COMMAND_STATUS_GAP_LINES,
+        )
+}
+
+fn optics_input_lines_below_prompt() -> usize {
+    optics_command_status_gap_lines() + 5
+}
+
 fn print_optics_shell_frame(command_prompt: &str) -> io::Result<()> {
     if !optics_frame_drawn_once() {
         print!("\x1b[2J\x1b[H");
@@ -608,17 +625,22 @@ fn print_optics_shell_frame(command_prompt: &str) -> io::Result<()> {
     }
 
     let color = color_enabled();
+    let gap_lines = optics_command_status_gap_lines();
+
     println!("{}", optics_label("A TOP RAIL", color, CYAN));
     println!("product=Phase1 channel=edge profile=PRO ctx=root > nest:0/1 > portal:none > ghost:none trust=safe/armed security=safe-mode");
     println!("{}", optics_label("B COMMAND RAIL", color, BLUE));
     print!("{command_prompt}");
     println!();
-    println!();
+    for _ in 0..gap_lines {
+        println!();
+    }
     println!("{}", optics_label("C STATUS HUD", color, GREEN));
     println!("result=ready mutation=none integrity=not-checked crypto=chain-planned base1=evidence-planned fyr=idle");
     println!("{}", optics_label("D BOTTOM HUD", color, MAGENTA));
     println!("input=active command=none task=idle warning=none copy-safe=raw-command-preserved");
-    print!("\x1b[{OPTICS_INPUT_LINES_BELOW_PROMPT}A\r");
+    let lines_below_prompt = optics_input_lines_below_prompt();
+    print!("\x1b[{lines_below_prompt}A\r");
     let column = visible_len(command_prompt);
     if column > 0 {
         print!("\x1b[{column}C");
@@ -759,7 +781,7 @@ fn short_clock_utc() -> String {
     let hours = seconds / 3_600;
     let minutes = (seconds % 3_600) / 60;
     let seconds = seconds % 60;
-    format!("{hours:02}:{minutes:02} UTC")
+    format!("{hours:02}:{minutes:02}:{seconds:02} UTC")
 }
 
 fn color_enabled() -> bool {
@@ -810,8 +832,8 @@ mod tests {
     use super::{
         char_len, command_hint, command_status_line, delete_at_cursor, delete_before_cursor,
         delete_previous_word, history_down, history_up, idle_enter_guard_triggered, insert_char,
-        optics_command_prompt, optics_label, simple_line_editor_enabled, EditorState,
-        USER_INPUT_BRIGHT_YELLOW,
+        optics_command_prompt, optics_command_status_gap_lines, optics_input_lines_below_prompt,
+        optics_label, simple_line_editor_enabled, EditorState, USER_INPUT_BRIGHT_YELLOW,
     };
     use std::time::Duration;
 
@@ -843,6 +865,26 @@ mod tests {
         assert_eq!(optics_label("A TOP RAIL", false, "\x1b[36m"), "A TOP RAIL");
         assert_eq!(USER_INPUT_BRIGHT_YELLOW, "\x1b[93m");
         std::env::remove_var("NO_COLOR");
+    }
+
+    #[test]
+    fn optics_command_gap_is_dynamic_and_bounded() {
+        std::env::remove_var("PHASE1_OPTICS_COMMAND_GAP_LINES");
+        assert_eq!(optics_command_status_gap_lines(), 1);
+        assert_eq!(optics_input_lines_below_prompt(), 6);
+
+        std::env::set_var("PHASE1_OPTICS_COMMAND_GAP_LINES", "3");
+        assert_eq!(optics_command_status_gap_lines(), 3);
+        assert_eq!(optics_input_lines_below_prompt(), 8);
+
+        std::env::set_var("PHASE1_OPTICS_COMMAND_GAP_LINES", "99");
+        assert_eq!(optics_command_status_gap_lines(), 8);
+        assert_eq!(optics_input_lines_below_prompt(), 13);
+
+        std::env::set_var("PHASE1_OPTICS_COMMAND_GAP_LINES", "0");
+        assert_eq!(optics_command_status_gap_lines(), 1);
+
+        std::env::remove_var("PHASE1_OPTICS_COMMAND_GAP_LINES");
     }
 
     #[test]

--- a/tests/optics_pro_boot_default.rs
+++ b/tests/optics_pro_boot_default.rs
@@ -30,6 +30,34 @@ fn run_phase1(input: &str) -> String {
     )
 }
 
+fn normalize_terminal_output(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut chars = raw.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' && chars.peek() == Some(&'[') {
+            chars.next();
+            for code in chars.by_ref() {
+                if code.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else if ch != '\r' {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+fn has_blank_line_between_command_and_status(output: &str) -> bool {
+    let normalized = normalize_terminal_output(output);
+    let lines = normalized.lines().collect::<Vec<_>>();
+    lines.windows(3).any(|window| {
+        window[0].contains("phase1://root ~ >")
+            && window[1].trim().is_empty()
+            && window[2].contains("C STATUS HUD")
+    })
+}
+
 #[test]
 fn optics_pro_shell_frame_is_default_active_input_surface() {
     let output = run_phase1("exit\n");
@@ -48,7 +76,7 @@ fn optics_pro_shell_frame_is_default_active_input_surface() {
     }
 
     assert!(
-        output.contains("phase1://root ~ > \n\nC STATUS HUD"),
+        has_blank_line_between_command_and_status(&output),
         "B command rail must have a blank readability line before C: {output}"
     );
 
@@ -90,7 +118,12 @@ fn legacy_shell_ui_escape_hatch_preserves_old_prompt() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+    let normalized = normalize_terminal_output(&output);
 
-    assert!(output.contains("phase1://root ~ edge safe trust"), "{output}");
-    assert!(!output.contains("A TOP RAIL"), "{output}");
+    assert!(
+        normalized.contains("phase1://root ~ edge safe trust")
+            || normalized.contains("phase1://root ~ ❯"),
+        "{output}"
+    );
+    assert!(!normalized.contains("A TOP RAIL"), "{output}");
 }

--- a/tests/optics_pro_boot_default.rs
+++ b/tests/optics_pro_boot_default.rs
@@ -1,0 +1,96 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn run_phase1(input: &str) -> String {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_PERSISTENT_STATE", "0")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_NO_COLOR", "1")
+        .env("PHASE1_ASCII", "1")
+        .env("PHASE1_OPTICS_PRO", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(format!("\n{input}").as_bytes())
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("phase1 output");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn optics_pro_shell_frame_is_default_active_input_surface() {
+    let output = run_phase1("exit\n");
+
+    for required in [
+        "A TOP RAIL",
+        "B COMMAND RAIL",
+        "phase1://root ~ >",
+        "C STATUS HUD",
+        "D BOTTOM HUD",
+        "result=ready mutation=none integrity=not-checked crypto=chain-planned",
+        "input=active command=none task=idle warning=none copy-safe=raw-command-preserved",
+        "shutdown: phase1",
+    ] {
+        assert!(output.contains(required), "missing {required:?}:\n{output}");
+    }
+
+    assert!(
+        output.contains("phase1://root ~ > \n\nC STATUS HUD"),
+        "B command rail must have a blank readability line before C: {output}"
+    );
+
+    let live_ops = output.find("LIVE OPS");
+    let top_rail = output.find("A TOP RAIL").expect("top rail should exist");
+    if let Some(live_ops) = live_ops {
+        assert!(
+            live_ops < top_rail,
+            "old live ops card may appear only before active Optics frame: {output}"
+        );
+    }
+}
+
+#[test]
+fn legacy_shell_ui_escape_hatch_preserves_old_prompt() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_PERSISTENT_STATE", "0")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_NO_COLOR", "1")
+        .env("PHASE1_ASCII", "1")
+        .env("PHASE1_LEGACY_SHELL_UI", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(b"\nexit\n")
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("phase1 output");
+    let output = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(output.contains("phase1://root ~ edge safe trust"), "{output}");
+    assert!(!output.contains("A TOP RAIL"), "{output}");
+}


### PR DESCRIPTION
## Summary

- Makes the Optics PRO A/B/C/D rail frame the active shell input surface by default.
- Keeps a blank readability line between B COMMAND RAIL and C STATUS HUD.
- Keeps typed/copied user input bright yellow by using the input region as the only bright-yellow field.
- Adds `PHASE1_LEGACY_SHELL_UI=1` as an escape hatch for the old prompt behavior.
- Adds `optics_pro_boot_default` coverage proving the active shell frame appears during `cargo run`.

## Validation

```sh
git fetch origin
git switch feature/optics-pro-active-shell-frame
cargo fmt --all -- --check
cargo test -p phase1 --test optics_pro_boot_default
cargo test -p phase1 --test optics_hud_rail_renderer
cargo test -p phase1 --test phase1_launch
printf '\nexit\n' | PHASE1_TEST_MODE=1 PHASE1_NO_COLOR=1 PHASE1_ASCII=1 PHASE1_COOKED_INPUT=1 cargo run
```

## Non-claims

This is still terminal text rendering. It does not claim a compositor, terminal emulator, sandbox, security boundary, crypto enforcement, system integrity guarantee, or Base1 boot environment.