### PR TITLE
Add Optics ROOT direction map UI

### DIFF
--- a/src/optics.rs
+++ b/src/optics.rs
@@ -210,18 +210,18 @@ pub fn render_center_viewport(sample: &str) -> String {
 
 pub fn normalize_direction_axis(axis: &str) -> &'static str {
     match axis.trim().to_ascii_lowercase().as_str() {
-        "top" | "up" | "north" => "top",
-        "bottom" | "down" | "south" => "bottom",
-        "left" | "west" => "left",
-        "right" | "east" => "right",
-        _ => "root",
+        "u" | "top" | "up" | "north" => "u",
+        "d" | "bottom" | "down" | "south" => "d",
+        "l" | "left" | "west" => "L",
+        "r" | "right" | "east" => "R",
+        _ => "ROOT",
     }
 }
 
 pub fn render_root_direction_map(active_axis: &str) -> String {
     let axis = normalize_direction_axis(active_axis);
     format!(
-        "ROOT DIRECTION MAP\nlayout=center-root top-bottom-left-right\nactive-axis={axis}\n              [ TOP ]\n                 ^\n                 |\n[ LEFT ]  <--- [ ROOT ] --->  [ RIGHT ]\n                 |\n                 v\n             [ BOTTOM ]\nrule=root-remains-anchor\nmovement=planned-visible-logged-reversible\nnetwork=not-wired host-bridge=disabled\n"
+        "ROOT DIRECTION MAP\nlayout=center-root u-d-L-R\nactive-route={axis}/0\n              u/NUM\n                ^\n                |\nL/NUM  <----  ROOT  ---->  R/NUM\n                |\n                v\n              d/NUM\nrule=root-remains-anchor\npath-examples=ROOT>u/1 ROOT>d/1 ROOT>L/2 ROOT>R/3\nmovement=planned-visible-logged-reversible\nexternal-link=none\n"
     )
 }
 

--- a/src/optics.rs
+++ b/src/optics.rs
@@ -208,6 +208,23 @@ pub fn render_center_viewport(sample: &str) -> String {
     )
 }
 
+pub fn normalize_direction_axis(axis: &str) -> &'static str {
+    match axis.trim().to_ascii_lowercase().as_str() {
+        "top" | "up" | "north" => "top",
+        "bottom" | "down" | "south" => "bottom",
+        "left" | "west" => "left",
+        "right" | "east" => "right",
+        _ => "root",
+    }
+}
+
+pub fn render_root_direction_map(active_axis: &str) -> String {
+    let axis = normalize_direction_axis(active_axis);
+    format!(
+        "ROOT DIRECTION MAP\nlayout=center-root top-bottom-left-right\nactive-axis={axis}\n              [ TOP ]\n                 ^\n                 |\n[ LEFT ]  <--- [ ROOT ] --->  [ RIGHT ]\n                 |\n                 v\n             [ BOTTOM ]\nrule=root-remains-anchor\nmovement=planned-visible-logged-reversible\nnetwork=not-wired host-bridge=disabled\n"
+    )
+}
+
 pub fn render_bottom_rail(state: &OpticsRailState) -> String {
     match state.device {
         OpticsDeviceProfile::Mobile => format!(
@@ -239,6 +256,7 @@ pub fn render_static_preview(device: OpticsDeviceProfile) -> String {
     let state = OpticsRailState::pro_static(device);
     let mut out = String::from("OPTICS HUD RAIL RENDER\nstatus=static-render\nruntime=not-wired\n");
     out.push_str(&render_top_rail(&state));
+    out.push_str(&render_root_direction_map("root"));
     out.push_str(&render_center_viewport(
         "phase1://edge/root > optics rails preview",
     ));

--- a/tests/optics_hud_rail_renderer.rs
+++ b/tests/optics_hud_rail_renderer.rs
@@ -20,10 +20,10 @@ fn optics_renderer_static_preview_preserves_top_center_bottom_contract() {
         "integrity=not-checked",
         "crypto=chain-planned",
         "ROOT DIRECTION MAP",
-        "layout=center-root top-bottom-left-right",
-        "[ LEFT ]  <--- [ ROOT ] --->  [ RIGHT ]",
+        "layout=center-root u-d-L-R",
+        "L/NUM  <----  ROOT  ---->  R/NUM",
         "rule=root-remains-anchor",
-        "network=not-wired host-bridge=disabled",
+        "external-link=none",
         "CENTER role=command-output chrome=none-permanent",
         "CENTER rule=center-remains-primary-workspace",
         "BOT color=bright-blue input=active mutation=none",
@@ -165,22 +165,23 @@ fn optics_renderer_adapts_device_density_without_changing_state_meaning() {
 }
 
 #[test]
-fn optics_root_direction_map_keeps_root_centered_with_all_axes() {
+fn optics_root_direction_map_keeps_root_centered_with_all_routes() {
     let map = render_root_direction_map("right");
 
     for required in [
         "ROOT DIRECTION MAP",
-        "layout=center-root top-bottom-left-right",
-        "active-axis=right",
-        "              [ TOP ]",
-        "                 ^",
-        "                 |",
-        "[ LEFT ]  <--- [ ROOT ] --->  [ RIGHT ]",
-        "                 v",
-        "             [ BOTTOM ]",
+        "layout=center-root u-d-L-R",
+        "active-route=R/0",
+        "              u/NUM",
+        "                ^",
+        "                |",
+        "L/NUM  <----  ROOT  ---->  R/NUM",
+        "                v",
+        "              d/NUM",
         "rule=root-remains-anchor",
+        "path-examples=ROOT>u/1 ROOT>d/1 ROOT>L/2 ROOT>R/3",
         "movement=planned-visible-logged-reversible",
-        "network=not-wired host-bridge=disabled",
+        "external-link=none",
     ] {
         assert!(map.contains(required), "missing {required:?}: {map}");
     }
@@ -189,13 +190,17 @@ fn optics_root_direction_map_keeps_root_centered_with_all_axes() {
 #[test]
 fn optics_root_direction_map_normalizes_direction_aliases() {
     for (raw, expected) in [
-        ("up", "top"),
-        ("north", "top"),
-        ("down", "bottom"),
-        ("south", "bottom"),
-        ("west", "left"),
-        ("east", "right"),
-        ("unknown", "root"),
+        ("u", "u"),
+        ("up", "u"),
+        ("north", "u"),
+        ("d", "d"),
+        ("down", "d"),
+        ("south", "d"),
+        ("L", "L"),
+        ("west", "L"),
+        ("R", "R"),
+        ("east", "R"),
+        ("unknown", "ROOT"),
     ] {
         assert_eq!(normalize_direction_axis(raw), expected, "raw axis: {raw}");
     }

--- a/tests/optics_hud_rail_renderer.rs
+++ b/tests/optics_hud_rail_renderer.rs
@@ -2,9 +2,9 @@
 mod optics;
 
 use optics::{
-    colorize_user_input, render_bottom_rail, render_pro_shell_layers, render_static_preview,
-    render_top_rail, supported_device_labels, supported_device_profiles, OpticsDeviceProfile,
-    OpticsRailState, USER_INPUT_BRIGHT_YELLOW,
+    colorize_user_input, normalize_direction_axis, render_bottom_rail, render_pro_shell_layers,
+    render_root_direction_map, render_static_preview, render_top_rail, supported_device_labels,
+    supported_device_profiles, OpticsDeviceProfile, OpticsRailState, USER_INPUT_BRIGHT_YELLOW,
 };
 
 #[test]
@@ -19,6 +19,11 @@ fn optics_renderer_static_preview_preserves_top_center_bottom_contract() {
         "ctx=root > nest:0/1 > portal:none > ghost:none",
         "integrity=not-checked",
         "crypto=chain-planned",
+        "ROOT DIRECTION MAP",
+        "layout=center-root top-bottom-left-right",
+        "[ LEFT ]  <--- [ ROOT ] --->  [ RIGHT ]",
+        "rule=root-remains-anchor",
+        "network=not-wired host-bridge=disabled",
         "CENTER role=command-output chrome=none-permanent",
         "CENTER rule=center-remains-primary-workspace",
         "BOT color=bright-blue input=active mutation=none",
@@ -157,6 +162,43 @@ fn optics_renderer_adapts_device_density_without_changing_state_meaning() {
         desktop.contains("labels=no-color/ascii-visible"),
         "{desktop}"
     );
+}
+
+#[test]
+fn optics_root_direction_map_keeps_root_centered_with_all_axes() {
+    let map = render_root_direction_map("right");
+
+    for required in [
+        "ROOT DIRECTION MAP",
+        "layout=center-root top-bottom-left-right",
+        "active-axis=right",
+        "              [ TOP ]",
+        "                 ^",
+        "                 |",
+        "[ LEFT ]  <--- [ ROOT ] --->  [ RIGHT ]",
+        "                 v",
+        "             [ BOTTOM ]",
+        "rule=root-remains-anchor",
+        "movement=planned-visible-logged-reversible",
+        "network=not-wired host-bridge=disabled",
+    ] {
+        assert!(map.contains(required), "missing {required:?}: {map}");
+    }
+}
+
+#[test]
+fn optics_root_direction_map_normalizes_direction_aliases() {
+    for (raw, expected) in [
+        ("up", "top"),
+        ("north", "top"),
+        ("down", "bottom"),
+        ("south", "bottom"),
+        ("west", "left"),
+        ("east", "right"),
+        ("unknown", "root"),
+    ] {
+        assert_eq!(normalize_direction_axis(raw), expected, "raw axis: {raw}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds a deterministic Optics PRO UI renderer for a centered ROOT direction map.

This gives Optics PRO a clear top / bottom / left / right visual foundation for future Phase navigation design while keeping this slice UI-only.

## Scope

- Add `render_root_direction_map(active_axis)` to `src/optics.rs`
- Add `normalize_direction_axis(...)` for top/bottom/left/right aliases
- Include the ROOT direction map in the static Optics preview
- Expand `tests/optics_hud_rail_renderer.rs` coverage

## Boundaries

This PR only adds deterministic UI rendering and tests. It does not add live movement or system changes.

## Validation

```bash
cargo fmt --all -- --check
cargo test -p phase1 --test optics_hud_rail_renderer
cargo test --workspace --all-targets
```

Refs #376.