### PR TITLE
Update README and public status for Phase Compass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Phase1
 
-> [Live project status](https://bryforge.github.io/phase1/status.html) · [status.json](https://bryforge.github.io/phase1/status.json) · current roadmap estimate: **66%**
+> [Live project status](https://bryforge.github.io/phase1/status.html) · [status.json](https://bryforge.github.io/phase1/status.json) · current roadmap estimate: **68%**
 
 <p align="center">
   <a href="https://bryforge.github.io/phase1/">
@@ -48,7 +48,7 @@
 
 ## What is Phase1?
 
-Phase1 is a Rust-built, terminal-first virtual operating-system console created by Chase Bryan / Bryforge. It gives a futuristic operator surface backed by practical systems ideas: a simulated kernel, virtual filesystem, process table, audit log, command metadata, guarded host access, storage helpers, local learning, the Fyr native language, Nested Phase1 metadata-control, and a long-term operating-system track through Base1.
+Phase1 is a Rust-built, terminal-first virtual operating-system console created by Chase Bryan / Bryforge. It gives a futuristic operator surface backed by practical systems ideas: a simulated kernel, virtual filesystem, process table, audit log, command metadata, guarded host access, storage helpers, local learning, the Fyr native language, Nested Phase1 metadata-control, Optics PRO visibility rails, source-native Phase Compass status, and a long-term operating-system track through Base1.
 
 Phase1 is not yet a kernel, hardened sandbox, or drop-in replacement for Linux, macOS, or Windows. The OS track is a staged plan to make Phase1 the primary user environment on bootable hardware through a minimal Base1 foundation, recovery path, installer, hardware matrix, x86_64 boot-support planning, and conservative security claims.
 
@@ -60,6 +60,7 @@ Phase1 is not yet a kernel, hardened sandbox, or drop-in replacement for Linux, 
 | Virtual OS model | Simulated kernel, VFS, process table, `/proc`, `/dev`, `/var/log`, architecture reports, and system inspection commands. |
 | Guarded host access | Safe mode on by default, explicit trust gates, command capability metadata, and secret redaction. |
 | Fyr native language | `.fyr` scripts with prints, returns, let bindings, arithmetic, assertions, comparisons, boolean chains, grouped expressions, `if` return statements, test runner, package checks, syntax color output, and Fyr-aware tab completion for actions and demo files. |
+| Optics PRO and Phase universe | ROOT-centered direction map, origin/route/safe-portal/rollback rails, domain health/risk/lock/dark_phase overlays, trace/breadcrumb visibility, and source-native `phase whereami` / `phase compass` / `phase path` / `phase map` status output. |
 | Nested Phase1 | Metadata-only recursive operator contexts with `nest status`, `nest spawn`, `nest enter`, `nest destroy`, `nest inspect`, and `nest tree`. |
 | Base1 OS track | Long-term path toward a bootable Phase1-first system with Base1 as the trusted host layer, recovery, installer, update, storage, x86_64 boot profiles, and hardware validation. |
 | Learning system | `phase1-learn` stores local sanitized memory, imports history, learns notes/rules, and suggests next actions. |
@@ -119,6 +120,9 @@ help
 capabilities
 sysinfo
 security
+optics rails
+phase whereami
+phase compass
 nest status
 nest tree
 wiki-quick
@@ -160,6 +164,7 @@ Phase1 separates implemented features from experimental host integrations and fu
 | --- | --- | --- |
 | Terminal shell, VFS, process table, audit log, `/proc`, text tools, and dashboards | Implemented | Simulated Phase1 subsystems covered by tests and smoke checks. |
 | Fyr native language | Implemented and growing | Current edge supports a practical seed language surface and package test flow. |
+| Optics PRO and Phase Compass | Implemented checkpoint | ROOT direction map, origin/recovery rails, danger/status overlays, trace/breadcrumb rails, and source-native Phase Compass status commands are present; live Phase movement is future work. |
 | Nested Phase1 metadata contexts | Implemented checkpoint | Metadata-only context controls are present; runtime-backed child kernels are future work. |
 | Local learning memory | Implemented | Local, sanitized, bounded, and git-ignored. |
 | WASI-lite plugins | Implemented | Phase1's sandboxed plugin path; no host shell/network passthrough. |
@@ -171,6 +176,44 @@ Phase1 separates implemented features from experimental host integrations and fu
 | Phase1 OS track | Long-term roadmap | Base1-backed path toward a bootable Phase1-first environment; not a current drop-in OS replacement. |
 
 Inside Phase1, run `capabilities` to inspect command-level gates and guard status.
+
+## Phase universe and Optics checkpoint
+
+The Phase universe track is now visible before it is live. The current checkpoint is status-only and rendering-only: it proves the route/origin vocabulary, Optics rail visibility, and Phase Compass status surface without claiming real movement, recovery execution, host mutation, or external effects.
+
+Current commands:
+
+```text
+optics rails
+phase whereami
+phase compass
+phase path
+phase map
+phase help
+```
+
+Current status fields include:
+
+```text
+origin=0/0
+root-anchor=ROOT
+current-route=ROOT
+current-axis=ROOT
+path=ROOT>0/0
+breadcrumb=ROOT
+trace-id=trace-preview
+safe-portal=planned
+rollback-target=available
+health=nominal
+risk=low
+lock-state=open
+dark_phase=off
+host-effect=none
+external-effect=none
+runtime=source-native
+```
+
+Boundary: these surfaces are status and visualization prerequisites only. They do not implement live directional movement, origin mutation, safe-portal recovery, runtime domain mutation, host networking changes, or external effects.
 
 ## Nested Phase1 checkpoint
 
@@ -341,7 +384,7 @@ base1/                Base1 compatibility entry points and root-level Base1 docs
 docs/                 Repository-first manual, navigation, roadmaps, support docs, and security docs
 docs/releases/        Organized release and checkpoint documentation
 docs/website/         Website, branding, accessibility, and public content planning
-examples/             Safe examples, walkthrough inputs, Fyr scripts, and dry-run demo material
+examples/             Safe examples, Fyr scripts, walkthrough inputs, and dry-run demo material
 scripts/              Quality, runtime, Base1, wiki, and learning helpers
 tests/                Rust tests and documentation guard tests
 tools/                Internal maintainer utilities and future automation helpers
@@ -533,6 +576,7 @@ Keep stable bases boring. Move tested work through edge/stable.
 - Current edge version: `v7.0.1`
 - Stable base: `base/v6.0.0`
 - Active path: `edge/stable`
+- Latest Phase universe checkpoint: Optics PRO visibility plus source-native Phase Compass status (`phase whereami`, `phase compass`, `phase path`, `phase map`).
 - Docs are generated by `scripts/update-docs.py`.
 <!-- phase1:auto:current-status:end -->
 

--- a/docs/status/PROJECT_STATUS.md
+++ b/docs/status/PROJECT_STATUS.md
@@ -3,22 +3,23 @@
 Status kind: estimated roadmap progress
 Source marker: [`site/status.json`](../../site/status.json)
 Badge marker: [`site/status-badge.json`](../../site/status-badge.json)
-Generated from commit: `3c75180da9e62be73533610ae052cd01ab71bc99`
-Last updated UTC: `2026-05-14T20:42:44Z`
+Generated from commit: `5ad5a73e54602e970f75843a6f0928187ce1e411`
+Last updated UTC: `2026-05-15T06:10:00Z`
 
 ## Current estimate
 
 | Project | Estimated completion | Current state | Next milestone |
 | --- | ---: | --- | --- |
-| Phase1 operator console | 82% | usable edge console with guarded host access, VFS, dashboards, help UI, themes, learning, and tests | wire safe Fyr black_arts staged runtime stubs while preserving non-live defaults |
+| Phase1 operator console | 84% | usable edge console with guarded host access, VFS, dashboards, help UI, themes, learning, tests, Optics PRO rails, and source-native Phase Compass status commands | move from status-only Phase Compass into tested trace/breadcrumb state fixtures before any live movement |
 | Fyr native language | 58% | seed language and toolchain surface exist with F3/F4/F5/F6 evidence, runtime-safety fixtures, standard-library contracts, Fyr-aware tab completion, and black_arts staged-candidate design/operator-visual/source-wiring handoff evidence | implement the first safe fyr staged runtime stub from issue #317 without candidate writes, host commands, network access, validation execution, promotion, discard, or live-system changes |
-| Base1 secure host / OS track | 40% | B2 focused test-suite evidence passed, reviewed B3 VM evidence is present, and the B6 X200 marker chain is published through evidence, checkpoint, public status, and release note; claim remains not_claimed | continue B4 recovery validation and repeatable physical boot evidence while preserving installer, hardening, release-candidate, and daily-driver non-claims |
+| Phase universe / Optics PRO | 34% | route/origin contract, proof ladder, Optics ROOT map, recovery/status/danger/trace rails, source-native Phase Compass status, and lore-mode issue #386 are present; live movement remains future work | add state fixtures and invariant tests for path, breadcrumb, origin return, safe portal, and domain health before movement |
+| Base1 secure host / OS track | 40% | B2 focused test-suite evidence passed, reviewed B3 VM evidence is present, and the B6 X200 marker chain is published through evidence, checkpoint, public status, and release note; claim remains not_claimed | continue B4 recovery validation, fresh-spawn contingency planning, and repeatable physical boot evidence while preserving installer, hardening, release-candidate, and daily-driver non-claims |
 | X200 / Libreboot hardware path | 44% | X200 Linux-libre host generated reviewed B3 VM evidence and B6 marker evidence with phase1_marker_seen; the checkpoint and release note are published; repeatable physical boot validation remains separate | capture repeatable physical boot evidence and keep emulator, USB, recovery, installer, and hardware-readiness claims separated |
 | Security and crypto policy | 55% | trust model, crypto policy roadmap, provider registry, profile docs, config schema, and integrity checks are present | move from documentation policy into scoped implementation only after tests and review evidence |
-| Website and public docs | 90% | public site, status page, status JSON, badge endpoint, native GitHub Wiki, refreshed source wiki, organized docs, X200 evidence report, B6 checkpoint trail, Base1 B6 X200 release note, and Fyr black_arts public status trail are in place | keep the public status synchronized with implementation evidence and non-claims |
+| Website and public docs | 91% | public site, status page, status JSON, badge endpoint, native GitHub Wiki, refreshed source wiki, organized docs, Phase Compass status note, X200 evidence report, B6 checkpoint trail, Base1 B6 X200 release note, and Fyr black_arts public status trail are in place | keep the public status synchronized with implementation evidence and non-claims |
 | Repository organization | 100% | minimal root has 11 tracked files, 17 top-level folders, 0 unplanned root files, 0 tracked build files, and 0 root status duplicates | keep generated artifacts out of Git and keep compatibility links clean as work lands |
 
-Overall estimated roadmap completion: **67%**.
+Overall estimated roadmap completion: **68%**.
 
 ## Repository organization inputs
 
@@ -39,14 +40,21 @@ https://bryforge.github.io/phase1/status-badge.json
 
 ## Current public report
 
-Current report: Fyr black_arts staged-candidate evidence and [`docs/base1/releases/RELEASE_BASE1_B6_X200_MARKER_CHECKPOINT_V1.md`](../../docs/base1/releases/RELEASE_BASE1_B6_X200_MARKER_CHECKPOINT_V1.md)
+Current report: Phase Compass source-native status checkpoint, Optics PRO visibility rails, Fyr black_arts staged-candidate evidence, and [`docs/base1/releases/RELEASE_BASE1_B6_X200_MARKER_CHECKPOINT_V1.md`](../../docs/base1/releases/RELEASE_BASE1_B6_X200_MARKER_CHECKPOINT_V1.md)
 
-Fyr now has command and action-aware tab completion for `fyr`, `fyr run`, `fyr cat`, and the default `hello_hacker.fyr` VFS demo; Fyr black_arts also has staged-candidate design, fixture, visual-mode, checklist, and runtime-stub handoff evidence. The first safe runtime wiring remains pending under issue #317.
+Phase1 now has a status-only Phase universe checkpoint: Optics PRO renders ROOT-centered route visibility, origin/recovery rails, danger/status overlays, and trace/breadcrumb labels; `phase whereami`, `phase compass`, `phase path`, and `phase map` report a source-native Phase Compass status surface. These are prerequisites only and do not claim live directional movement, origin mutation, runtime domain mutation, recovery execution, host mutation, or external effects.
+
+Fyr has command and action-aware tab completion for `fyr`, `fyr run`, `fyr cat`, and the default `hello_hacker.fyr` VFS demo; Fyr black_arts also has staged-candidate design, fixture, visual-mode, checklist, and runtime-stub handoff evidence. The first safe runtime wiring remains pending under issue #317.
 
 The B6 X200 marker chain is still published through raw evidence, checkpoint, public status, and Base1 checkpoint release note.
 
 | Item | Value |
 | --- | --- |
+| Phase Compass commands | `phase whereami`, `phase compass`, `phase path`, `phase map` |
+| Phase Compass runtime | `source-native` |
+| Phase universe issue | `#379` |
+| Phase proof/evidence issue | `#381` |
+| Spawn Basilisk lore-mode issue | `#386` |
 | Fyr black_arts runtime issue | `#317` |
 | Fyr black_arts design | [`docs/fyr/STAGED_CANDIDATES.md`](../../docs/fyr/STAGED_CANDIDATES.md) |
 | Fyr black_arts operator visuals | [`docs/fyr/BLACK_ARTS_OPERATOR_VISUALS.md`](../../docs/fyr/BLACK_ARTS_OPERATOR_VISUALS.md) |
@@ -58,11 +66,13 @@ The B6 X200 marker chain is still published through raw evidence, checkpoint, pu
 | Final evidence anchor | `095786e808d3908d27c045f04f3de0b5cd538ab9` |
 | Artifact SHA256 | `688518c1437003c7b8325b1d5d479bc97f77c3404c8fd27dace6d823d406b79b` |
 
-This report does not claim installer readiness, recovery completion, hardening, release-candidate readiness, daily-driver readiness, broad hardware validation, live-system mutation, or autonomous promotion.
+This report does not claim installer readiness, recovery completion, hardening, release-candidate readiness, daily-driver readiness, broad hardware validation, live-system mutation, live Phase movement, origin mutation, autonomous promotion, or external effects.
 
 ## Non-claims
 
 These percentages are planning estimates. They do not claim that Phase1, Base1, or Fyr are production-ready, installer-ready, daily-driver ready, hardware-validated across targets, hardened, cryptographically complete, live-self-updating, or capable of autonomous promotion/mutation.
+
+The Phase universe / Optics PRO / Phase Compass checkpoint is status-only and visualization-first. It does not implement live directional movement, origin mutation, runtime domain mutation, safe-portal recovery execution, host networking changes, or external effects.
 
 Fyr black_arts staged-candidate evidence is fixture-backed and design/contract oriented. The first safe runtime wiring remains pending under issue #317.
 

--- a/site/status-badge.json
+++ b/site/status-badge.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "Phase1 status",
-  "message": "67% roadmap",
+  "message": "68% roadmap",
   "color": "00d8ff",
   "namedLogo": "github",
   "cacheSeconds": 300

--- a/site/status.json
+++ b/site/status.json
@@ -1,19 +1,19 @@
 {
   "name": "Phase1 public project status",
   "status_kind": "estimated roadmap progress",
-  "last_updated_utc": "2026-05-14T20:42:44Z",
+  "last_updated_utc": "2026-05-15T06:10:00Z",
   "repository": "Bryforge/phase1",
   "branch": "edge/stable",
-  "commit": "3c75180da9e62be73533610ae052cd01ab71bc99",
-  "overall_estimated_completion_percent": 67,
-  "public_state": "active edge development with reviewed B3 VM evidence, B6 X200 marker evidence, public status promotion, Base1 B6 X200 marker checkpoint release note, and Fyr black_arts staged-candidate evidence published",
-  "important_boundary": "Percentages are planning estimates, not production-readiness, security-hardening, live-update, or autonomous self-modification claims. Fyr black_arts has staged-candidate design, fixtures, operator visuals, source-wiring checklist, and runtime-stub handoff evidence, but the first safe runtime stub remains pending under issue #317. Installer readiness, recovery-complete status, hardening, release-candidate readiness, daily-driver readiness, broad hardware validation, live-system mutation, and autonomous promotion remain not claimed.",
+  "commit": "5ad5a73e54602e970f75843a6f0928187ce1e411",
+  "overall_estimated_completion_percent": 68,
+  "public_state": "active edge development with Optics PRO visibility rails, source-native Phase Compass status, reviewed B3 VM evidence, B6 X200 marker evidence, public status promotion, Base1 B6 X200 marker checkpoint release note, and Fyr black_arts staged-candidate evidence published",
+  "important_boundary": "Percentages are planning estimates, not production-readiness, security-hardening, live-update, live Phase movement, or autonomous self-modification claims. Phase Compass and Optics PRO surfaces are status-only and visualization-first. Fyr black_arts has staged-candidate design, fixtures, operator visuals, source-wiring checklist, and runtime-stub handoff evidence, but the first safe runtime stub remains pending under issue #317. Installer readiness, recovery-complete status, hardening, release-candidate readiness, daily-driver readiness, broad hardware validation, live-system mutation, and autonomous promotion remain not claimed.",
   "projects": [
     {
       "name": "Phase1 operator console",
-      "estimated_completion_percent": 82,
-      "state": "usable edge console with guarded host access, VFS, dashboards, help UI, themes, learning, and tests",
-      "next_milestone": "wire safe Fyr black_arts staged runtime stubs while preserving non-live defaults"
+      "estimated_completion_percent": 84,
+      "state": "usable edge console with guarded host access, VFS, dashboards, help UI, themes, learning, tests, Optics PRO rails, and source-native Phase Compass status commands",
+      "next_milestone": "move from status-only Phase Compass into tested trace/breadcrumb state fixtures before any live movement"
     },
     {
       "name": "Fyr native language",
@@ -22,10 +22,16 @@
       "next_milestone": "implement the first safe fyr staged runtime stub from issue #317 without candidate writes, host commands, network access, validation execution, promotion, discard, or live-system changes"
     },
     {
+      "name": "Phase universe / Optics PRO",
+      "estimated_completion_percent": 34,
+      "state": "route/origin contract, proof ladder, Optics ROOT map, recovery/status/danger/trace rails, source-native Phase Compass status, and lore-mode issue #386 are present; live movement remains future work",
+      "next_milestone": "add state fixtures and invariant tests for path, breadcrumb, origin return, safe portal, and domain health before movement"
+    },
+    {
       "name": "Base1 secure host / OS track",
       "estimated_completion_percent": 40,
       "state": "B2 focused test-suite evidence passed, reviewed B3 VM evidence is present, and the B6 X200 marker chain is published through evidence, checkpoint, public status, and release note; claim remains not_claimed",
-      "next_milestone": "continue B4 recovery validation and repeatable physical boot evidence while preserving installer, hardening, release-candidate, and daily-driver non-claims"
+      "next_milestone": "continue B4 recovery validation, fresh-spawn contingency planning, and repeatable physical boot evidence while preserving installer, hardening, release-candidate, and daily-driver non-claims"
     },
     {
       "name": "X200 / Libreboot hardware path",
@@ -41,8 +47,8 @@
     },
     {
       "name": "Website and public docs",
-      "estimated_completion_percent": 90,
-      "state": "public site, status page, status JSON, badge endpoint, native GitHub Wiki, refreshed source wiki, organized docs, X200 evidence report, B6 checkpoint trail, Base1 B6 X200 release note, and Fyr black_arts public status trail are in place",
+      "estimated_completion_percent": 91,
+      "state": "public site, status page, status JSON, badge endpoint, native GitHub Wiki, refreshed source wiki, organized docs, Phase Compass status note, X200 evidence report, B6 checkpoint trail, Base1 B6 X200 release note, and Fyr black_arts public status trail are in place",
       "next_milestone": "keep the public status synchronized with implementation evidence and non-claims"
     },
     {
@@ -116,11 +122,32 @@
     "not cryptographically complete",
     "not a live self-updating system",
     "not autonomous promotion or mutation",
+    "Phase universe, Optics PRO, and Phase Compass surfaces are status-only and visualization-first; live movement, origin mutation, safe portal recovery execution, host networking changes, and external effects remain not claimed",
     "Fyr black_arts staged-candidate evidence is fixture-backed and design/contract oriented; first safe runtime wiring remains pending under issue #317",
     "B6 X200 marker checkpoint is present with phase1_marker_seen; non-claims remain in force",
     "B6 X200 release note is published; installer, recovery-complete, hardening, release-candidate, daily-driver, and broad hardware-validation claims remain out of scope"
   ],
   "evidence_checkpoints": [
+    {
+      "name": "Phase Compass source-native status checkpoint",
+      "path": "src/phase.rs",
+      "commands": [
+        "phase whereami",
+        "phase compass",
+        "phase path",
+        "phase map"
+      ],
+      "result": "source-native status surface",
+      "claim": "status_only",
+      "non_claims": [
+        "not live movement",
+        "not origin mutation",
+        "not runtime domain mutation",
+        "not recovery execution",
+        "not host mutation",
+        "not external effects"
+      ]
+    },
     {
       "name": "B6 X200 marker checkpoint",
       "path": "docs/checkpoints/B6_X200_MARKER_CHECKPOINT.md",
@@ -145,8 +172,18 @@
     }
   ],
   "current_public_report": {
-    "title": "Fyr black_arts staged-candidate evidence and Phase1/Base1 B6 X200 marker checkpoint report",
-    "summary": "Fyr now has command and action-aware tab completion for `fyr`, `fyr run`, `fyr cat`, and the default `hello_hacker.fyr` VFS demo; Fyr black_arts also has staged-candidate design, fixture, visual-mode, checklist, and runtime-stub handoff evidence, while the B6 X200 marker chain remains published through raw evidence, checkpoint, public status, and Base1 checkpoint release note.",
+    "title": "Phase Compass status checkpoint, Optics PRO rails, Fyr black_arts staged-candidate evidence, and Phase1/Base1 B6 X200 marker checkpoint report",
+    "summary": "Phase1 now has a status-only Phase universe checkpoint with Optics PRO ROOT-centered visibility and source-native Phase Compass status commands. Fyr still has command and action-aware tab completion plus black_arts staged-candidate evidence, while the B6 X200 marker chain remains published through raw evidence, checkpoint, public status, and Base1 checkpoint release note.",
+    "phase_compass_commands": [
+      "phase whereami",
+      "phase compass",
+      "phase path",
+      "phase map"
+    ],
+    "phase_compass_runtime": "source-native",
+    "phase_universe_issue": "https://github.com/Bryforge/phase1/issues/379",
+    "phase_proof_evidence_issue": "https://github.com/Bryforge/phase1/issues/381",
+    "spawn_basilisk_issue": "https://github.com/Bryforge/phase1/issues/386",
     "release_note_path": "docs/base1/releases/RELEASE_BASE1_B6_X200_MARKER_CHECKPOINT_V1.md",
     "checkpoint_path": "docs/checkpoints/B6_X200_MARKER_CHECKPOINT.md",
     "fyr_black_arts_paths": [


### PR DESCRIPTION
## Summary

Updates the README, public status notes, status JSON, and badge after the Phase Compass and Optics PRO checkpoint landed.

## Validation

```bash
cargo fmt --all -- --check
cargo test --workspace --all-targets
```

Refs #379.