### PR TITLE
Add Phase navigation contract

### DIFF
--- a/docs/phase/PHASE_NAVIGATION_CONTRACT.md
+++ b/docs/phase/PHASE_NAVIGATION_CONTRACT.md
@@ -1,0 +1,98 @@
+# Phase Navigation Contract
+
+## Purpose
+
+Phase Navigation is a planned Phase1 operator navigation track for moving between explicit Phase1-controlled contexts such as floors, portals, domains, and existing nest surfaces.
+
+This contract starts the feature as documentation and command-contract evidence only. It does not add live runtime mutation yet.
+
+## Scope
+
+The initial scope is an internal navigation contract for Phase1 spaces:
+
+- floors represent named or numbered operator spaces;
+- domains represent bounded Phase1-controlled context groups;
+- portals represent explicit links between approved Phase1 contexts;
+- root remains the reversible base context;
+- all movement is operator-commanded, visible, and auditable.
+
+## Planned command surface
+
+```text
+phase status
+phase floor create <num|name>
+phase floor enter <num|name>
+phase floor main <num|name>
+phase portal link <from> <to>
+phase domain establish <name>
+phase back
+phase root
+```
+
+## Required status fields
+
+The first runtime status surface should preserve these fields when the command promotes beyond this contract:
+
+```text
+phase-navigation : planned
+execution-state  : not-executed
+active-floor     : root
+active-domain    : none
+active-portal    : none
+path             : root
+transition       : none
+phase-safe       : on
+host-tools       : gated
+claim-boundary   : internal-context-navigation-only
+```
+
+## Optics A/B/C/D rail contract
+
+Phase Navigation must be visible in Optics rails before any live runtime transition is promoted.
+
+Target shape:
+
+```text
+A TOP RAIL     floor=<num|root> domain=<name|none> portal=<active|none> nest=<level/max>
+B COMMAND      phase floor enter 2
+
+C STATUS HUD   active-main=floor/2 transition=ok path=root>floor/2
+D BOTTOM HUD   back=root phase-safe=on host-tools=gated
+```
+
+## Safety boundaries
+
+This feature is internal Phase1 context navigation only.
+
+It must not claim or imply:
+
+- network lateral movement;
+- host compromise;
+- privilege escalation;
+- hidden persistence;
+- uncontrolled execution;
+- sandbox hardening;
+- malware safety;
+- production isolation.
+
+Every phase transition must be:
+
+- explicit;
+- visible;
+- logged;
+- reversible;
+- bounded by current safe-mode and host-tool policy;
+- compatible with existing nest and portal concepts;
+- represented through text labels, not color or icons alone.
+
+## Promotion ladder
+
+```text
+planned -> documented -> command-contract tested -> runtime stub -> local-state runtime -> Optics-integrated runtime -> reviewed -> release eligible
+```
+
+No runtime command should promote until shell state, nested context restoration, rollback behavior, and Optics rail visibility are clear.
+
+## First implementation rule
+
+The first PR for this track is documentation-only. It may add tests that preserve this contract, but it must not create live `phase` runtime behavior yet.

--- a/tests/phase_navigation_contract_docs.rs
+++ b/tests/phase_navigation_contract_docs.rs
@@ -1,0 +1,101 @@
+use std::fs;
+
+const CONTRACT: &str = "docs/phase/PHASE_NAVIGATION_CONTRACT.md";
+
+fn contract() -> String {
+    fs::read_to_string(CONTRACT).expect("read Phase navigation contract")
+}
+
+#[test]
+fn phase_navigation_contract_exists_and_defines_scope() {
+    let doc = contract();
+
+    assert!(doc.contains("# Phase Navigation Contract"));
+    assert!(doc.contains("internal navigation contract for Phase1 spaces"));
+    assert!(doc.contains("floors represent named or numbered operator spaces"));
+    assert!(doc.contains("domains represent bounded Phase1-controlled context groups"));
+    assert!(doc.contains("portals represent explicit links between approved Phase1 contexts"));
+    assert!(doc.contains("root remains the reversible base context"));
+}
+
+#[test]
+fn phase_navigation_contract_lists_command_surface() {
+    let doc = contract();
+
+    for command in [
+        "phase status",
+        "phase floor create <num|name>",
+        "phase floor enter <num|name>",
+        "phase floor main <num|name>",
+        "phase portal link <from> <to>",
+        "phase domain establish <name>",
+        "phase back",
+        "phase root",
+    ] {
+        assert!(doc.contains(command), "missing command contract: {command}");
+    }
+}
+
+#[test]
+fn phase_navigation_contract_preserves_status_fields() {
+    let doc = contract();
+
+    for field in [
+        "phase-navigation : planned",
+        "execution-state  : not-executed",
+        "active-floor     : root",
+        "active-domain    : none",
+        "active-portal    : none",
+        "path             : root",
+        "transition       : none",
+        "phase-safe       : on",
+        "host-tools       : gated",
+        "claim-boundary   : internal-context-navigation-only",
+    ] {
+        assert!(doc.contains(field), "missing status field: {field}");
+    }
+}
+
+#[test]
+fn phase_navigation_contract_preserves_optics_rails() {
+    let doc = contract();
+
+    assert!(doc.contains("Optics A/B/C/D rail contract"));
+    assert!(doc.contains("A TOP RAIL     floor=<num|root> domain=<name|none> portal=<active|none> nest=<level/max>"));
+    assert!(doc.contains("B COMMAND      phase floor enter 2"));
+    assert!(doc.contains("C STATUS HUD   active-main=floor/2 transition=ok path=root>floor/2"));
+    assert!(doc.contains("D BOTTOM HUD   back=root phase-safe=on host-tools=gated"));
+}
+
+#[test]
+fn phase_navigation_contract_preserves_boundaries_and_promotion_rule() {
+    let doc = contract();
+
+    for forbidden in [
+        "network lateral movement",
+        "host compromise",
+        "privilege escalation",
+        "hidden persistence",
+        "uncontrolled execution",
+        "sandbox hardening",
+        "malware safety",
+        "production isolation",
+    ] {
+        assert!(doc.contains(forbidden), "missing forbidden claim: {forbidden}");
+    }
+
+    for requirement in [
+        "explicit",
+        "visible",
+        "logged",
+        "reversible",
+        "bounded by current safe-mode and host-tool policy",
+        "compatible with existing nest and portal concepts",
+        "represented through text labels, not color or icons alone",
+        "planned -> documented -> command-contract tested -> runtime stub -> local-state runtime -> Optics-integrated runtime -> reviewed -> release eligible",
+        "The first PR for this track is documentation-only",
+        "must not create live `phase` runtime behavior yet",
+    ] {
+        assert!(doc.contains(requirement), "missing safety or promotion rule: {requirement}");
+    }
+}

--- a/tests/phase_navigation_contract_docs.rs
+++ b/tests/phase_navigation_contract_docs.rs
@@ -61,7 +61,9 @@ fn phase_navigation_contract_preserves_optics_rails() {
     let doc = contract();
 
     assert!(doc.contains("Optics A/B/C/D rail contract"));
-    assert!(doc.contains("A TOP RAIL     floor=<num|root> domain=<name|none> portal=<active|none> nest=<level/max>"));
+    assert!(doc.contains(
+        "A TOP RAIL     floor=<num|root> domain=<name|none> portal=<active|none> nest=<level/max>"
+    ));
     assert!(doc.contains("B COMMAND      phase floor enter 2"));
     assert!(doc.contains("C STATUS HUD   active-main=floor/2 transition=ok path=root>floor/2"));
     assert!(doc.contains("D BOTTOM HUD   back=root phase-safe=on host-tools=gated"));
@@ -81,7 +83,10 @@ fn phase_navigation_contract_preserves_boundaries_and_promotion_rule() {
         "malware safety",
         "production isolation",
     ] {
-        assert!(doc.contains(forbidden), "missing forbidden claim: {forbidden}");
+        assert!(
+            doc.contains(forbidden),
+            "missing forbidden claim: {forbidden}"
+        );
     }
 
     for requirement in [
@@ -96,6 +101,9 @@ fn phase_navigation_contract_preserves_boundaries_and_promotion_rule() {
         "The first PR for this track is documentation-only",
         "must not create live `phase` runtime behavior yet",
     ] {
-        assert!(doc.contains(requirement), "missing safety or promotion rule: {requirement}");
+        assert!(
+            doc.contains(requirement),
+            "missing safety or promotion rule: {requirement}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adds the first documentation-only contract for Phase Navigation: Phase1-controlled floors, portals, domains, and root/back movement.

This follows issue #372 and keeps the first slice evidence-bound: no live `phase` runtime command yet.

## Scope

- Add `docs/phase/PHASE_NAVIGATION_CONTRACT.md`
- Add `tests/phase_navigation_contract_docs.rs`
- Preserve planned command vocabulary, required status fields, Optics A/B/C/D rail shape, safety boundaries, and promotion ladder

## Boundaries

This PR does not implement runtime navigation, network movement, host compromise behavior, privilege escalation, hidden persistence, sandbox hardening, malware safety, or production isolation claims.

## Validation

Expected focused validation:

```bash
cargo fmt --all -- --check
cargo test -p phase1 --test phase_navigation_contract_docs
cargo test --workspace --all-targets
```

Closes #372 when the contract-only slice is accepted.