### PR TITLE
Promote Phase compass to source-native status renderer

### DIFF
--- a/src/phase.rs
+++ b/src/phase.rs
@@ -13,7 +13,9 @@ fn phase_help() -> String {
     out.push_str("PHASE HELP\n");
     out.push_str("mode=status-only\n");
     out.push_str("commands=whereami compass path map status help\n");
-    out.push_str("boundary=no-live-movement no-origin-mutation no-host-effect no-external-effect\n");
+    out.push_str(
+        "boundary=no-live-movement no-origin-mutation no-host-effect no-external-effect\n",
+    );
     out.push_str("examples:\n");
     out.push_str("  phase whereami\n");
     out.push_str("  phase compass\n");

--- a/src/phase.rs
+++ b/src/phase.rs
@@ -1,0 +1,122 @@
+pub fn run(args: &[String]) -> String {
+    let action = args.first().map(String::as_str).unwrap_or("whereami");
+
+    match action {
+        "whereami" | "compass" | "path" | "map" | "status" => phase_compass_status(),
+        "help" | "--help" | "-h" => phase_help(),
+        other => unknown_phase_action(other),
+    }
+}
+
+fn phase_help() -> String {
+    let mut out = String::new();
+    out.push_str("PHASE HELP\n");
+    out.push_str("mode=status-only\n");
+    out.push_str("commands=whereami compass path map status help\n");
+    out.push_str("boundary=no-live-movement no-origin-mutation no-host-effect no-external-effect\n");
+    out.push_str("examples:\n");
+    out.push_str("  phase whereami\n");
+    out.push_str("  phase compass\n");
+    out.push_str("  phase path\n");
+    out.push_str("  phase map\n");
+    out
+}
+
+fn unknown_phase_action(action: &str) -> String {
+    format!(
+        "PHASE COMPASS\nmode=status-only\nstatus=unknown-action\naction={action}\nhint=phase whereami | phase compass | phase path | phase map | phase help\nmutation=disabled\nhost-effect=none\nexternal-effect=none\n"
+    )
+}
+
+fn phase_compass_status() -> String {
+    let mut out = String::new();
+    out.push_str("PHASE COMPASS\n");
+    out.push_str("mode=status-only\n");
+    out.push_str("runtime=source-native\n");
+    out.push_str("mutation=disabled\n");
+    out.push_str("origin=0/0\n");
+    out.push_str("root-anchor=ROOT\n");
+    out.push_str("current-route=ROOT\n");
+    out.push_str("current-axis=ROOT\n");
+    out.push_str("path=ROOT>0/0\n");
+    out.push_str("breadcrumb=ROOT\n");
+    out.push_str("trace-id=trace-preview\n");
+    out.push_str("safe-portal=planned\n");
+    out.push_str("rollback-target=available\n");
+    out.push_str("health=nominal\n");
+    out.push_str("risk=low\n");
+    out.push_str("lock-state=open\n");
+    out.push_str("dark_phase=off\n");
+    out.push_str("host-effect=none\n");
+    out.push_str("external-effect=none\n");
+    out.push_str("operator-intent=explicit\n");
+    out.push_str("claim-boundary=phase-compass-status-only\n");
+    out.push('\n');
+    out.push_str("SUPPORTED ROUTES\n");
+    out.push_str("phase whereami\n");
+    out.push_str("phase compass\n");
+    out.push_str("phase path\n");
+    out.push_str("phase map\n");
+    out.push('\n');
+    out.push_str("ROOT DIRECTION MAP\n");
+    out.push_str("              u/NUM\n");
+    out.push_str("                ^\n");
+    out.push_str("                |\n");
+    out.push_str("L/NUM  <----  ROOT  ---->  R/NUM\n");
+    out.push_str("                |\n");
+    out.push_str("                v\n");
+    out.push_str("              d/NUM\n");
+    out.push_str("rule=root-remains-anchor\n");
+    out.push_str("external-link=none\n");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run;
+
+    #[test]
+    fn phase_whereami_reports_status_only_native_compass() {
+        let output = run(&["whereami".to_string()]);
+
+        for required in [
+            "PHASE COMPASS",
+            "mode=status-only",
+            "runtime=source-native",
+            "mutation=disabled",
+            "origin=0/0",
+            "root-anchor=ROOT",
+            "current-route=ROOT",
+            "current-axis=ROOT",
+            "path=ROOT>0/0",
+            "breadcrumb=ROOT",
+            "trace-id=trace-preview",
+            "safe-portal=planned",
+            "rollback-target=available",
+            "operator-intent=explicit",
+            "claim-boundary=phase-compass-status-only",
+            "L/NUM  <----  ROOT  ---->  R/NUM",
+        ] {
+            assert!(output.contains(required), "missing {required}:\n{output}");
+        }
+    }
+
+    #[test]
+    fn phase_aliases_share_status_surface() {
+        for action in ["compass", "path", "map", "status"] {
+            let output = run(&[action.to_string()]);
+            assert!(output.contains("PHASE COMPASS"), "{output}");
+            assert!(output.contains("runtime=source-native"), "{output}");
+            assert!(output.contains("mutation=disabled"), "{output}");
+        }
+    }
+
+    #[test]
+    fn phase_unknown_action_stays_status_only() {
+        let output = run(&["shift".to_string()]);
+        assert!(output.contains("status=unknown-action"), "{output}");
+        assert!(output.contains("mutation=disabled"), "{output}");
+        assert!(output.contains("host-effect=none"), "{output}");
+        assert!(output.contains("external-effect=none"), "{output}");
+    }
+}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -2,6 +2,8 @@
 mod arena;
 #[path = "optics.rs"]
 mod optics;
+#[path = "phase.rs"]
+mod phase;
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -62,6 +64,9 @@ pub fn execute_plugin(plugins_dir: &Path, name: &str, args: &[String]) -> String
     if is_arena(name) {
         return launch_arena(args);
     }
+    if is_phase(name) {
+        return phase_native(args);
+    }
     if is_optics_status(name, args) {
         return optics_status(args);
     }
@@ -110,6 +115,24 @@ pub fn execute_plugin(plugins_dir: &Path, name: &str, args: &[String]) -> String
         "status : failed\n"
     });
     out.push_str(&format!("exit   : {}\n", manifest.exit_code));
+    out
+}
+
+fn is_phase(name: &str) -> bool {
+    name == "phase"
+}
+
+fn phase_native(args: &[String]) -> String {
+    let mut out = String::from("phase1 native run\n");
+    out.push_str("command: phase\n");
+    if args.is_empty() {
+        out.push_str("args   : none\n");
+    } else {
+        out.push_str(&format!("args   : {}\n", redact_args(args).join(" ")));
+    }
+    out.push_str(&phase::run(args));
+    out.push_str("status : ok\n");
+    out.push_str("exit   : 0\n");
     out
 }
 
@@ -243,7 +266,7 @@ fn list_plugins(plugins_dir: &Path) -> String {
             }
         }
     }
-    for built_in in ["arena", "game"] {
+    for built_in in ["arena", "game", "phase"] {
         if !names.iter().any(|name| name == built_in) {
             names.push(built_in.to_string());
         }
@@ -262,6 +285,9 @@ fn inspect_plugin(plugins_dir: &Path, name: &str) -> String {
     }
     if is_arena(name) {
         return arena_inspect();
+    }
+    if is_phase(name) {
+        return phase_inspect();
     }
 
     let path = match plugin_path(plugins_dir, name) {
@@ -299,6 +325,9 @@ fn validate_plugin(plugins_dir: &Path, name: &str) -> String {
     if is_arena(name) {
         return "wasm: arena built-in phase1-wasi-lite game launcher\n".to_string();
     }
+    if is_phase(name) {
+        return "wasm: phase source-native status surface\n".to_string();
+    }
 
     let path = match plugin_path(plugins_dir, name) {
         Ok(path) => path,
@@ -330,6 +359,16 @@ fn arena_inspect() -> String {
     out.push_str("cap    : none\n");
     out.push_str("play   : arena start\n");
     out.push_str("dev    : docs/developers/GAME_DEV.md and scripts/test-game.sh\n");
+    out
+}
+
+fn phase_inspect() -> String {
+    let mut out = String::from("phase1 wasm inspect\n");
+    out.push_str("plugin : phase\n");
+    out.push_str("module : source-native Phase compass status surface\n");
+    out.push_str("runtime: source-native\n");
+    out.push_str("cap    : none\n");
+    out.push_str("usage  : phase whereami | phase compass | phase path | phase map\n");
     out
 }
 
@@ -474,6 +513,7 @@ mod tests {
         assert!(listed.contains("demo"));
         assert!(listed.contains("arena"));
         assert!(listed.contains("game"));
+        assert!(listed.contains("phase"));
         let inspected = inspect_plugin(&dir, "demo");
         assert!(inspected.contains("valid wasm"));
         let game = inspect_plugin(&dir, "arena");
@@ -481,6 +521,8 @@ mod tests {
         assert!(game.contains("Phase1 Arena"));
         let workspace = inspect_plugin(&dir, "game");
         assert!(workspace.contains("development workspace"));
+        let phase = inspect_plugin(&dir, "phase");
+        assert!(phase.contains("source-native Phase compass status surface"));
         let _ = fs::remove_dir_all(dir);
     }
 
@@ -492,6 +534,22 @@ mod tests {
         assert!(out.contains("hello wasi"));
         assert!(out.contains("host=blocked"));
         assert!(out.contains("[redacted]"));
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn phase_builtin_uses_source_native_status_surface() {
+        let dir = temp_plugins();
+        let out = execute_plugin(&dir, "phase", &["whereami".to_string()]);
+        assert!(out.contains("phase1 native run"));
+        assert!(out.contains("command: phase"));
+        assert!(out.contains("args   : whereami"));
+        assert!(out.contains("PHASE COMPASS"));
+        assert!(out.contains("runtime=source-native"));
+        assert!(out.contains("mutation=disabled"));
+        assert!(out.contains("origin=0/0"));
+        assert!(out.contains("path=ROOT>0/0"));
+        assert!(!out.contains("phase1 wasi run"));
         let _ = fs::remove_dir_all(dir);
     }
 

--- a/tests/phase_compass_status_runtime.rs
+++ b/tests/phase_compass_status_runtime.rs
@@ -41,6 +41,7 @@ fn assert_compass_core(output: &str) {
     for required in [
         "PHASE COMPASS",
         "mode=status-only",
+        "runtime=source-native",
         "mutation=disabled",
         "origin=0/0",
         "root-anchor=ROOT",
@@ -61,21 +62,19 @@ fn assert_compass_core(output: &str) {
 }
 
 #[test]
-fn phase_compass_wasi_plugin_runs_from_default_plugins_directory() {
+fn phase_compass_uses_source_native_runtime_surface() {
     let output = wasm::execute_plugin(Path::new("plugins"), "phase", &["whereami".to_string()]);
 
     for required in [
-        "phase1 wasi run",
-        "plugin : phase",
-        "runtime: phase1-wasi-lite",
-        "sandbox: fs=virtual net=disabled host=blocked",
-        "cap    : none",
+        "phase1 native run",
+        "command: phase",
         "args   : whereami",
         "status : ok",
         "exit   : 0",
     ] {
         assert!(output.contains(required), "missing {required:?}:\n{output}");
     }
+    assert!(!output.contains("phase1 wasi run"), "{output}");
     assert_compass_core(&output);
 }
 


### PR DESCRIPTION
## Summary

Promotes the Phase Compass status surface from manifest-backed output to a source-native renderer while preserving the same operator command path.

The command still runs through the existing Phase1 execution route:

```text
phase whereami
phase compass
phase path
phase map
```

But the rendered body now comes from `src/phase.rs` and reports:

```text
runtime=source-native
```

## Scope

- Add `src/phase.rs`
- Route the built-in `phase` surface through the source-native Phase renderer
- Preserve the default `phase` command behavior from inside Phase1
- Keep the WASI-lite dispatcher wrapper as the safe entry path
- Update focused runtime tests

## Boundaries

This remains status-only. It does not add live movement, origin mutation, trace storage, runtime domain mutation, recovery execution, host mutation, or external effects.

## Validation

```bash
cargo fmt --all -- --check
cargo test -p phase1 --test phase_compass_status_runtime
cargo test --workspace --all-targets
```

Refs #379.