### PR TITLE
Add Optics domain status overlay rails

### DIFF
--- a/src/optics.rs
+++ b/src/optics.rs
@@ -59,6 +59,12 @@ pub struct OpticsRailState {
     pub route: String,
     pub safe_portal: String,
     pub rollback: String,
+    pub domain_health: String,
+    pub risk: String,
+    pub lock_state: String,
+    pub dark_phase: String,
+    pub host_effect: String,
+    pub external_effect: String,
     pub device: OpticsDeviceProfile,
     pub input: String,
     pub mutation: String,
@@ -85,6 +91,12 @@ impl OpticsRailState {
             route: "ROOT".to_string(),
             safe_portal: "planned".to_string(),
             rollback: "available".to_string(),
+            domain_health: "nominal".to_string(),
+            risk: "low".to_string(),
+            lock_state: "open".to_string(),
+            dark_phase: "off".to_string(),
+            host_effect: "none".to_string(),
+            external_effect: "none".to_string(),
             device,
             input: "active".to_string(),
             mutation: "none".to_string(),
@@ -124,7 +136,7 @@ pub fn render_pro_shell_layers(state: &OpticsRailState, typed_input: &str, color
     format!(
         "{top_label}\nproduct={} channel={} profile={} ctx={} origin={} route={} trust={} security={} device={}\n\
          {command_label}\nphase1://edge/root > {typed}\n\n\
-         {status_label}\nresult={} mutation={} integrity={} crypto={} base1={} fyr={} safe-portal={} rollback={}\n\
+         {status_label}\nresult={} mutation={} integrity={} crypto={} base1={} fyr={} safe-portal={} rollback={} health={} risk={} lock={} dark_phase={} host-effect={} external-effect={}\n\
          {bottom_label}\ninput={} command={} task={} warning={} copy-safe=raw-command-preserved\n",
         state.product,
         state.channel,
@@ -143,6 +155,12 @@ pub fn render_pro_shell_layers(state: &OpticsRailState, typed_input: &str, color
         state.fyr,
         state.safe_portal,
         state.rollback,
+        state.domain_health,
+        state.risk,
+        state.lock_state,
+        state.dark_phase,
+        state.host_effect,
+        state.external_effect,
         state.input,
         state.command_family,
         state.active_task,
@@ -174,7 +192,7 @@ fn result_label_color(value: &str, color: bool) -> String {
 pub fn render_top_rail(state: &OpticsRailState) -> String {
     match state.device {
         OpticsDeviceProfile::Mobile => format!(
-            "TOP product={} channel={} profile={} ctx={} origin={} route={} trust={} device={}\n",
+            "TOP product={} channel={} profile={} ctx={} origin={} route={} trust={} device={}\nTOP health={} risk={} lock={} dark_phase={}\n",
             state.product,
             state.channel,
             state.profile,
@@ -182,10 +200,14 @@ pub fn render_top_rail(state: &OpticsRailState) -> String {
             state.origin,
             state.route,
             state.trust,
-            state.device.as_label()
+            state.device.as_label(),
+            state.domain_health,
+            state.risk,
+            state.lock_state,
+            state.dark_phase
         ),
         OpticsDeviceProfile::Laptop | OpticsDeviceProfile::Terminal => format!(
-            "TOP product={} channel={} profile={} ctx={} origin={} route={} trust={} security={}\nTOP integrity={} crypto={} base1={} fyr={} safe-portal={} device={}\n",
+            "TOP product={} channel={} profile={} ctx={} origin={} route={} trust={} security={}\nTOP integrity={} crypto={} base1={} fyr={} safe-portal={} device={}\nTOP health={} risk={} lock={} dark_phase={} host-effect={} external-effect={}\n",
             state.product,
             state.channel,
             state.profile,
@@ -199,10 +221,16 @@ pub fn render_top_rail(state: &OpticsRailState) -> String {
             state.base1,
             state.fyr,
             state.safe_portal,
-            state.device.as_label()
+            state.device.as_label(),
+            state.domain_health,
+            state.risk,
+            state.lock_state,
+            state.dark_phase,
+            state.host_effect,
+            state.external_effect
         ),
         OpticsDeviceProfile::Desktop => format!(
-            "TOP product={} channel={} profile={} ctx={} origin={} route={} trust={} security={}\nTOP integrity={} crypto={} base1={} fyr={} safe-portal={} rollback={} device={} evidence=planned\n",
+            "TOP product={} channel={} profile={} ctx={} origin={} route={} trust={} security={}\nTOP integrity={} crypto={} base1={} fyr={} safe-portal={} rollback={} device={} evidence=planned\nTOP health={} risk={} lock={} dark_phase={} host-effect={} external-effect={}\n",
             state.product,
             state.channel,
             state.profile,
@@ -217,7 +245,13 @@ pub fn render_top_rail(state: &OpticsRailState) -> String {
             state.fyr,
             state.safe_portal,
             state.rollback,
-            state.device.as_label()
+            state.device.as_label(),
+            state.domain_health,
+            state.risk,
+            state.lock_state,
+            state.dark_phase,
+            state.host_effect,
+            state.external_effect
         ),
     }
 }
@@ -249,11 +283,16 @@ pub fn render_root_direction_map(active_axis: &str) -> String {
 pub fn render_bottom_rail(state: &OpticsRailState) -> String {
     match state.device {
         OpticsDeviceProfile::Mobile => format!(
-            "BOT color=bright-blue input={} mutation={} result={} origin={}\n",
-            state.input, state.mutation, state.last_result, state.origin
+            "BOT color=bright-blue input={} mutation={} result={} origin={} health={} risk={}\n",
+            state.input,
+            state.mutation,
+            state.last_result,
+            state.origin,
+            state.domain_health,
+            state.risk
         ),
         OpticsDeviceProfile::Laptop | OpticsDeviceProfile::Terminal => format!(
-            "BOT color=bright-blue input={} mutation={} command={} task={} result={}\nBOT warning={} safe-portal={} rollback={} copy-safe=raw-command-preserved\n",
+            "BOT color=bright-blue input={} mutation={} command={} task={} result={}\nBOT warning={} safe-portal={} rollback={} copy-safe=raw-command-preserved host-effect={} external-effect={}\n",
             state.input,
             state.mutation,
             state.command_family,
@@ -261,10 +300,12 @@ pub fn render_bottom_rail(state: &OpticsRailState) -> String {
             state.last_result,
             state.warning,
             state.safe_portal,
-            state.rollback
+            state.rollback,
+            state.host_effect,
+            state.external_effect
         ),
         OpticsDeviceProfile::Desktop => format!(
-            "BOT color=bright-blue input={} mutation={} command={} task={} result={}\nBOT warning={} safe-portal={} rollback={} copy-safe=raw-command-preserved labels=no-color/ascii-visible\n",
+            "BOT color=bright-blue input={} mutation={} command={} task={} result={}\nBOT warning={} safe-portal={} rollback={} copy-safe=raw-command-preserved labels=no-color/ascii-visible host-effect={} external-effect={}\n",
             state.input,
             state.mutation,
             state.command_family,
@@ -272,7 +313,9 @@ pub fn render_bottom_rail(state: &OpticsRailState) -> String {
             state.last_result,
             state.warning,
             state.safe_portal,
-            state.rollback
+            state.rollback,
+            state.host_effect,
+            state.external_effect
         ),
     }
 }

--- a/tests/optics_hud_rail_renderer.rs
+++ b/tests/optics_hud_rail_renderer.rs
@@ -23,6 +23,12 @@ fn optics_renderer_static_preview_preserves_top_center_bottom_contract() {
         "crypto=chain-planned",
         "safe-portal=planned",
         "rollback=available",
+        "health=nominal",
+        "risk=low",
+        "lock=open",
+        "dark_phase=off",
+        "host-effect=none",
+        "external-effect=none",
         "ROOT DIRECTION MAP",
         "layout=center-root u-d-L-R",
         "L/NUM  <----  ROOT  ---->  R/NUM",
@@ -77,6 +83,30 @@ fn optics_pro_shell_layers_expose_origin_route_and_recovery_state() {
         "safe-portal=ready",
         "rollback=0/0",
         "phase1://edge/root > phase whereami",
+    ] {
+        assert!(frame.contains(required), "missing {required:?}: {frame}");
+    }
+}
+
+#[test]
+fn optics_pro_shell_layers_expose_danger_status_overlays() {
+    let mut state = OpticsRailState::pro_static(OpticsDeviceProfile::Terminal);
+    state.domain_health = "unstable".to_string();
+    state.risk = "high".to_string();
+    state.lock_state = "sealed".to_string();
+    state.dark_phase = "armed".to_string();
+    state.host_effect = "none".to_string();
+    state.external_effect = "none".to_string();
+    let frame = render_pro_shell_layers(&state, "phase danger status", false);
+
+    for required in [
+        "health=unstable",
+        "risk=high",
+        "lock=sealed",
+        "dark_phase=armed",
+        "host-effect=none",
+        "external-effect=none",
+        "phase1://edge/root > phase danger status",
     ] {
         assert!(frame.contains(required), "missing {required:?}: {frame}");
     }
@@ -168,6 +198,7 @@ fn optics_renderer_adapts_device_density_without_changing_state_meaning() {
 
     assert!(mobile.contains("BOT color=bright-blue input=active mutation=none result=ok"));
     assert!(mobile.contains("origin=0/0"), "{mobile}");
+    assert!(mobile.contains("health=nominal risk=low"), "{mobile}");
     assert!(
         !mobile.contains("BOT warning="),
         "mobile should stay one-line bottom rail: {mobile}"
@@ -176,6 +207,10 @@ fn optics_renderer_adapts_device_density_without_changing_state_meaning() {
     assert!(laptop.contains("device=laptop"), "{laptop}");
     assert!(
         laptop.contains("BOT warning=none safe-portal=planned rollback=available"),
+        "{laptop}"
+    );
+    assert!(
+        laptop.contains("host-effect=none external-effect=none"),
         "{laptop}"
     );
 
@@ -239,6 +274,12 @@ fn optics_renderer_custom_state_preserves_command_and_safety_labels() {
     state.route = "ROOT>L/2".to_string();
     state.safe_portal = "ready".to_string();
     state.rollback = "ROOT".to_string();
+    state.domain_health = "quarantined".to_string();
+    state.risk = "critical".to_string();
+    state.lock_state = "sealed".to_string();
+    state.dark_phase = "armed".to_string();
+    state.host_effect = "none".to_string();
+    state.external_effect = "none".to_string();
     state.integrity = "changed".to_string();
     state.crypto = "denied".to_string();
     state.mutation = "typing".to_string();
@@ -257,6 +298,12 @@ fn optics_renderer_custom_state_preserves_command_and_safety_labels() {
     assert!(top.contains("origin=0/0"), "{top}");
     assert!(top.contains("route=ROOT>L/2"), "{top}");
     assert!(top.contains("safe-portal=ready"), "{top}");
+    assert!(top.contains("health=quarantined"), "{top}");
+    assert!(top.contains("risk=critical"), "{top}");
+    assert!(top.contains("lock=sealed"), "{top}");
+    assert!(top.contains("dark_phase=armed"), "{top}");
+    assert!(top.contains("host-effect=none"), "{top}");
+    assert!(top.contains("external-effect=none"), "{top}");
     assert!(top.contains("integrity=changed"), "{top}");
     assert!(top.contains("crypto=denied"), "{top}");
     assert!(bottom.contains("mutation=typing"), "{bottom}");
@@ -266,6 +313,8 @@ fn optics_renderer_custom_state_preserves_command_and_safety_labels() {
     assert!(bottom.contains("warning=guarded-operation"), "{bottom}");
     assert!(bottom.contains("safe-portal=ready"), "{bottom}");
     assert!(bottom.contains("rollback=ROOT"), "{bottom}");
+    assert!(bottom.contains("host-effect=none"), "{bottom}");
+    assert!(bottom.contains("external-effect=none"), "{bottom}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds the next Optics PRO prerequisite slice: rendering-only domain status overlays.

This extends the Optics rails with additional status fields needed before future Phase universe state work.

## Scope

- Extend `OpticsRailState` with domain status overlay fields
- Render health, risk, lock, phase-mode, host-effect, and external-effect labels
- Preserve mobile/laptop/desktop density behavior
- Add focused renderer tests

## Boundaries

This is Optics rendering only. It does not add live movement, recovery execution, runtime domain mutation, host mutation, or external effects.

## Validation

```bash
cargo fmt --all -- --check
cargo test -p phase1 --test optics_hud_rail_renderer
cargo test --workspace --all-targets
```

Refs #379.