### PR TITLE
Add White Arts command stub contract

### DIFF
--- a/docs/white-arts/COMMAND_STUB_CONTRACT.md
+++ b/docs/white-arts/COMMAND_STUB_CONTRACT.md
@@ -1,0 +1,101 @@
+# White Arts Command Stub Contract
+
+## Purpose
+
+This contract defines the first safe runtime-facing White Arts command surface before implementation. The initial command must be read-only, report-only, deterministic, and explicit about non-claims.
+
+The first runtime slice should provide operator visibility into White Arts status without granting repair, host mutation, credential access, destructive writes, or autonomous healing.
+
+## Initial command surface
+
+```text
+white-arts
+white-arts status
+white-arts help
+white-arts inventory
+white-arts check
+white-arts report
+white-arts audit security
+white-arts audit integrity
+white-arts audit base1
+white-arts audit fyr
+```
+
+All commands in the first runtime slice are status or planned-action surfaces only.
+
+## Required status output
+
+The first `white-arts status` output should preserve these fields:
+
+```text
+phase1 white arts
+status           : planned
+mode             : defensive-read-only
+mutation         : disabled
+repair-policy    : staged-candidate-only
+execution-state  : not-executed
+host-execution   : disabled
+network-access   : disabled
+credential-access: disabled
+sandbox-claim    : not-claimed
+audit-scope      : report-only
+integrity-scope  : docs-scripts-release-metadata
+base1-scope      : read-only-recovery-and-evidence
+fyr-scope        : metadata-and-reporting-only
+claim-boundary   : evidence-bound-maintenance
+```
+
+## Planned command behavior
+
+| Command | First behavior | Mutation allowed | Required boundary |
+| --- | --- | --- | --- |
+| `white-arts` | same as `white-arts status` | no | defensive-read-only |
+| `white-arts status` | print status fields | no | evidence-bound-maintenance |
+| `white-arts help` | list command surface and non-claims | no | no repair execution |
+| `white-arts inventory` | planned nominal-state inventory report | no | report-only |
+| `white-arts check` | planned read-only check summary | no | no host mutation |
+| `white-arts report` | planned report template path | no | deterministic output |
+| `white-arts audit security` | planned security audit movement summary | no | no exploitation |
+| `white-arts audit integrity` | planned integrity audit summary | no | read-only verification |
+| `white-arts audit base1` | planned Base1 evidence review summary | no | no device writes |
+| `white-arts audit fyr` | planned Fyr metadata/reporting summary | no | no host execution |
+
+## Forbidden behavior
+
+The first runtime stub must not:
+
+- execute host tools;
+- access the network;
+- collect credentials;
+- silently modify files;
+- write boot artifacts;
+- delete recovery material;
+- promote candidate repairs;
+- imply malware safety;
+- imply forensic admissibility;
+- imply production hardening.
+
+## Audit and Optics expectations
+
+When runtime wiring is added, command execution should record a sanitized audit event such as:
+
+```text
+white-arts.status mode=read-only mutation=disabled
+```
+
+Optics rails may show White Arts state only as a visible status label, for example:
+
+```text
+C STATUS HUD   white-arts=planned integrity=report-only repair=staged-candidate-only
+D BOTTOM HUD   mutation=disabled host-tools=gated claim=evidence-bound-maintenance
+```
+
+## Promotion rule
+
+Runtime implementation should not begin with repair behavior. It should promote in this order:
+
+```text
+contract-tested -> runtime-status-stub -> inventory-reporter -> check-reporter -> candidate-repair-planner -> reviewed-repair-flow
+```
+
+Every promotion requires focused tests, docs, non-claim language, and a failure behavior note.

--- a/docs/white-arts/README.md
+++ b/docs/white-arts/README.md
@@ -87,6 +87,7 @@ No command should silently modify repository files, host settings, credentials, 
 - [Integrity validation plan](INTEGRITY_VALIDATION_PLAN.md)
 - [Healing and maintenance model](HEALING_MAINTENANCE_MODEL.md)
 - [Security audit movement](SECURITY_AUDIT_MOVEMENT.md)
+- [Command stub contract](COMMAND_STUB_CONTRACT.md)
 - [Protocols and security guardrails](PROTOCOLS_AND_GUARDRAILS.md)
 - [Open security server suite](OPEN_SECURITY_SERVER_SUITE.md)
 - [Maintenance TODO](TODO.md)

--- a/tests/white_arts_command_stub_contract_docs.rs
+++ b/tests/white_arts_command_stub_contract_docs.rs
@@ -78,7 +78,10 @@ fn white_arts_command_stub_contract_blocks_unsafe_behavior() {
         "imply forensic admissibility",
         "imply production hardening",
     ] {
-        assert!(contract.contains(forbidden), "missing forbidden behavior: {forbidden}");
+        assert!(
+            contract.contains(forbidden),
+            "missing forbidden behavior: {forbidden}"
+        );
     }
 }
 

--- a/tests/white_arts_command_stub_contract_docs.rs
+++ b/tests/white_arts_command_stub_contract_docs.rs
@@ -1,0 +1,102 @@
+use std::fs;
+
+const CONTRACT: &str = "docs/white-arts/COMMAND_STUB_CONTRACT.md";
+const INDEX: &str = "docs/white-arts/README.md";
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("read {path}: {err}"))
+}
+
+#[test]
+fn white_arts_command_stub_contract_exists_and_is_linked() {
+    let contract = read(CONTRACT);
+    let index = read(INDEX);
+
+    assert!(contract.contains("# White Arts Command Stub Contract"));
+    assert!(contract.contains("read-only, report-only, deterministic"));
+    assert!(index.contains("[Command stub contract](COMMAND_STUB_CONTRACT.md)"));
+}
+
+#[test]
+fn white_arts_command_stub_contract_lists_initial_surface() {
+    let contract = read(CONTRACT);
+
+    for command in [
+        "white-arts",
+        "white-arts status",
+        "white-arts help",
+        "white-arts inventory",
+        "white-arts check",
+        "white-arts report",
+        "white-arts audit security",
+        "white-arts audit integrity",
+        "white-arts audit base1",
+        "white-arts audit fyr",
+    ] {
+        assert!(contract.contains(command), "missing command: {command}");
+    }
+}
+
+#[test]
+fn white_arts_command_stub_contract_preserves_required_status_fields() {
+    let contract = read(CONTRACT);
+
+    for field in [
+        "phase1 white arts",
+        "status           : planned",
+        "mode             : defensive-read-only",
+        "mutation         : disabled",
+        "repair-policy    : staged-candidate-only",
+        "execution-state  : not-executed",
+        "host-execution   : disabled",
+        "network-access   : disabled",
+        "credential-access: disabled",
+        "sandbox-claim    : not-claimed",
+        "audit-scope      : report-only",
+        "integrity-scope  : docs-scripts-release-metadata",
+        "base1-scope      : read-only-recovery-and-evidence",
+        "fyr-scope        : metadata-and-reporting-only",
+        "claim-boundary   : evidence-bound-maintenance",
+    ] {
+        assert!(contract.contains(field), "missing status field: {field}");
+    }
+}
+
+#[test]
+fn white_arts_command_stub_contract_blocks_unsafe_behavior() {
+    let contract = read(CONTRACT);
+
+    for forbidden in [
+        "execute host tools",
+        "access the network",
+        "collect credentials",
+        "silently modify files",
+        "write boot artifacts",
+        "delete recovery material",
+        "promote candidate repairs",
+        "imply malware safety",
+        "imply forensic admissibility",
+        "imply production hardening",
+    ] {
+        assert!(contract.contains(forbidden), "missing forbidden behavior: {forbidden}");
+    }
+}
+
+#[test]
+fn white_arts_command_stub_contract_preserves_audit_optics_and_promotion_rules() {
+    let contract = read(CONTRACT);
+
+    for requirement in [
+        "white-arts.status mode=read-only mutation=disabled",
+        "C STATUS HUD   white-arts=planned integrity=report-only repair=staged-candidate-only",
+        "D BOTTOM HUD   mutation=disabled host-tools=gated claim=evidence-bound-maintenance",
+        "contract-tested -> runtime-status-stub -> inventory-reporter -> check-reporter -> candidate-repair-planner -> reviewed-repair-flow",
+        "Runtime implementation should not begin with repair behavior",
+        "Every promotion requires focused tests, docs, non-claim language, and a failure behavior note",
+    ] {
+        assert!(
+            contract.contains(requirement),
+            "missing audit, optics, or promotion rule: {requirement}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds the next White Arts roadmap slice from #347: a command-stub contract for the first runtime-facing `white-arts` surface.

This stays documentation/test only and locks the future runtime behavior to defensive, read-only, report-only status surfaces before any implementation.

## Scope

- Add `docs/white-arts/COMMAND_STUB_CONTRACT.md`
- Link it from `docs/white-arts/README.md`
- Add `tests/white_arts_command_stub_contract_docs.rs`

## Boundaries

This PR does not wire a live `white-arts` command yet. It does not add repair execution, host tools, network access, credential access, boot artifact writes, recovery material deletion, malware-safety claims, forensic admissibility claims, or production hardening claims.

## Validation

Expected focused validation:

```bash
cargo fmt --all -- --check
cargo test -p phase1 --test white_arts_command_stub_contract_docs
cargo test --workspace --all-targets
```

Refs #347.