### PR TITLE
Add White Arts inventory reporter contract

### DIFF
--- a/docs/white-arts/INVENTORY_REPORTER_CONTRACT.md
+++ b/docs/white-arts/INVENTORY_REPORTER_CONTRACT.md
@@ -1,0 +1,97 @@
+# White Arts Inventory Reporter Contract
+
+## Purpose
+
+The White Arts inventory reporter is the first planned read-only reporter after the `white-arts status` stub. Its job is to show what Phase1/Base1/Fyr surfaces are covered by nominal-state and integrity planning without performing repairs or host actions.
+
+This contract is documentation and test evidence only. It does not wire a live `white-arts inventory` command yet.
+
+## Planned command
+
+```text
+white-arts inventory
+```
+
+The first runtime implementation should be read-only and deterministic.
+
+## Required report header
+
+```text
+phase1 white arts inventory
+status           : planned
+mode             : defensive-read-only
+mutation         : disabled
+host-execution   : disabled
+network-access   : disabled
+repair-policy    : staged-candidate-only
+claim-boundary   : evidence-bound-maintenance
+```
+
+## Required inventory columns
+
+The reporter should preserve this table shape:
+
+```text
+system
+owner-surface
+nominal-signal
+test-command
+integrity-gate
+failure-behavior
+recovery-path
+claim-boundary
+```
+
+## Required inventory rows
+
+The first inventory report should include rows for these surfaces:
+
+| System | Owner surface | Nominal signal | Claim boundary |
+| --- | --- | --- | --- |
+| Phase1 boot and shell | boot selector, Optics shell, command loop | boots to explicit shell state | active edge console, not finished OS |
+| VFS and kernel model | VFS, proc, dev, audit log | deterministic simulated surfaces | simulator model, not kernel replacement |
+| Policy and host gates | safe-mode, host trust, capability metadata | host tools gated by policy | no implicit host access |
+| Command registry | help, man, completions, capabilities | discoverable command metadata | docs and registry evidence only |
+| Storage and host workspace | storage helper, Git/Rust guarded workflows | validated workspace and redaction rules | no arbitrary host directory access |
+| WASI-lite plugins | wasm list, inspect, validate, run | no host shell, no host network | lightweight runtime, not hardened sandbox |
+| Program analysis | analyze load/list/inspect metadata | not-executed sample metadata | no malware safety or forensic claim |
+| Nest and portal surfaces | nest, portal, phase navigation contracts | visible local context metadata | internal navigation only |
+| Fyr language | check, build, test, run, staged docs | deterministic VFS-oriented behavior | not self-hosting or privileged repair |
+| Base1 evidence track | docs, dry-runs, recovery validation | read-only evidence chain | not installer-ready or daily-driver ready |
+| Security and crypto docs | security policy, crypto roadmaps, provider registry | guardrails documented and tested | not cryptographically complete |
+| Website and release metadata | status JSON, README, release docs | public status matches evidence | no overclaiming public status |
+| CI and quality gates | Rust workflow, xtask, quality scripts | fmt/check/test/validation pass | CI evidence, not certification |
+```
+
+## Output rules
+
+The inventory reporter must:
+
+- prefer deterministic text output;
+- use text labels, not color or icons alone;
+- avoid host execution;
+- avoid network access;
+- avoid collecting credentials;
+- avoid writing files;
+- avoid deleting or repairing material;
+- avoid claiming malware safety, forensic admissibility, production hardening, or OS completion.
+
+## Audit expectation
+
+When runtime wiring is added, a status-only audit event may be recorded:
+
+```text
+white-arts.inventory mode=read-only mutation=disabled rows=<count>
+```
+
+The audit event must not include raw secrets, credential-bearing paths, unredacted command bodies, or host output.
+
+## Promotion rule
+
+The inventory reporter may promote only after:
+
+```text
+contract-tested -> runtime-inventory-stub -> deterministic-output-tested -> quality-gate-linked -> reviewed
+```
+
+Repair planning remains a later staged-candidate feature and must not be included in the inventory reporter.

--- a/docs/white-arts/README.md
+++ b/docs/white-arts/README.md
@@ -88,6 +88,7 @@ No command should silently modify repository files, host settings, credentials, 
 - [Healing and maintenance model](HEALING_MAINTENANCE_MODEL.md)
 - [Security audit movement](SECURITY_AUDIT_MOVEMENT.md)
 - [Command stub contract](COMMAND_STUB_CONTRACT.md)
+- [Inventory reporter contract](INVENTORY_REPORTER_CONTRACT.md)
 - [Protocols and security guardrails](PROTOCOLS_AND_GUARDRAILS.md)
 - [Open security server suite](OPEN_SECURITY_SERVER_SUITE.md)
 - [Maintenance TODO](TODO.md)

--- a/tests/white_arts_inventory_reporter_contract_docs.rs
+++ b/tests/white_arts_inventory_reporter_contract_docs.rs
@@ -1,0 +1,99 @@
+use std::fs;
+
+const CONTRACT: &str = "docs/white-arts/INVENTORY_REPORTER_CONTRACT.md";
+const INDEX: &str = "docs/white-arts/README.md";
+
+fn read(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|err| panic!("read {path}: {err}"))
+}
+
+#[test]
+fn white_arts_inventory_reporter_contract_exists_and_is_linked() {
+    let contract = read(CONTRACT);
+    let index = read(INDEX);
+
+    assert!(contract.contains("# White Arts Inventory Reporter Contract"));
+    assert!(contract.contains("white-arts inventory"));
+    assert!(index.contains("[Inventory reporter contract](INVENTORY_REPORTER_CONTRACT.md)"));
+}
+
+#[test]
+fn white_arts_inventory_reporter_contract_preserves_header_fields() {
+    let contract = read(CONTRACT);
+
+    for field in [
+        "phase1 white arts inventory",
+        "status           : planned",
+        "mode             : defensive-read-only",
+        "mutation         : disabled",
+        "host-execution   : disabled",
+        "network-access   : disabled",
+        "repair-policy    : staged-candidate-only",
+        "claim-boundary   : evidence-bound-maintenance",
+    ] {
+        assert!(contract.contains(field), "missing inventory header field: {field}");
+    }
+}
+
+#[test]
+fn white_arts_inventory_reporter_contract_preserves_table_shape() {
+    let contract = read(CONTRACT);
+
+    for column in [
+        "system",
+        "owner-surface",
+        "nominal-signal",
+        "test-command",
+        "integrity-gate",
+        "failure-behavior",
+        "recovery-path",
+        "claim-boundary",
+    ] {
+        assert!(contract.contains(column), "missing inventory column: {column}");
+    }
+}
+
+#[test]
+fn white_arts_inventory_reporter_contract_lists_required_system_rows() {
+    let contract = read(CONTRACT);
+
+    for system in [
+        "Phase1 boot and shell",
+        "VFS and kernel model",
+        "Policy and host gates",
+        "Command registry",
+        "Storage and host workspace",
+        "WASI-lite plugins",
+        "Program analysis",
+        "Nest and portal surfaces",
+        "Fyr language",
+        "Base1 evidence track",
+        "Security and crypto docs",
+        "Website and release metadata",
+        "CI and quality gates",
+    ] {
+        assert!(contract.contains(system), "missing inventory system row: {system}");
+    }
+}
+
+#[test]
+fn white_arts_inventory_reporter_contract_preserves_safety_and_promotion_rules() {
+    let contract = read(CONTRACT);
+
+    for rule in [
+        "prefer deterministic text output",
+        "use text labels, not color or icons alone",
+        "avoid host execution",
+        "avoid network access",
+        "avoid collecting credentials",
+        "avoid writing files",
+        "avoid deleting or repairing material",
+        "avoid claiming malware safety, forensic admissibility, production hardening, or OS completion",
+        "white-arts.inventory mode=read-only mutation=disabled rows=<count>",
+        "must not include raw secrets, credential-bearing paths, unredacted command bodies, or host output",
+        "contract-tested -> runtime-inventory-stub -> deterministic-output-tested -> quality-gate-linked -> reviewed",
+        "Repair planning remains a later staged-candidate feature",
+    ] {
+        assert!(contract.contains(rule), "missing safety or promotion rule: {rule}");
+    }
+}

--- a/tests/white_arts_inventory_reporter_contract_docs.rs
+++ b/tests/white_arts_inventory_reporter_contract_docs.rs
@@ -31,7 +31,10 @@ fn white_arts_inventory_reporter_contract_preserves_header_fields() {
         "repair-policy    : staged-candidate-only",
         "claim-boundary   : evidence-bound-maintenance",
     ] {
-        assert!(contract.contains(field), "missing inventory header field: {field}");
+        assert!(
+            contract.contains(field),
+            "missing inventory header field: {field}"
+        );
     }
 }
 
@@ -49,7 +52,10 @@ fn white_arts_inventory_reporter_contract_preserves_table_shape() {
         "recovery-path",
         "claim-boundary",
     ] {
-        assert!(contract.contains(column), "missing inventory column: {column}");
+        assert!(
+            contract.contains(column),
+            "missing inventory column: {column}"
+        );
     }
 }
 
@@ -72,7 +78,10 @@ fn white_arts_inventory_reporter_contract_lists_required_system_rows() {
         "Website and release metadata",
         "CI and quality gates",
     ] {
-        assert!(contract.contains(system), "missing inventory system row: {system}");
+        assert!(
+            contract.contains(system),
+            "missing inventory system row: {system}"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the next White Arts roadmap slice from #347: a read-only inventory reporter contract for future `white-arts inventory` runtime work.

This is documentation/test only and keeps the inventory surface defensive, deterministic, read-only, and non-claiming.

## Scope

- Add `docs/white-arts/INVENTORY_REPORTER_CONTRACT.md`
- Link it from `docs/white-arts/README.md`
- Add `tests/white_arts_inventory_reporter_contract_docs.rs`

## Boundaries

This PR does not wire a live `white-arts inventory` command yet. It does not add repairs, host execution, network access, credential access, file writes, recovery deletion, malware-safety claims, forensic admissibility claims, production hardening claims, or OS completion claims.

## Validation

Expected focused validation:

```bash
cargo fmt --all -- --check
cargo test -p phase1 --test white_arts_inventory_reporter_contract_docs
cargo test --workspace --all-targets
```

Refs #347.