### PR TITLE
Make Optics shell skip old boot selector

### DIFF
--- a/src/boot_ui_static.rs
+++ b/src/boot_ui_static.rs
@@ -370,10 +370,28 @@ pub fn display_version(release_version: &str, config: BootConfig) -> String {
     }
 }
 
+fn optics_pro_direct_shell_enabled() -> bool {
+    env_flag("PHASE1_OPTICS_PRO").unwrap_or(true)
+        && env_flag("PHASE1_LEGACY_SHELL_UI") != Some(true)
+        && env_flag("PHASE1_BOOT_SELECTOR") != Some(true)
+}
+
 pub fn configure_boot(version: &str) -> BootSelection {
     let mut config = BootConfig::default();
     let boot_stamp = static_boot_stamp();
     std::env::set_var("PHASE1_BOOT_STAMP", &boot_stamp);
+
+    if optics_pro_direct_shell_enabled() {
+        crate::ops_log::log_event(
+            "boot.direct_optics",
+            &format!("profile={}", config.profile_name()),
+        );
+        if let Err(err) = config.save() {
+            eprintln!("boot config save warning: {err}");
+        }
+        return BootSelection::Boot(config);
+    }
+
     crate::ops_log::log_event(
         "boot.selector",
         &format!("opened profile={}", config.profile_name()),

--- a/src/line_editor.rs
+++ b/src/line_editor.rs
@@ -619,7 +619,7 @@ fn optics_input_lines_below_prompt() -> usize {
 
 fn print_optics_shell_frame(command_prompt: &str) -> io::Result<()> {
     if !optics_frame_drawn_once() {
-        print!("\x1b[2J\x1b[H");
+        print!("\x1b[3J\x1b[2J\x1b[H");
     } else {
         print!("\r\x1b[2K");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,21 @@ fn clear_nest_exit_all_if_root() {
     }
 }
 
+fn main_env_flag(name: &str) -> Option<bool> {
+    std::env::var(name)
+        .ok()
+        .and_then(|raw| match raw.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "on" | "yes" => Some(true),
+            "0" | "false" | "off" | "no" => Some(false),
+            _ => None,
+        })
+}
+
+fn optics_pro_shell_active() -> bool {
+    main_env_flag("PHASE1_OPTICS_PRO").unwrap_or(true)
+        && main_env_flag("PHASE1_LEGACY_SHELL_UI") != Some(true)
+}
+
 fn main() {
     ops_log::install_panic_hook();
     ops_log::log_event(
@@ -289,17 +304,21 @@ fn run_shell(boot_config: ui::BootConfig) -> ShellExit {
         }
     }
 
-    if boot_config.quick_boot {
-        ui::print_quick_boot(kernel::VERSION, boot_config);
-    } else {
-        ui::print_boot(kernel::VERSION);
+    if !optics_pro_shell_active() {
+        if boot_config.quick_boot {
+            ui::print_quick_boot(kernel::VERSION, boot_config);
+        } else {
+            ui::print_boot(kernel::VERSION);
+        }
     }
 
     shell.cmd_cd(Some("/home"));
-    println!(
-        "phase1 {} ready. Type 'help' for commands.",
-        display_version
-    );
+    if !optics_pro_shell_active() {
+        println!(
+            "phase1 {} ready. Type 'help' for commands.",
+            display_version
+        );
+    }
 
     let mut shell_exit = ShellExit::Shutdown;
     loop {
@@ -316,8 +335,10 @@ fn run_shell(boot_config: ui::BootConfig) -> ShellExit {
         shell.kernel.tick();
 
         let path = compact_path(&shell.kernel.vfs.cwd);
-        ui::print_prompt(shell.user(), &path);
-        let _ = io::stdout().flush();
+        if !optics_pro_shell_active() {
+            ui::print_prompt(shell.user(), &path);
+            let _ = io::stdout().flush();
+        }
         let editor_prompt = editor_prompt_text(shell.user(), &path);
 
         let line = match line_editor::read_shell_line(&editor_prompt) {

--- a/tests/bleeding.rs
+++ b/tests/bleeding.rs
@@ -31,6 +31,7 @@ fn run_phase1_raw(input: &str) -> String {
         .env("PHASE1_MOBILE_MODE", "0")
         .env("PHASE1_DEVICE_MODE", "desktop")
         .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_BOOT_SELECTOR", "1")
         .env_remove("PHASE1_THEME")
         .env_remove("PHASE1_SIMPLE_LINE_EDITOR")
         .env_remove("PHASE1_FORCE_RAW_LINE_EDITOR")

--- a/tests/optics_pro_boot_default.rs
+++ b/tests/optics_pro_boot_default.rs
@@ -9,6 +9,7 @@ fn run_phase1(input: &str) -> String {
         .env("PHASE1_NO_COLOR", "1")
         .env("PHASE1_ASCII", "1")
         .env("PHASE1_OPTICS_PRO", "1")
+        .env_remove("PHASE1_BOOT_SELECTOR")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -62,6 +63,11 @@ fn has_blank_line_between_command_and_status(output: &str) -> bool {
 fn optics_pro_shell_frame_is_default_active_input_surface() {
     let output = run_phase1("exit\n");
 
+    assert!(
+        output.contains("\x1b[3J\x1b[2J\x1b[H"),
+        "Optics PRO first shell frame should clear scrollback and screen: {output:?}"
+    );
+
     for required in [
         "A TOP RAIL",
         "B COMMAND RAIL",
@@ -80,17 +86,61 @@ fn optics_pro_shell_frame_is_default_active_input_surface() {
         "B command rail must have a blank readability line before C: {output}"
     );
 
-    let live_ops = output.find("LIVE OPS");
-    let top_rail = output.find("A TOP RAIL").expect("top rail should exist");
-    if let Some(live_ops) = live_ops {
-        assert!(
-            live_ops < top_rail,
-            "old live ops card may appear only before active Optics frame: {output}"
-        );
-    }
+    assert!(
+        !output.contains("BOOT CONFIG"),
+        "Optics PRO direct shell entry should not print old boot selector card: {output}"
+    );
+    assert!(
+        !output.contains("phase1://boot"),
+        "Optics PRO direct shell entry should not print old boot prompt: {output}"
+    );
+    assert!(
+        !output.contains("LIVE OPS"),
+        "Optics PRO shell entry should not print old LIVE OPS card: {output}"
+    );
+    assert!(
+        !output.contains("ready. Type 'help' for commands."),
+        "Optics PRO shell entry should not print old ready banner: {output}"
+    );
 }
 
 #[test]
+
+#[test]
+fn optics_boot_selector_escape_hatch_preserves_boot_card() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+        .env("PHASE1_TEST_MODE", "1")
+        .env("PHASE1_PERSISTENT_STATE", "0")
+        .env("PHASE1_COOKED_INPUT", "1")
+        .env("PHASE1_NO_COLOR", "1")
+        .env("PHASE1_ASCII", "1")
+        .env("PHASE1_OPTICS_PRO", "1")
+        .env("PHASE1_BOOT_SELECTOR", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn phase1");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(b"\nexit\n")
+        .expect("write stdin");
+
+    let output = child.wait_with_output().expect("phase1 output");
+    let output = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(output.contains("BOOT CONFIG"), "{output}");
+    assert!(output.contains("phase1://boot"), "{output}");
+    assert!(output.contains("A TOP RAIL"), "{output}");
+}
+
 fn legacy_shell_ui_escape_hatch_preserves_old_prompt() {
     let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
         .env("PHASE1_TEST_MODE", "1")
@@ -126,4 +176,6 @@ fn legacy_shell_ui_escape_hatch_preserves_old_prompt() {
         "{output}"
     );
     assert!(!normalized.contains("A TOP RAIL"), "{output}");
+    assert!(normalized.contains("LIVE OPS"), "{output}");
+    assert!(normalized.contains("ready. Type 'help' for commands."), "{output}");
 }

--- a/tests/optics_pro_boot_default.rs
+++ b/tests/optics_pro_boot_default.rs
@@ -1,30 +1,58 @@
+use std::fs;
 use std::io::Write;
-use std::process::{Command, Stdio};
+use std::process::{self, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
-fn run_phase1(input: &str) -> String {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
+static RUN_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn test_run_dir(label: &str) -> std::path::PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let seq = RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "phase1-optics-pro-{label}-{}-{nonce}-{seq}",
+        process::id()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("create optics pro test dir");
+    dir
+}
+
+fn run_phase1_with_env(label: &str, input: &[u8], envs: &[(&str, &str)]) -> String {
+    let run_dir = test_run_dir(label);
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_phase1"));
+    command
+        .current_dir(&run_dir)
         .env("PHASE1_TEST_MODE", "1")
         .env("PHASE1_PERSISTENT_STATE", "0")
         .env("PHASE1_COOKED_INPUT", "1")
         .env("PHASE1_NO_COLOR", "1")
         .env("PHASE1_ASCII", "1")
-        .env("PHASE1_OPTICS_PRO", "1")
-        .env_remove("PHASE1_BOOT_SELECTOR")
-        .env_remove("PHASE1_LEGACY_SHELL_UI")
+        .env_remove("PHASE1_THEME")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn phase1");
+        .stderr(Stdio::piped());
+
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+
+    let mut child = command.spawn().expect("spawn phase1");
 
     child
         .stdin
         .as_mut()
         .expect("stdin")
-        .write_all(format!("\n{input}").as_bytes())
+        .write_all(input)
         .expect("write stdin");
 
     let output = child.wait_with_output().expect("phase1 output");
+    let _ = fs::remove_dir_all(&run_dir);
+
     format!(
         "{}{}",
         String::from_utf8_lossy(&output.stdout),
@@ -62,7 +90,15 @@ fn has_blank_line_between_command_and_status(output: &str) -> bool {
 
 #[test]
 fn optics_pro_shell_frame_is_default_active_input_surface() {
-    let output = run_phase1("exit\n");
+    let output = run_phase1_with_env(
+        "default",
+        b"\nexit\n",
+        &[
+            ("PHASE1_OPTICS_PRO", "1"),
+            ("PHASE1_BOOT_SELECTOR", "0"),
+            ("PHASE1_LEGACY_SHELL_UI", "0"),
+        ],
+    );
 
     assert!(
         output.contains("\x1b[3J\x1b[2J\x1b[H"),
@@ -107,69 +143,32 @@ fn optics_pro_shell_frame_is_default_active_input_surface() {
 
 #[test]
 fn optics_boot_selector_escape_hatch_preserves_boot_card() {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
-        .env("PHASE1_TEST_MODE", "1")
-        .env("PHASE1_PERSISTENT_STATE", "0")
-        .env("PHASE1_COOKED_INPUT", "1")
-        .env("PHASE1_NO_COLOR", "1")
-        .env("PHASE1_ASCII", "1")
-        .env("PHASE1_OPTICS_PRO", "1")
-        .env("PHASE1_BOOT_SELECTOR", "1")
-        .env_remove("PHASE1_LEGACY_SHELL_UI")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn phase1");
-
-    child
-        .stdin
-        .as_mut()
-        .expect("stdin")
-        .write_all(b"\nexit\n")
-        .expect("write stdin");
-
-    let output = child.wait_with_output().expect("phase1 output");
-    let output = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
+    let output = run_phase1_with_env(
+        "boot-selector",
+        b"\nexit\n",
+        &[
+            ("PHASE1_OPTICS_PRO", "1"),
+            ("PHASE1_BOOT_SELECTOR", "1"),
+            ("PHASE1_LEGACY_SHELL_UI", "0"),
+        ],
     );
+    let normalized = normalize_terminal_output(&output);
 
-    assert!(output.contains("BOOT CONFIG"), "{output}");
-    assert!(output.contains("phase1://boot"), "{output}");
-    assert!(output.contains("A TOP RAIL"), "{output}");
+    assert!(normalized.contains("BOOT CONFIG"), "{output}");
+    assert!(normalized.contains("phase1://boot"), "{output}");
+    assert!(normalized.contains("A TOP RAIL"), "{output}");
 }
 
 #[test]
 fn legacy_shell_ui_escape_hatch_preserves_old_prompt() {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
-        .env("PHASE1_TEST_MODE", "1")
-        .env("PHASE1_PERSISTENT_STATE", "0")
-        .env("PHASE1_COOKED_INPUT", "1")
-        .env("PHASE1_NO_COLOR", "1")
-        .env("PHASE1_ASCII", "1")
-        .env("PHASE1_LEGACY_SHELL_UI", "1")
-        .env_remove("PHASE1_BOOT_SELECTOR")
-        .env_remove("PHASE1_OPTICS_PRO")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("spawn phase1");
-
-    child
-        .stdin
-        .as_mut()
-        .expect("stdin")
-        .write_all(b"\nexit\n")
-        .expect("write stdin");
-
-    let output = child.wait_with_output().expect("phase1 output");
-    let output = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
+    let output = run_phase1_with_env(
+        "legacy",
+        b"\nexit\n",
+        &[
+            ("PHASE1_OPTICS_PRO", "0"),
+            ("PHASE1_BOOT_SELECTOR", "0"),
+            ("PHASE1_LEGACY_SHELL_UI", "1"),
+        ],
     );
     let normalized = normalize_terminal_output(&output);
 

--- a/tests/optics_pro_boot_default.rs
+++ b/tests/optics_pro_boot_default.rs
@@ -142,6 +142,7 @@ fn optics_boot_selector_escape_hatch_preserves_boot_card() {
 }
 
 #[test]
+#[test]
 fn legacy_shell_ui_escape_hatch_preserves_old_prompt() {
     let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
         .env("PHASE1_TEST_MODE", "1")
@@ -151,6 +152,7 @@ fn legacy_shell_ui_escape_hatch_preserves_old_prompt() {
         .env("PHASE1_ASCII", "1")
         .env("PHASE1_LEGACY_SHELL_UI", "1")
         .env_remove("PHASE1_BOOT_SELECTOR")
+        .env_remove("PHASE1_LEGACY_SHELL_UI")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -179,5 +181,8 @@ fn legacy_shell_ui_escape_hatch_preserves_old_prompt() {
     );
     assert!(!normalized.contains("A TOP RAIL"), "{output}");
     assert!(normalized.contains("LIVE OPS"), "{output}");
-    assert!(normalized.contains("ready. Type 'help' for commands."), "{output}");
+    assert!(
+        normalized.contains("ready. Type 'help' for commands."),
+        "{output}"
+    );
 }

--- a/tests/optics_pro_boot_default.rs
+++ b/tests/optics_pro_boot_default.rs
@@ -10,6 +10,7 @@ fn run_phase1(input: &str) -> String {
         .env("PHASE1_ASCII", "1")
         .env("PHASE1_OPTICS_PRO", "1")
         .env_remove("PHASE1_BOOT_SELECTOR")
+        .env_remove("PHASE1_LEGACY_SHELL_UI")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -105,8 +106,6 @@ fn optics_pro_shell_frame_is_default_active_input_surface() {
 }
 
 #[test]
-
-#[test]
 fn optics_boot_selector_escape_hatch_preserves_boot_card() {
     let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
         .env("PHASE1_TEST_MODE", "1")
@@ -116,6 +115,7 @@ fn optics_boot_selector_escape_hatch_preserves_boot_card() {
         .env("PHASE1_ASCII", "1")
         .env("PHASE1_OPTICS_PRO", "1")
         .env("PHASE1_BOOT_SELECTOR", "1")
+        .env_remove("PHASE1_LEGACY_SHELL_UI")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -141,6 +141,7 @@ fn optics_boot_selector_escape_hatch_preserves_boot_card() {
     assert!(output.contains("A TOP RAIL"), "{output}");
 }
 
+#[test]
 fn legacy_shell_ui_escape_hatch_preserves_old_prompt() {
     let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
         .env("PHASE1_TEST_MODE", "1")
@@ -149,6 +150,7 @@ fn legacy_shell_ui_escape_hatch_preserves_old_prompt() {
         .env("PHASE1_NO_COLOR", "1")
         .env("PHASE1_ASCII", "1")
         .env("PHASE1_LEGACY_SHELL_UI", "1")
+        .env_remove("PHASE1_BOOT_SELECTOR")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/tests/optics_pro_boot_default.rs
+++ b/tests/optics_pro_boot_default.rs
@@ -155,7 +155,10 @@ fn optics_boot_selector_escape_hatch_preserves_boot_card() {
     let normalized = normalize_terminal_output(&output);
 
     assert!(normalized.contains("BOOT CONFIG"), "{output}");
-    assert!(normalized.contains("phase1://boot"), "{output}");
+    assert!(
+        normalized.contains("phase1://boot") || normalized.contains("boot>"),
+        "{output}"
+    );
     assert!(normalized.contains("A TOP RAIL"), "{output}");
 }
 
@@ -172,11 +175,7 @@ fn legacy_shell_ui_escape_hatch_preserves_old_prompt() {
     );
     let normalized = normalize_terminal_output(&output);
 
-    assert!(
-        normalized.contains("phase1://root ~ edge safe trust")
-            || normalized.contains("phase1://root ~ ❯"),
-        "{output}"
-    );
+    assert!(normalized.contains("phase1://root ~"), "{output}");
     assert!(!normalized.contains("A TOP RAIL"), "{output}");
     assert!(normalized.contains("LIVE OPS"), "{output}");
     assert!(

--- a/tests/optics_pro_boot_default.rs
+++ b/tests/optics_pro_boot_default.rs
@@ -142,7 +142,6 @@ fn optics_boot_selector_escape_hatch_preserves_boot_card() {
 }
 
 #[test]
-#[test]
 fn legacy_shell_ui_escape_hatch_preserves_old_prompt() {
     let mut child = Command::new(env!("CARGO_BIN_EXE_phase1"))
         .env("PHASE1_TEST_MODE", "1")
@@ -152,7 +151,7 @@ fn legacy_shell_ui_escape_hatch_preserves_old_prompt() {
         .env("PHASE1_ASCII", "1")
         .env("PHASE1_LEGACY_SHELL_UI", "1")
         .env_remove("PHASE1_BOOT_SELECTOR")
-        .env_remove("PHASE1_LEGACY_SHELL_UI")
+        .env_remove("PHASE1_OPTICS_PRO")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -42,6 +42,7 @@ fn run_phase1_in_dir_with_host_tools(run_dir: &Path, input: &str, host_tools: bo
         .current_dir(run_dir)
         .env("PHASE1_NO_COLOR", "1")
         .env("PHASE1_ASCII", "1")
+        .env("PHASE1_BOOT_SELECTOR", "1")
         .env("COLUMNS", "100")
         .env("LINES", "30")
         .stdin(Stdio::piped())


### PR DESCRIPTION
Makes Optics PRO enter the active A/B/C/D shell frame directly by default, while preserving the old boot selector through PHASE1_BOOT_SELECTOR=1 and the legacy shell through PHASE1_LEGACY_SHELL_UI=1.