### PR TITLE
Document Fyr whitespace normalization

### DIFF
--- a/docs/fyr/LANGUAGE_BOOK.md
+++ b/docs/fyr/LANGUAGE_BOOK.md
@@ -100,7 +100,33 @@ Example:
 fn main() -> i32 { let answer = 42; if (answer > 40 && answer < 50) { return answer; } return 0; }
 ```
 
-## 6. Diagnostics
+## 6. Whitespace
+
+Fyr whitespace behavior is defined in [`WHITESPACE_NORMALIZATION.md`](WHITESPACE_NORMALIZATION.md).
+
+Core rule:
+
+- spaces between normal tokens should not change program meaning;
+- spaces inside strings, text literals, comments, and any future indentation-sensitive syntax must be preserved.
+
+Example equivalent forms:
+
+```fyr
+let x=1+2;
+let x = 1 + 2;
+let   x   =   1   +   2;
+```
+
+Example preserved literal spacing:
+
+```fyr
+print("hello world");
+print("hello   world");
+```
+
+Those string literals are not equivalent because the spaces are literal content.
+
+## 7. Diagnostics
 
 Current diagnostics are designed to be deterministic and VFS-facing. Covered diagnostics include:
 
@@ -119,7 +145,7 @@ Current diagnostics are designed to be deterministic and VFS-facing. Covered dia
 
 Diagnostics should identify the Fyr file or package target where possible.
 
-## 7. Tooling commands
+## 8. Tooling commands
 
 Current commands:
 
@@ -147,7 +173,7 @@ Safety model:
 - No host compiler.
 - Deterministic dry-run build output.
 
-## 8. Phase1 integration
+## 9. Phase1 integration
 
 Fyr is part of Phase1, not a separate production language. The intended path is:
 
@@ -157,7 +183,7 @@ Fyr is part of Phase1, not a separate production language. The intended path is:
 4. Use F5 self-workflows to help Phase1 inspect, copy, construct, and validate itself.
 5. Add a small standard library only after the runtime is bounded and tested.
 
-## 9. Examples
+## 10. Examples
 
 Current examples:
 
@@ -169,9 +195,10 @@ Current roadmap and toolchain docs:
 - [`ROADMAP.md`](ROADMAP.md)
 - [`TOOLCHAIN.md`](TOOLCHAIN.md)
 - [`README.md`](README.md)
+- [`NATIVE_EXECUTION_GUIDANCE.md`](NATIVE_EXECUTION_GUIDANCE.md)
 - [`../status/FYR_PHASE1_100_COMPLETION_GATES.md`](../status/FYR_PHASE1_100_COMPLETION_GATES.md)
 
-## 10. Validation links
+## 11. Validation links
 
 Current Fyr-focused integration tests include:
 
@@ -183,7 +210,7 @@ Current Fyr-focused integration tests include:
 - `tests/fyr_f3_package_diagnostics.rs`
 - `tests/fyr_f3_expression_diagnostics.rs`
 
-## 11. Contributor guide
+## 12. Contributor guide
 
 When adding Fyr behavior:
 
@@ -193,7 +220,7 @@ When adding Fyr behavior:
 4. Do not raise public completion percentages manually.
 5. Preserve non-claims unless release evidence supports changing them.
 
-## 12. Roadmap
+## 13. Roadmap
 
 Fyr's 100% gate is evidence-bound. All F0-F7 gates must be satisfied before public wording can move from "Phase1-native language track" to "Phase1's native scripting language." See [`../status/FYR_PHASE1_100_COMPLETION_GATES.md`](../status/FYR_PHASE1_100_COMPLETION_GATES.md).
 
@@ -203,3 +230,4 @@ Fyr's 100% gate is evidence-bound. All F0-F7 gates must be satisfied before publ
 - [`../../docs/project/PHASE1_NATIVE_LANGUAGE.md`](../../docs/project/PHASE1_NATIVE_LANGUAGE.md)
 - [`ROADMAP.md`](ROADMAP.md)
 - [`TOOLCHAIN.md`](TOOLCHAIN.md)
+- [`WHITESPACE_NORMALIZATION.md`](WHITESPACE_NORMALIZATION.md)

--- a/docs/fyr/WHITESPACE_NORMALIZATION.md
+++ b/docs/fyr/WHITESPACE_NORMALIZATION.md
@@ -1,0 +1,92 @@
+# Fyr whitespace normalization
+
+Status: language contract
+Scope: insignificant whitespace between Fyr tokens, preservation of meaningful whitespace, and future parser/runtime expectations.
+
+## Purpose
+
+Fyr should be comfortable to write and edit in `.fyr` files without making spacing style fragile.
+
+Whitespace between normal language tokens should not change program meaning.
+
+Whitespace inside strings, text literals, comments, and any future indentation-sensitive syntax must be preserved according to that construct's rules.
+
+## Core rule
+
+These forms should be equivalent when they use the same tokens:
+
+```fyr
+let x=1+2;
+let x = 1 + 2;
+let   x   =   1   +   2;
+```
+
+The parser should treat insignificant whitespace as a separator or visual formatting aid, not as semantic content.
+
+## Must normalize
+
+Fyr should ignore insignificant whitespace around:
+
+- assignment operators;
+- arithmetic operators;
+- comparison operators;
+- boolean operators;
+- grouping parentheses;
+- statement separators;
+- function call argument separators;
+- braces when they are used as block delimiters.
+
+Examples:
+
+```fyr
+assert_eq(answer,42);
+assert_eq( answer , 42 );
+
+if(answer>40&&answer<50){return answer;}
+if ( answer > 40 && answer < 50 ) { return answer; }
+```
+
+## Must preserve
+
+Fyr must preserve meaningful whitespace inside:
+
+- string literals;
+- future text literals;
+- comments;
+- any future indentation-sensitive syntax if such syntax is introduced deliberately.
+
+Examples:
+
+```fyr
+print("hello world");
+print("hello   world");
+```
+
+Those strings are not equivalent because the spaces are literal content.
+
+## Current implementation expectation
+
+Current Fyr already accepts compact and spaced expression forms across many arithmetic, boolean, grouping, and control-flow tests.
+
+This document preserves the language contract and gives future parser work a clear boundary:
+
+- normalize insignificant token spacing;
+- preserve literal/comment spacing;
+- keep diagnostics deterministic;
+- keep file-backed `.fyr` workflows preferred for real work.
+
+## Relationship to native execution guidance
+
+Whitespace normalization supports editor-first `.fyr` workflows.
+
+Operators should be free to format `.fyr` files for readability while preserving program meaning.
+
+Native or inline execution should remain for short tests and quick checks only. Real work should be saved in `.fyr` files and edited with an editor.
+
+See [`NATIVE_EXECUTION_GUIDANCE.md`](NATIVE_EXECUTION_GUIDANCE.md).
+
+## Non-claims
+
+This document does not claim that Fyr has a complete formatter, complete parser, complete language grammar, production readiness, or hardened sandboxing.
+
+It defines the whitespace behavior that current and future Fyr parser work should preserve.

--- a/tests/fyr_whitespace_normalization_docs.rs
+++ b/tests/fyr_whitespace_normalization_docs.rs
@@ -1,0 +1,107 @@
+use std::fs;
+
+const WHITESPACE_DOC: &str = "docs/fyr/WHITESPACE_NORMALIZATION.md";
+const LANGUAGE_BOOK: &str = "docs/fyr/LANGUAGE_BOOK.md";
+
+#[test]
+fn fyr_whitespace_normalization_doc_exists_and_defines_scope() {
+    let doc = fs::read_to_string(WHITESPACE_DOC).expect("Fyr whitespace normalization doc should exist");
+
+    for required in [
+        "# Fyr whitespace normalization",
+        "Status: language contract",
+        "insignificant whitespace between Fyr tokens",
+        "preservation of meaningful whitespace",
+        "Whitespace between normal language tokens should not change program meaning.",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn fyr_whitespace_normalization_preserves_core_equivalence_rule() {
+    let doc = fs::read_to_string(WHITESPACE_DOC).expect("Fyr whitespace normalization doc should exist");
+
+    for required in [
+        "let x=1+2;",
+        "let x = 1 + 2;",
+        "let   x   =   1   +   2;",
+        "The parser should treat insignificant whitespace as a separator or visual formatting aid, not as semantic content.",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn fyr_whitespace_normalization_lists_token_spacing_surfaces() {
+    let doc = fs::read_to_string(WHITESPACE_DOC).expect("Fyr whitespace normalization doc should exist");
+
+    for required in [
+        "assignment operators",
+        "arithmetic operators",
+        "comparison operators",
+        "boolean operators",
+        "grouping parentheses",
+        "statement separators",
+        "function call argument separators",
+        "braces when they are used as block delimiters",
+        "assert_eq(answer,42);",
+        "assert_eq( answer , 42 );",
+        "if(answer>40&&answer<50){return answer;}",
+        "if ( answer > 40 && answer < 50 ) { return answer; }",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn fyr_whitespace_normalization_preserves_meaningful_whitespace() {
+    let doc = fs::read_to_string(WHITESPACE_DOC).expect("Fyr whitespace normalization doc should exist");
+
+    for required in [
+        "string literals",
+        "future text literals",
+        "comments",
+        "future indentation-sensitive syntax",
+        "print(\"hello world\");",
+        "print(\"hello   world\");",
+        "Those strings are not equivalent because the spaces are literal content.",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn fyr_whitespace_normalization_links_file_backed_workflows_and_non_claims() {
+    let doc = fs::read_to_string(WHITESPACE_DOC).expect("Fyr whitespace normalization doc should exist");
+
+    for required in [
+        "NATIVE_EXECUTION_GUIDANCE.md",
+        "editor-first `.fyr` workflows",
+        "Native or inline execution should remain for short tests and quick checks only.",
+        "does not claim that Fyr has a complete formatter",
+        "complete parser",
+        "complete language grammar",
+        "production readiness",
+        "hardened sandboxing",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn fyr_language_book_links_whitespace_normalization_contract() {
+    let book = fs::read_to_string(LANGUAGE_BOOK).expect("Fyr language book should exist");
+
+    for required in [
+        "## 6. Whitespace",
+        "WHITESPACE_NORMALIZATION.md",
+        "spaces between normal tokens should not change program meaning",
+        "spaces inside strings, text literals, comments, and any future indentation-sensitive syntax must be preserved",
+        "let x=1+2;",
+        "let x = 1 + 2;",
+        "let   x   =   1   +   2;",
+    ] {
+        assert!(book.contains(required), "missing {required:?}: {book}");
+    }
+}

--- a/tests/fyr_whitespace_normalization_docs.rs
+++ b/tests/fyr_whitespace_normalization_docs.rs
@@ -5,8 +5,8 @@ const LANGUAGE_BOOK: &str = "docs/fyr/LANGUAGE_BOOK.md";
 
 #[test]
 fn fyr_whitespace_normalization_doc_exists_and_defines_scope() {
-    let doc = fs::read_to_string(WHITESPACE_DOC)
-        .expect("Fyr whitespace normalization doc should exist");
+    let doc =
+        fs::read_to_string(WHITESPACE_DOC).expect("Fyr whitespace normalization doc should exist");
 
     for required in [
         "# Fyr whitespace normalization",
@@ -21,8 +21,8 @@ fn fyr_whitespace_normalization_doc_exists_and_defines_scope() {
 
 #[test]
 fn fyr_whitespace_normalization_preserves_core_equivalence_rule() {
-    let doc = fs::read_to_string(WHITESPACE_DOC)
-        .expect("Fyr whitespace normalization doc should exist");
+    let doc =
+        fs::read_to_string(WHITESPACE_DOC).expect("Fyr whitespace normalization doc should exist");
 
     for required in [
         "let x=1+2;",
@@ -36,8 +36,8 @@ fn fyr_whitespace_normalization_preserves_core_equivalence_rule() {
 
 #[test]
 fn fyr_whitespace_normalization_lists_token_spacing_surfaces() {
-    let doc = fs::read_to_string(WHITESPACE_DOC)
-        .expect("Fyr whitespace normalization doc should exist");
+    let doc =
+        fs::read_to_string(WHITESPACE_DOC).expect("Fyr whitespace normalization doc should exist");
 
     for required in [
         "assignment operators",
@@ -59,8 +59,8 @@ fn fyr_whitespace_normalization_lists_token_spacing_surfaces() {
 
 #[test]
 fn fyr_whitespace_normalization_preserves_meaningful_whitespace() {
-    let doc = fs::read_to_string(WHITESPACE_DOC)
-        .expect("Fyr whitespace normalization doc should exist");
+    let doc =
+        fs::read_to_string(WHITESPACE_DOC).expect("Fyr whitespace normalization doc should exist");
 
     for required in [
         "string literals",
@@ -77,8 +77,8 @@ fn fyr_whitespace_normalization_preserves_meaningful_whitespace() {
 
 #[test]
 fn fyr_whitespace_normalization_links_file_backed_workflows_and_non_claims() {
-    let doc = fs::read_to_string(WHITESPACE_DOC)
-        .expect("Fyr whitespace normalization doc should exist");
+    let doc =
+        fs::read_to_string(WHITESPACE_DOC).expect("Fyr whitespace normalization doc should exist");
 
     for required in [
         "NATIVE_EXECUTION_GUIDANCE.md",

--- a/tests/fyr_whitespace_normalization_docs.rs
+++ b/tests/fyr_whitespace_normalization_docs.rs
@@ -5,7 +5,8 @@ const LANGUAGE_BOOK: &str = "docs/fyr/LANGUAGE_BOOK.md";
 
 #[test]
 fn fyr_whitespace_normalization_doc_exists_and_defines_scope() {
-    let doc = fs::read_to_string(WHITESPACE_DOC).expect("Fyr whitespace normalization doc should exist");
+    let doc = fs::read_to_string(WHITESPACE_DOC)
+        .expect("Fyr whitespace normalization doc should exist");
 
     for required in [
         "# Fyr whitespace normalization",
@@ -20,7 +21,8 @@ fn fyr_whitespace_normalization_doc_exists_and_defines_scope() {
 
 #[test]
 fn fyr_whitespace_normalization_preserves_core_equivalence_rule() {
-    let doc = fs::read_to_string(WHITESPACE_DOC).expect("Fyr whitespace normalization doc should exist");
+    let doc = fs::read_to_string(WHITESPACE_DOC)
+        .expect("Fyr whitespace normalization doc should exist");
 
     for required in [
         "let x=1+2;",
@@ -34,7 +36,8 @@ fn fyr_whitespace_normalization_preserves_core_equivalence_rule() {
 
 #[test]
 fn fyr_whitespace_normalization_lists_token_spacing_surfaces() {
-    let doc = fs::read_to_string(WHITESPACE_DOC).expect("Fyr whitespace normalization doc should exist");
+    let doc = fs::read_to_string(WHITESPACE_DOC)
+        .expect("Fyr whitespace normalization doc should exist");
 
     for required in [
         "assignment operators",
@@ -56,7 +59,8 @@ fn fyr_whitespace_normalization_lists_token_spacing_surfaces() {
 
 #[test]
 fn fyr_whitespace_normalization_preserves_meaningful_whitespace() {
-    let doc = fs::read_to_string(WHITESPACE_DOC).expect("Fyr whitespace normalization doc should exist");
+    let doc = fs::read_to_string(WHITESPACE_DOC)
+        .expect("Fyr whitespace normalization doc should exist");
 
     for required in [
         "string literals",
@@ -73,7 +77,8 @@ fn fyr_whitespace_normalization_preserves_meaningful_whitespace() {
 
 #[test]
 fn fyr_whitespace_normalization_links_file_backed_workflows_and_non_claims() {
-    let doc = fs::read_to_string(WHITESPACE_DOC).expect("Fyr whitespace normalization doc should exist");
+    let doc = fs::read_to_string(WHITESPACE_DOC)
+        .expect("Fyr whitespace normalization doc should exist");
 
     for required in [
         "NATIVE_EXECUTION_GUIDANCE.md",


### PR DESCRIPTION
## Summary

Adds the Fyr whitespace normalization language contract.

This preserves the rule that:

- insignificant spaces between normal tokens should not change program meaning;
- spacing inside strings, future text literals, comments, and future indentation-sensitive syntax must be preserved;
- file-backed `.fyr` workflows remain preferred for real work.

## Validation

```sh
git fetch origin
git switch feature/fyr-whitespace-normalization-contract
cargo fmt --all -- --check
cargo test -p phase1 --test fyr_whitespace_normalization_docs
cargo test -p phase1 --test fyr_language_book_current_behavior
cargo test -p phase1 --test fyr_let_bindings
cargo test -p phase1 --test fyr_arithmetic_expressions
cargo test -p phase1 --test fyr_boolean_operators
```

## Non-claims

This does not claim Fyr has a complete formatter, complete parser, complete grammar, production readiness, or hardened sandboxing.