### PR TITLE
Document Optics rail configuration

### DIFF
--- a/docs/ui/OPTICS_PRO_UI.md
+++ b/docs/ui/OPTICS_PRO_UI.md
@@ -48,6 +48,8 @@ The first visual state should communicate:
 
 The HUD rail screen real estate model is defined in [`OPTICS_HUD_RAILS.md`](OPTICS_HUD_RAILS.md).
 
+The active rail configuration contract is defined in [`OPTICS_RAIL_CONFIGURATION.md`](OPTICS_RAIL_CONFIGURATION.md).
+
 Optics PRO should use:
 
 - a top HUD rail for global system state, context, trust, integrity, crypto chain, Base1, Fyr, nest, portal, and ghost summaries;
@@ -219,4 +221,5 @@ cargo test -p phase1 --test optics_pro_ui_plan_docs
 cargo test -p phase1 --test optics_pro_preview_fixture_docs
 cargo test -p phase1 --test optics_hud_rails_docs
 cargo test -p phase1 --test optics_command_surface_docs
+cargo test -p phase1 --test optics_rail_configuration_docs
 ```

--- a/docs/ui/OPTICS_RAIL_CONFIGURATION.md
+++ b/docs/ui/OPTICS_RAIL_CONFIGURATION.md
@@ -1,0 +1,142 @@
+# Optics Rail Configuration
+
+Status: configuration contract
+Scope: Optics PRO active shell rails, command/status gap allocation, color safety, and fallback controls.
+
+## Purpose
+
+Optics PRO uses a rail-style shell frame to keep the operator oriented while preserving the center command area as the primary workspace.
+
+The shell frame has four layers:
+
+```text
+A TOP RAIL
+B COMMAND RAIL
+
+C STATUS HUD
+D BOTTOM HUD
+```
+
+The blank line between B and C is intentional and may grow when the operator needs more writing room.
+
+## Default behavior
+
+By default, Phase1 should start the active shell using Optics PRO rails.
+
+The old shell prompt remains available through an explicit legacy escape hatch only.
+
+## Configuration variables
+
+```text
+PHASE1_OPTICS_PRO=1
+```
+
+Enables the Optics PRO active shell frame. This is the default when the variable is not set.
+
+```text
+PHASE1_OPTICS_PRO=0
+```
+
+Disables the Optics PRO active shell frame.
+
+```text
+PHASE1_LEGACY_SHELL_UI=1
+```
+
+Forces the legacy shell prompt. This must override the default Optics PRO shell frame.
+
+```text
+PHASE1_OPTICS_COMMAND_GAP_LINES=<number>
+```
+
+Controls the number of blank lines between the command rail and the status HUD.
+
+The supported range is:
+
+```text
+minimum: 1
+maximum: 8
+```
+
+Values below the minimum clamp to 1. Values above the maximum clamp to 8.
+
+## Layer responsibilities
+
+### A TOP RAIL
+
+The top rail shows stable context:
+
+- product;
+- channel;
+- profile;
+- root/nest/portal/ghost context;
+- trust state;
+- security mode.
+
+### B COMMAND RAIL
+
+The command rail is the active typing area.
+
+Only typed or pasted operator input may use bright yellow.
+
+No other label, status, warning, or rail title may use bright yellow.
+
+### C STATUS HUD
+
+The status HUD shows live interpretation and safety context:
+
+- result state;
+- mutation state;
+- integrity state;
+- crypto chain state;
+- Base1 state;
+- Fyr state.
+
+### D BOTTOM HUD
+
+The bottom HUD shows persistent operator cues:
+
+- input state;
+- command family;
+- active task;
+- warning state;
+- copy/paste safety rule.
+
+## Color policy
+
+The color policy exists for readability, not decoration.
+
+- A TOP RAIL: cyan
+- B COMMAND RAIL label: blue
+- typed/pasted operator input: bright yellow only
+- C STATUS HUD: green
+- D BOTTOM HUD: magenta
+- denied/failed/unsafe states: red
+
+Bright yellow is reserved for operator input only.
+
+## Dynamic spacing policy
+
+The B-to-C gap exists to make typing, pasted commands, code fragments, and future multi-line editing easier to read.
+
+Current configuration is environment-driven.
+
+Future live controls may use a key chord such as Shift+Enter or another terminal-supported equivalent to grow the B-to-C gap interactively.
+
+## Non-claims
+
+Optics rail configuration does not claim:
+
+- compositor behavior;
+- terminal emulator behavior;
+- sandboxing;
+- security boundary enforcement;
+- crypto enforcement;
+- system integrity guarantees;
+- Base1 boot environment completion.
+
+## Current status
+
+This document preserves the Optics rail configuration contract.
+
+Live interactive gap resizing remains future work.

--- a/tests/optics_rail_configuration_docs.rs
+++ b/tests/optics_rail_configuration_docs.rs
@@ -6,7 +6,8 @@ const COMMAND_DOC: &str = "docs/ui/OPTICS_COMMAND_SURFACE.md";
 
 #[test]
 fn optics_rail_configuration_doc_exists_and_defines_scope() {
-    let doc = fs::read_to_string(RAIL_CONFIG_DOC).expect("Optics rail configuration doc should exist");
+    let doc =
+        fs::read_to_string(RAIL_CONFIG_DOC).expect("Optics rail configuration doc should exist");
 
     for required in [
         "# Optics Rail Configuration",
@@ -24,7 +25,8 @@ fn optics_rail_configuration_doc_exists_and_defines_scope() {
 
 #[test]
 fn optics_rail_configuration_documents_environment_controls() {
-    let doc = fs::read_to_string(RAIL_CONFIG_DOC).expect("Optics rail configuration doc should exist");
+    let doc =
+        fs::read_to_string(RAIL_CONFIG_DOC).expect("Optics rail configuration doc should exist");
 
     for required in [
         "PHASE1_OPTICS_PRO=1",
@@ -42,7 +44,8 @@ fn optics_rail_configuration_documents_environment_controls() {
 
 #[test]
 fn optics_rail_configuration_preserves_layer_responsibilities() {
-    let doc = fs::read_to_string(RAIL_CONFIG_DOC).expect("Optics rail configuration doc should exist");
+    let doc =
+        fs::read_to_string(RAIL_CONFIG_DOC).expect("Optics rail configuration doc should exist");
 
     for required in [
         "product",
@@ -64,7 +67,8 @@ fn optics_rail_configuration_preserves_layer_responsibilities() {
 
 #[test]
 fn optics_rail_configuration_preserves_color_policy() {
-    let doc = fs::read_to_string(RAIL_CONFIG_DOC).expect("Optics rail configuration doc should exist");
+    let doc =
+        fs::read_to_string(RAIL_CONFIG_DOC).expect("Optics rail configuration doc should exist");
 
     for required in [
         "A TOP RAIL: cyan",
@@ -81,7 +85,8 @@ fn optics_rail_configuration_preserves_color_policy() {
 
 #[test]
 fn optics_rail_configuration_preserves_dynamic_spacing_and_non_claims() {
-    let doc = fs::read_to_string(RAIL_CONFIG_DOC).expect("Optics rail configuration doc should exist");
+    let doc =
+        fs::read_to_string(RAIL_CONFIG_DOC).expect("Optics rail configuration doc should exist");
 
     for required in [
         "B-to-C gap",

--- a/tests/optics_rail_configuration_docs.rs
+++ b/tests/optics_rail_configuration_docs.rs
@@ -1,0 +1,115 @@
+use std::fs;
+
+const RAIL_CONFIG_DOC: &str = "docs/ui/OPTICS_RAIL_CONFIGURATION.md";
+const OPTICS_DOC: &str = "docs/ui/OPTICS_PRO_UI.md";
+const COMMAND_DOC: &str = "docs/ui/OPTICS_COMMAND_SURFACE.md";
+
+#[test]
+fn optics_rail_configuration_doc_exists_and_defines_scope() {
+    let doc = fs::read_to_string(RAIL_CONFIG_DOC).expect("Optics rail configuration doc should exist");
+
+    for required in [
+        "# Optics Rail Configuration",
+        "Status: configuration contract",
+        "Optics PRO active shell rails",
+        "A TOP RAIL",
+        "B COMMAND RAIL",
+        "C STATUS HUD",
+        "D BOTTOM HUD",
+        "blank line between B and C",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn optics_rail_configuration_documents_environment_controls() {
+    let doc = fs::read_to_string(RAIL_CONFIG_DOC).expect("Optics rail configuration doc should exist");
+
+    for required in [
+        "PHASE1_OPTICS_PRO=1",
+        "PHASE1_OPTICS_PRO=0",
+        "PHASE1_LEGACY_SHELL_UI=1",
+        "PHASE1_OPTICS_COMMAND_GAP_LINES=<number>",
+        "minimum: 1",
+        "maximum: 8",
+        "Values below the minimum clamp to 1.",
+        "Values above the maximum clamp to 8.",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn optics_rail_configuration_preserves_layer_responsibilities() {
+    let doc = fs::read_to_string(RAIL_CONFIG_DOC).expect("Optics rail configuration doc should exist");
+
+    for required in [
+        "product",
+        "channel",
+        "profile",
+        "root/nest/portal/ghost context",
+        "active typing area",
+        "result state",
+        "mutation state",
+        "integrity state",
+        "crypto chain state",
+        "Base1 state",
+        "Fyr state",
+        "persistent operator cues",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn optics_rail_configuration_preserves_color_policy() {
+    let doc = fs::read_to_string(RAIL_CONFIG_DOC).expect("Optics rail configuration doc should exist");
+
+    for required in [
+        "A TOP RAIL: cyan",
+        "B COMMAND RAIL label: blue",
+        "typed/pasted operator input: bright yellow only",
+        "C STATUS HUD: green",
+        "D BOTTOM HUD: magenta",
+        "denied/failed/unsafe states: red",
+        "Bright yellow is reserved for operator input only.",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn optics_rail_configuration_preserves_dynamic_spacing_and_non_claims() {
+    let doc = fs::read_to_string(RAIL_CONFIG_DOC).expect("Optics rail configuration doc should exist");
+
+    for required in [
+        "B-to-C gap",
+        "future multi-line editing",
+        "Shift+Enter",
+        "terminal-supported equivalent",
+        "Live interactive gap resizing remains future work.",
+        "does not claim",
+        "compositor behavior",
+        "terminal emulator behavior",
+        "sandboxing",
+        "security boundary enforcement",
+        "crypto enforcement",
+        "system integrity guarantees",
+        "Base1 boot environment completion",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn optics_rail_configuration_is_linked_from_existing_optics_docs() {
+    let optics = fs::read_to_string(OPTICS_DOC).expect("Optics PRO UI doc should exist");
+    let command = fs::read_to_string(COMMAND_DOC).expect("Optics command surface doc should exist");
+
+    assert!(
+        optics.contains("OPTICS_RAIL_CONFIGURATION.md")
+            || command.contains("OPTICS_RAIL_CONFIGURATION.md"),
+        "rail configuration doc should be linked from existing Optics docs"
+    );
+}


### PR DESCRIPTION
## Summary

Adds the Optics rail configuration contract before moving on to Fyr whitespace work.

This documents and tests:

- A/B/C/D rail layer responsibilities.
- Default Optics PRO shell behavior and the legacy escape hatch.
- `PHASE1_OPTICS_PRO` and `PHASE1_LEGACY_SHELL_UI` behavior.
- `PHASE1_OPTICS_COMMAND_GAP_LINES` dynamic spacing behavior.
- Minimum and maximum gap clamp expectations.
- Color policy, including bright yellow reserved only for typed/pasted operator input.
- Dynamic spacing policy for future Shift+Enter or terminal-supported equivalents.
- Non-claims for compositor, terminal emulator, sandbox, security boundary, crypto enforcement, system integrity guarantee, and Base1 boot environment.

## Validation

```sh
git fetch origin
git switch feature/optics-rail-config
cargo fmt --all -- --check
cargo test -p phase1 --test optics_rail_configuration_docs
cargo test -p phase1 --test optics_pro_ui_plan_docs
cargo test -p phase1 --test optics_pro_boot_default
cargo test -p phase1 --test optics_hud_rail_renderer
```

## Follow-up

After this, implement live rail resizing controls and then move to the Fyr whitespace normalization contract.