### PR TITLE
Document Fyr native execution guidance

### DIFF
--- a/docs/fyr/NATIVE_EXECUTION_GUIDANCE.md
+++ b/docs/fyr/NATIVE_EXECUTION_GUIDANCE.md
@@ -1,0 +1,111 @@
+# Fyr native execution guidance
+
+Status: active operator guidance
+Scope: safe use of Fyr inline/native execution versus file-backed `.fyr` source workflows.
+
+## Purpose
+
+Fyr can be exercised from the Phase1 native command surface, but native inline runs should stay short and disposable.
+
+Real Fyr work should be saved into `.fyr` source files and edited with an editor.
+
+This keeps Fyr programs reviewable, repeatable, testable, and recoverable.
+
+## Rule
+
+Use native or inline Fyr execution only for:
+
+- short parser checks;
+- quick expression tests;
+- smoke tests;
+- command-surface verification;
+- tiny examples that do not need to be saved.
+
+Use `.fyr` files for:
+
+- real programs;
+- package work;
+- reusable scripts;
+- examples that should be committed;
+- tests;
+- automation candidates;
+- anything that might need review, diffing, recovery, or repeat execution.
+
+## Recommended workflow
+
+Prefer this shape for real work:
+
+```text
+fyr init app
+avim app/src/main.fyr
+fyr check app
+fyr test app
+fyr run app/src/main.fyr
+```
+
+Single-file work should also be file-backed:
+
+```text
+fyr new hello.fyr
+avim hello.fyr
+fyr check hello.fyr
+fyr run hello.fyr
+```
+
+## Native execution boundary
+
+Native execution is useful for checking that Fyr is alive and for testing tiny snippets.
+
+It should not become the normal place where operators write programs.
+
+The native environment should not encourage long, unsaved source text, because long inline input is harder to:
+
+- save;
+- recover;
+- diff;
+- format;
+- review;
+- test repeatedly;
+- attach to package workflows;
+- inspect during failures.
+
+## Editor expectation
+
+Operators should use an editor for meaningful Fyr source.
+
+Current acceptable editor paths include Phase1 editor commands such as:
+
+```text
+avim file.fyr
+ned file.fyr
+```
+
+Host editors may be used only through explicit host-facing workflows outside Fyr's VFS-first safety boundary.
+
+## Package and test expectation
+
+Package/check/build/test/run workflows should prefer file-backed sources.
+
+A package should keep source and tests under stable paths:
+
+```text
+fyr.toml
+src/main.fyr
+tests/smoke.fyr
+```
+
+## Safety relationship
+
+This guidance supports the existing Fyr safety model:
+
+- VFS-first by default;
+- no host shell by default;
+- no host compiler by default;
+- no network by default;
+- deterministic outputs for check/build/test/run evidence.
+
+## Non-claims
+
+This guidance does not claim Fyr is production-ready, hardened, audited, or a general-purpose sandbox.
+
+It is operator workflow guidance for keeping Fyr usage evidence-bound and file-backed.

--- a/docs/fyr/SAFETY_MODEL.md
+++ b/docs/fyr/SAFETY_MODEL.md
@@ -19,6 +19,14 @@ Current Fyr workflows must preserve these defaults:
 - Package build output reports `backend : seed/interpreted` and `host    : none`.
 - Diagnostics should name Fyr files/packages without exposing host paths unless the operator explicitly chose a host-facing workflow outside Fyr.
 
+## Native execution guidance
+
+Native or inline Fyr execution is for short tests and quick checks only.
+
+Meaningful Fyr work should be saved into `.fyr` files and edited with an editor.
+
+The detailed operator workflow is documented in [`NATIVE_EXECUTION_GUIDANCE.md`](NATIVE_EXECUTION_GUIDANCE.md).
+
 ## Current allowed operations
 
 Current Fyr commands may:
@@ -126,6 +134,7 @@ Related docs:
 
 - [`TOOLCHAIN.md`](TOOLCHAIN.md)
 - [`LANGUAGE_BOOK.md`](LANGUAGE_BOOK.md)
+- [`NATIVE_EXECUTION_GUIDANCE.md`](NATIVE_EXECUTION_GUIDANCE.md)
 - [`ROADMAP.md`](ROADMAP.md)
 - [`../status/FYR_PHASE1_100_COMPLETION_GATES.md`](../status/FYR_PHASE1_100_COMPLETION_GATES.md)
 

--- a/docs/fyr/TOOLCHAIN.md
+++ b/docs/fyr/TOOLCHAIN.md
@@ -28,6 +28,8 @@ tests/
 
 The Fyr safety boundary is documented in [`SAFETY_MODEL.md`](SAFETY_MODEL.md).
 
+Native execution workflow guidance is documented in [`NATIVE_EXECUTION_GUIDANCE.md`](NATIVE_EXECUTION_GUIDANCE.md).
+
 Current defaults:
 
 - VFS-only.
@@ -38,10 +40,19 @@ Current defaults:
 - Deterministic dry-run build output.
 - Build output reports `backend : seed/interpreted` and `host    : none`.
 
+## Operator workflow guidance
+
+Use native or inline Fyr execution only for short tests and quick checks.
+
+Use `.fyr` files edited with an editor for real work.
+
+Prefer file-backed package/check/build/test/run workflows over long unsaved native input.
+
 ## Example
 
 ```text
 fyr init hello
+avim hello/src/main.fyr
 fyr check hello
 fyr build hello
 fyr run hello/src/main.fyr

--- a/tests/fyr_native_execution_guidance_docs.rs
+++ b/tests/fyr_native_execution_guidance_docs.rs
@@ -6,7 +6,8 @@ const TOOLCHAIN_DOC: &str = "docs/fyr/TOOLCHAIN.md";
 
 #[test]
 fn fyr_native_execution_guidance_doc_exists_and_defines_scope() {
-    let doc = fs::read_to_string(GUIDANCE_DOC).expect("Fyr native execution guidance doc should exist");
+    let doc =
+        fs::read_to_string(GUIDANCE_DOC).expect("Fyr native execution guidance doc should exist");
 
     for required in [
         "# Fyr native execution guidance",
@@ -21,7 +22,8 @@ fn fyr_native_execution_guidance_doc_exists_and_defines_scope() {
 
 #[test]
 fn fyr_native_execution_guidance_limits_inline_native_runs_to_short_tests() {
-    let doc = fs::read_to_string(GUIDANCE_DOC).expect("Fyr native execution guidance doc should exist");
+    let doc =
+        fs::read_to_string(GUIDANCE_DOC).expect("Fyr native execution guidance doc should exist");
 
     for required in [
         "Use native or inline Fyr execution only for:",
@@ -38,7 +40,8 @@ fn fyr_native_execution_guidance_limits_inline_native_runs_to_short_tests() {
 
 #[test]
 fn fyr_native_execution_guidance_requires_file_backed_real_work() {
-    let doc = fs::read_to_string(GUIDANCE_DOC).expect("Fyr native execution guidance doc should exist");
+    let doc =
+        fs::read_to_string(GUIDANCE_DOC).expect("Fyr native execution guidance doc should exist");
 
     for required in [
         "Use `.fyr` files for:",
@@ -60,7 +63,8 @@ fn fyr_native_execution_guidance_requires_file_backed_real_work() {
 
 #[test]
 fn fyr_native_execution_guidance_preserves_editor_and_package_expectations() {
-    let doc = fs::read_to_string(GUIDANCE_DOC).expect("Fyr native execution guidance doc should exist");
+    let doc =
+        fs::read_to_string(GUIDANCE_DOC).expect("Fyr native execution guidance doc should exist");
 
     for required in [
         "Operators should use an editor for meaningful Fyr source.",
@@ -77,7 +81,8 @@ fn fyr_native_execution_guidance_preserves_editor_and_package_expectations() {
 
 #[test]
 fn fyr_native_execution_guidance_preserves_safety_relationship_and_non_claims() {
-    let doc = fs::read_to_string(GUIDANCE_DOC).expect("Fyr native execution guidance doc should exist");
+    let doc =
+        fs::read_to_string(GUIDANCE_DOC).expect("Fyr native execution guidance doc should exist");
 
     for required in [
         "VFS-first by default",
@@ -100,7 +105,10 @@ fn fyr_native_execution_guidance_is_linked_from_safety_and_toolchain_docs() {
     let toolchain = fs::read_to_string(TOOLCHAIN_DOC).expect("Fyr toolchain doc should exist");
 
     assert!(safety.contains("NATIVE_EXECUTION_GUIDANCE.md"), "{safety}");
-    assert!(toolchain.contains("NATIVE_EXECUTION_GUIDANCE.md"), "{toolchain}");
+    assert!(
+        toolchain.contains("NATIVE_EXECUTION_GUIDANCE.md"),
+        "{toolchain}"
+    );
     assert!(
         safety.contains("Native or inline Fyr execution is for short tests and quick checks only."),
         "{safety}"

--- a/tests/fyr_native_execution_guidance_docs.rs
+++ b/tests/fyr_native_execution_guidance_docs.rs
@@ -1,0 +1,112 @@
+use std::fs;
+
+const GUIDANCE_DOC: &str = "docs/fyr/NATIVE_EXECUTION_GUIDANCE.md";
+const SAFETY_DOC: &str = "docs/fyr/SAFETY_MODEL.md";
+const TOOLCHAIN_DOC: &str = "docs/fyr/TOOLCHAIN.md";
+
+#[test]
+fn fyr_native_execution_guidance_doc_exists_and_defines_scope() {
+    let doc = fs::read_to_string(GUIDANCE_DOC).expect("Fyr native execution guidance doc should exist");
+
+    for required in [
+        "# Fyr native execution guidance",
+        "Status: active operator guidance",
+        "safe use of Fyr inline/native execution",
+        "file-backed `.fyr` source workflows",
+        "Real Fyr work should be saved into `.fyr` source files and edited with an editor.",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn fyr_native_execution_guidance_limits_inline_native_runs_to_short_tests() {
+    let doc = fs::read_to_string(GUIDANCE_DOC).expect("Fyr native execution guidance doc should exist");
+
+    for required in [
+        "Use native or inline Fyr execution only for:",
+        "short parser checks",
+        "quick expression tests",
+        "smoke tests",
+        "command-surface verification",
+        "tiny examples that do not need to be saved",
+        "It should not become the normal place where operators write programs.",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn fyr_native_execution_guidance_requires_file_backed_real_work() {
+    let doc = fs::read_to_string(GUIDANCE_DOC).expect("Fyr native execution guidance doc should exist");
+
+    for required in [
+        "Use `.fyr` files for:",
+        "real programs",
+        "package work",
+        "reusable scripts",
+        "tests",
+        "automation candidates",
+        "review, diffing, recovery, or repeat execution",
+        "fyr init app",
+        "avim app/src/main.fyr",
+        "fyr check app",
+        "fyr test app",
+        "fyr run app/src/main.fyr",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn fyr_native_execution_guidance_preserves_editor_and_package_expectations() {
+    let doc = fs::read_to_string(GUIDANCE_DOC).expect("Fyr native execution guidance doc should exist");
+
+    for required in [
+        "Operators should use an editor for meaningful Fyr source.",
+        "avim file.fyr",
+        "ned file.fyr",
+        "Package/check/build/test/run workflows should prefer file-backed sources.",
+        "fyr.toml",
+        "src/main.fyr",
+        "tests/smoke.fyr",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn fyr_native_execution_guidance_preserves_safety_relationship_and_non_claims() {
+    let doc = fs::read_to_string(GUIDANCE_DOC).expect("Fyr native execution guidance doc should exist");
+
+    for required in [
+        "VFS-first by default",
+        "no host shell by default",
+        "no host compiler by default",
+        "no network by default",
+        "deterministic outputs for check/build/test/run evidence",
+        "does not claim Fyr is production-ready",
+        "hardened",
+        "audited",
+        "general-purpose sandbox",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn fyr_native_execution_guidance_is_linked_from_safety_and_toolchain_docs() {
+    let safety = fs::read_to_string(SAFETY_DOC).expect("Fyr safety model doc should exist");
+    let toolchain = fs::read_to_string(TOOLCHAIN_DOC).expect("Fyr toolchain doc should exist");
+
+    assert!(safety.contains("NATIVE_EXECUTION_GUIDANCE.md"), "{safety}");
+    assert!(toolchain.contains("NATIVE_EXECUTION_GUIDANCE.md"), "{toolchain}");
+    assert!(
+        safety.contains("Native or inline Fyr execution is for short tests and quick checks only."),
+        "{safety}"
+    );
+    assert!(
+        toolchain.contains("Use `.fyr` files edited with an editor for real work."),
+        "{toolchain}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds operator guidance for using Fyr native/inline execution versus file-backed `.fyr` source workflows.

This preserves the rule that:

- native or inline Fyr execution is for short tests and quick checks only;
- real Fyr work should be saved in `.fyr` files;
- meaningful Fyr source should be edited with an editor;
- package/check/build/test/run workflows should prefer file-backed sources.

## Validation

```sh
git fetch origin
git switch feature/fyr-native-execution-guidance
cargo fmt --all -- --check
cargo test -p phase1 --test fyr_native_execution_guidance_docs
cargo test -p phase1 --test fyr_safety_model_docs
cargo test -p phase1 --test fyr_runtime_toolchain
```

## Non-claims

This does not claim Fyr is production-ready, hardened, audited, or a general-purpose sandbox.