### PR TITLE
Add real system development guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,8 @@ Start with [`MANUAL_ROADMAP.md`](MANUAL_ROADMAP.md) for the full book, manual, a
 ## Fast navigation
 
 - [`REPOSITORY_NAVIGATION.md`](REPOSITORY_NAVIGATION.md) — repository map, fast paths, reader paths, issue-template chooser, quality-gate chooser, and reorganization rules.
+- [`project/REAL_SYSTEM_DEVELOPMENT_GUIDE.md`](project/REAL_SYSTEM_DEVELOPMENT_GUIDE.md) — real-system development direction, evidence ladder, Phase1/Base1/Fyr/Optics roles, and promotion rules.
+- [`project/TRILATERAL_PHASE_MOVEMENT.md`](project/TRILATERAL_PHASE_MOVEMENT.md) — Trilateral Phase Movement design contract, fixture-first state model, preview-only transition rules, and non-claims.
 - [`REORGANIZATION_PLAN.md`](REORGANIZATION_PLAN.md) — minimalist target structure, destination map, move policy, and rollback rules.
 - [`../README.md`](../README.md) — public project entry point and quick start.
 - [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — repository-wide contribution guidelines.
@@ -29,6 +31,8 @@ Start with [`MANUAL_ROADMAP.md`](MANUAL_ROADMAP.md) for the full book, manual, a
 | --- | --- | --- |
 | First-time user | [`operators/README.md`](operators/README.md) | Launch Phase1 safely and understand the current boundary. |
 | Operator | [`phase1/README.md`](phase1/README.md) | Learn boot modes, shell workflows, VFS, host tools, and logs. |
+| Real-system builder | [`project/REAL_SYSTEM_DEVELOPMENT_GUIDE.md`](project/REAL_SYSTEM_DEVELOPMENT_GUIDE.md) | Build toward real-world capability through fixtures, tests, gates, VM evidence, and hardware evidence. |
+| Phase movement designer | [`project/TRILATERAL_PHASE_MOVEMENT.md`](project/TRILATERAL_PHASE_MOVEMENT.md) | Develop Phase universe movement as fixture-first, preview-only, effect-free state transitions before live movement. |
 | Repository navigator | [`REPOSITORY_NAVIGATION.md`](REPOSITORY_NAVIGATION.md) | Find the right repo area, support path, contribution path, or validation gate quickly. |
 | Repository organizer | [`REORGANIZATION_PLAN.md`](REORGANIZATION_PLAN.md) | Follow preservation-first moves, destination mapping, compatibility, and rollback rules. |
 | Contributor | [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | Prepare repository contributions while preserving quality, safety, compatibility, and non-claims. |
@@ -46,6 +50,8 @@ Start with [`MANUAL_ROADMAP.md`](MANUAL_ROADMAP.md) for the full book, manual, a
 
 - [`REPOSITORY_NAVIGATION.md`](REPOSITORY_NAVIGATION.md) — repository navigation guide and fast-path map.
 - [`REORGANIZATION_PLAN.md`](REORGANIZATION_PLAN.md) — repository reorganization plan and minimalist target structure.
+- [`project/REAL_SYSTEM_DEVELOPMENT_GUIDE.md`](project/REAL_SYSTEM_DEVELOPMENT_GUIDE.md) — real-system development guide and evidence ladder.
+- [`project/TRILATERAL_PHASE_MOVEMENT.md`](project/TRILATERAL_PHASE_MOVEMENT.md) — Trilateral Phase Movement model and fixture-first implementation contract.
 - [`phase1/`](phase1/) — Phase1 Operator Manual.
 - [`base1/`](base1/) — Base1 Recovery and OS Foundation Manual.
 - [`fyr/`](fyr/) — Fyr Language Book.

--- a/docs/REPOSITORY_NAVIGATION.md
+++ b/docs/REPOSITORY_NAVIGATION.md
@@ -23,6 +23,8 @@ Phase1 now covers several connected workstreams:
 | --- | --- |
 | Run Phase1 | [`../README.md`](../README.md#quick-start) |
 | Understand what is implemented | [`../docs/project/FEATURE_STATUS.md`](../docs/project/FEATURE_STATUS.md) |
+| Build toward a real-life system | [`project/REAL_SYSTEM_DEVELOPMENT_GUIDE.md`](project/REAL_SYSTEM_DEVELOPMENT_GUIDE.md) |
+| Develop Trilateral Phase Movement | [`project/TRILATERAL_PHASE_MOVEMENT.md`](project/TRILATERAL_PHASE_MOVEMENT.md) |
 | Learn the docs structure | [`README.md`](README.md) |
 | Understand the reorganization plan | [`REORGANIZATION_PLAN.md`](REORGANIZATION_PLAN.md) |
 | Review public asset filenames | [`../assets/README.md`](../assets/README.md) |
@@ -52,6 +54,8 @@ Phase1 now covers several connected workstreams:
 | `SECURITY.md` | Security model, trust gates, crypto policy goal, and reporting guidance. |
 | `docs/quality/QUALITY.md` | Quality gates, validation commands, score model, and ownership areas. |
 | `docs/project/FEATURE_STATUS.md` | Implemented, experimental, restricted, and roadmap feature matrix. |
+| `docs/project/REAL_SYSTEM_DEVELOPMENT_GUIDE.md` | Real-system development direction, evidence ladder, project roles, promotion rules, and next development order. |
+| `docs/project/TRILATERAL_PHASE_MOVEMENT.md` | Trilateral Phase Movement design contract, fixture-first state model, preview-only transition rules, and non-claims. |
 | `docs/project/PHASE1_NATIVE_LANGUAGE.md` | Fyr language specification and entry point. |
 | `.github/` | Pull request template, issue templates, workflows, and automation. |
 | `src/` | Phase1 Rust source. |
@@ -82,6 +86,20 @@ Phase1 now covers several connected workstreams:
 2. Run the quick start.
 3. Read [`operators/README.md`](operators/README.md).
 4. Check [`../docs/project/FEATURE_STATUS.md`](../docs/project/FEATURE_STATUS.md) before assuming a feature is implemented.
+
+### Real-system builder
+
+1. Read [`project/REAL_SYSTEM_DEVELOPMENT_GUIDE.md`](project/REAL_SYSTEM_DEVELOPMENT_GUIDE.md).
+2. Treat simulation as a proving layer, not the destination.
+3. Move concepts through fixtures, tests, read-only surfaces, VM evidence, real-device read-only evidence, and only then explicit-gated execution.
+4. Keep Base1 claims tied to Base1 evidence and keep Optics/Fyr/Phase UI progress separate from boot-readiness claims.
+
+### Phase movement designer
+
+1. Read [`project/TRILATERAL_PHASE_MOVEMENT.md`](project/TRILATERAL_PHASE_MOVEMENT.md).
+2. Start with Phase state fixtures before live movement.
+3. Keep `host-effect=none` and `external-effect=none` until explicit gates and evidence exist.
+4. Add invariant tests before adding runtime preview commands.
 
 ### Contributor
 
@@ -217,5 +235,3 @@ Older planning notes, development checkpoints, AI/Gina notes, AVIM notes, and le
 ### White Arts
 
 Use `docs/white-arts/README.md` for White Arts defensive validation, nominal-state, maintenance, security-audit, and open security server suite planning. White Arts work remains evidence-bound, read-only first, and non-claiming until tests and validation reports support promotion.
-
-- [`white-arts/OPEN_SECURITY_SERVER_SUITE.md`](white-arts/OPEN_SECURITY_SERVER_SUITE.md) — documentation-first open-source security server environment suite plan.

--- a/docs/project/REAL_SYSTEM_DEVELOPMENT_GUIDE.md
+++ b/docs/project/REAL_SYSTEM_DEVELOPMENT_GUIDE.md
@@ -1,0 +1,357 @@
+# Phase1 Real-System Development Guide
+
+Status: active development guide
+Scope: real-system direction, evidence ladder, concept promotion rules, Phase1/Base1/Fyr/Optics roles, and next development order.
+
+## Purpose
+
+Phase1 is not being built as a simulator game.
+
+Phase1 starts with simulated and preview surfaces because those surfaces let us test the shape of a system before it is allowed to touch real hardware, real filesystems, real networks, or real recovery paths. Simulation is a proving layer, not the destination.
+
+The long-term direction is a real-life computing system with a Phase1-first operator environment, a Base1 evidence-chain boot foundation, Fyr as the native Phase1 language, and Optics PRO as the operator lens for state, movement, safety, recovery, and system health.
+
+## Reality rule
+
+A concept is not real because it has a name.
+
+A concept becomes real only when it moves through evidence:
+
+```text
+idea
+fixture
+documentation contract
+tests
+read-only command surface
+runtime preview
+guarded experiment
+VM or emulator evidence
+real-device read-only evidence
+real-device execution evidence
+promotion after review
+```
+
+This rule keeps Phase1 ambitious without becoming dishonest.
+
+## Core roles
+
+| Area | Role | Current boundary |
+| --- | --- | --- |
+| Phase1 | Operator environment, command model, VFS, runtime surface, capability gates, status surfaces, and future Phase universe controller. | Terminal-first virtual OS console with simulated and guarded host-backed components. |
+| Base1 | Real-system boot, recovery, validation, hardware evidence, delivery profiles, and promotion ladder. | Evidence-chain target; no broad daily-driver or installer-ready claim until hardware proof exists. |
+| Fyr | Native Phase1 language and future system scripting/control language. | Implemented language/toolchain track, still evidence-bound and not production-claimed. |
+| Optics PRO | Operator lens for rails, status, Phase movement, state, safety, and recovery visibility. | Read-only/status-only until explicit-gate and invariant evidence exists. |
+
+## Design principles
+
+1. Build toward reality without skipping proof.
+2. Keep simulation as the lab, not the product claim.
+3. Promote only the narrowest claim supported by evidence.
+4. Prefer read-only state visibility before mutation.
+5. Prefer pure transition functions before live commands.
+6. Prefer VM and QEMU evidence before real-device execution.
+7. Preserve explicit approval gates for host, network, boot, recovery, and external effects.
+8. Treat every powerful concept as safety-sensitive until tests prove its boundary.
+
+## Real-system ladder
+
+### Level R0: Concept
+
+The idea exists in notes, design docs, or conversation.
+
+Promotion requirement:
+
+- write the concept down;
+- name its non-claims;
+- define what it must not do yet.
+
+### Level R1: Fixture
+
+The concept exists as static state, sample output, or documentation fixture.
+
+Promotion requirement:
+
+- deterministic fixture;
+- no mutation;
+- no host effect;
+- no external effect.
+
+### Level R2: Tested model
+
+The concept has tests that check invariants and forbidden behavior.
+
+Promotion requirement:
+
+- unit or docs tests;
+- forbidden marker tests;
+- no accidental claim expansion.
+
+### Level R3: Read-only command surface
+
+The concept is visible inside Phase1 as a command or preview.
+
+Promotion requirement:
+
+- status-only command;
+- deterministic output;
+- explicit non-claims;
+- capability metadata.
+
+### Level R4: Runtime preview
+
+The concept is wired to a runtime state model but still cannot mutate host, origin, boot, recovery, network, or external systems.
+
+Promotion requirement:
+
+- pure transition model;
+- invariant tests;
+- rollback state visible;
+- host-effect and external-effect remain `none`.
+
+### Level R5: Guarded experiment
+
+The concept can perform a limited mutation inside a controlled Phase1 scope.
+
+Promotion requirement:
+
+- explicit operator command;
+- safe-mode and trust gate review;
+- rollback or reset path;
+- audit log;
+- failure behavior.
+
+### Level R6: VM evidence
+
+The concept runs in an emulator or VM profile.
+
+Promotion requirement:
+
+- reproducible command path;
+- captured logs;
+- validation report;
+- no real-device claim.
+
+### Level R7: Real-device read-only evidence
+
+The concept observes or reports from real hardware without mutating it.
+
+Promotion requirement:
+
+- hardware profile;
+- operator checklist;
+- log bundle;
+- redaction review;
+- explicit read-only result.
+
+### Level R8: Real-device execution evidence
+
+The concept executes on real hardware within a narrow, reversible, operator-approved path.
+
+Promotion requirement:
+
+- device identity;
+- backup and recovery plan;
+- explicit confirmation phrase;
+- rollback or recovery evidence;
+- post-run validation.
+
+### Level R9: Promoted real-system capability
+
+The concept is part of the stable system contract.
+
+Promotion requirement:
+
+- repeated evidence;
+- docs and tests;
+- safety review;
+- release note;
+- clear support boundary.
+
+## Concept notes to preserve
+
+### Trilateral Phase Movement
+
+Trilateral Phase Movement is the future Phase universe navigation model.
+
+It should not start as live movement. It should start as a pure state model with fixtures and invariant tests.
+
+The three movement planes are:
+
+```text
+Plane A: spatial movement
+origin / route / axis / path
+
+Plane B: state movement
+breadcrumb / trace / current context / selected domain
+
+Plane C: safety movement
+safe-portal / rollback / health / risk / lock / dark_phase / host-effect / external-effect
+```
+
+A movement is valid only when all three planes agree that the transition is safe, observable, reversible where required, and free of unintended host or external effects.
+
+### Optics PRO
+
+Optics PRO should visualize the Phase universe before it controls it.
+
+Current labels such as `origin`, `route`, `axis`, `path`, `breadcrumb`, `trace`, `safe-portal`, `rollback`, `health`, `risk`, `lock`, `dark_phase`, `host-effect`, and `external-effect` are the right foundation for a real operator lens.
+
+The next step is not live HUD activation. The next step is tested state fixtures that Optics can render consistently.
+
+### Safe portal and rollback
+
+Safe portal and rollback must be visible before they are executable.
+
+Recommended states:
+
+```text
+safe-portal=planned
+safe-portal=available
+safe-portal=blocked
+safe-portal=armed
+safe-portal=executed
+safe-portal=failed
+
+rollback=unavailable
+rollback=available
+rollback=armed
+rollback=executed
+rollback=failed
+```
+
+Only `executed` may imply that a real recovery action happened.
+
+### Dark phase
+
+`dark_phase` should remain a visible state and risk label, not a stealth claim.
+
+Recommended states:
+
+```text
+dark_phase=off
+dark_phase=observed
+dark_phase=isolated
+dark_phase=blocked
+```
+
+Do not use dark phase to imply unauthorized persistence, stealth, offensive action, or hidden control.
+
+### Fyr staged runtime and Black Arts
+
+Fyr is the native language of Phase1.
+
+The staged runtime and Black Arts concepts should remain candidate-only until they pass validation and approval.
+
+Allowed early states:
+
+```text
+candidate-only
+non-live
+fixture-backed
+validation-required
+approval-gated
+promotion-blocked
+```
+
+Forbidden early states:
+
+```text
+live-system-mutation
+automatic-promotion
+unreviewed-host-effect
+unreviewed-network-effect
+unreviewed-recovery-action
+```
+
+### Base1 real-system path
+
+Base1 is the path from Phase1-as-lab toward Phase1-as-real-system.
+
+The preferred Base1 ladder is:
+
+```text
+dry-run
+read-only validation
+preview bundle
+QEMU evidence
+VM evidence
+real-device read-only evidence
+hardware boot evidence
+promotion after proof
+```
+
+Do not let Phase1 UI, Optics, or Fyr language progress imply Base1 boot readiness. Base1 claims need Base1 evidence.
+
+## Development direction
+
+### Immediate next steps
+
+1. Merge the #391 Optics read-only command surface after its docs-link fix passes CI.
+2. Add a dedicated Phase universe state fixture with fields for origin, route, axis, path, breadcrumb, trace, safe portal, rollback, health, risk, lock, dark phase, host effect, and external effect.
+3. Add invariant tests proving the fixture is read-only and effect-free.
+4. Connect Optics rendering to that fixture without live movement.
+5. Create a pure Trilateral Phase Movement transition model.
+6. Add tests for valid movement, denied movement, locked movement, rollback-visible movement, and no host/external effects.
+7. Only after that, add a preview command such as `phase move preview <direction>`.
+
+### Near-term implementation order
+
+```text
+1. phase-state fixture
+2. phase-state invariant tests
+3. trilateral transition model
+4. movement preview command
+5. Optics renders movement preview state
+6. Fyr can inspect or script preview-only state
+7. Base1 records evidence for real-system promotion paths
+```
+
+### Real-system development order
+
+```text
+Phase1 model first
+Optics visibility second
+Fyr scripted inspection third
+Base1 VM evidence fourth
+Base1 real-device read-only evidence fifth
+narrow real execution last
+```
+
+## What should not happen next
+
+Do not jump directly to live movement.
+
+Do not make Optics mutate origin.
+
+Do not make safe portal execute recovery yet.
+
+Do not claim Base1 boot readiness from UI work.
+
+Do not turn Fyr staged candidates into live system mutation without approval gates.
+
+Do not hide host or external effects behind friendly labels.
+
+## Builder guidance
+
+When building Phase1, ask these questions before every PR:
+
+1. What real-world capability does this move us toward?
+2. What is the exact current evidence level?
+3. What can this not claim yet?
+4. What state is visible to the operator?
+5. What mutation is impossible in this PR?
+6. What test proves the boundary?
+7. What is the rollback or failure path?
+8. Does this make the system more real without becoming unsafe or dishonest?
+
+## North star
+
+Phase1 should become a real operator-centered computing environment.
+
+Base1 should make the system touch real hardware only when evidence supports it.
+
+Fyr should become the native language that lets operators and developers express Phase1-native workflows safely.
+
+Optics should make system state clear enough that a human can understand movement, risk, recovery, trust, and effect boundaries before anything dangerous happens.
+
+That is the path from concept to real system.

--- a/docs/project/TRILATERAL_PHASE_MOVEMENT.md
+++ b/docs/project/TRILATERAL_PHASE_MOVEMENT.md
@@ -1,0 +1,235 @@
+# Trilateral Phase Movement
+
+Status: design contract and fixture-first implementation guide
+Scope: Phase universe movement model, safety planes, Optics visibility, tests, and non-claims.
+
+## Purpose
+
+Trilateral Phase Movement is the planned movement model for the Phase universe.
+
+It exists to make Phase1 movement real without making it reckless. Movement must eventually represent actual state transitions, but it must begin as pure state and proof before live execution exists.
+
+## Definition
+
+A Phase movement is trilateral when it is checked across three planes:
+
+| Plane | Meaning | Example fields |
+| --- | --- | --- |
+| Spatial plane | Where the operator is moving. | `origin`, `route`, `axis`, `path` |
+| State plane | How the movement is remembered and inspected. | `breadcrumb`, `trace`, `context`, `selected-domain` |
+| Safety plane | Whether the movement is allowed and effect-free. | `safe-portal`, `rollback`, `health`, `risk`, `lock`, `dark_phase`, `host-effect`, `external-effect` |
+
+A transition is accepted only when all three planes produce a consistent safe result.
+
+## Initial state fixture
+
+The first implementation should preserve this default shape:
+
+```text
+origin=0/0
+route=ROOT
+axis=ROOT
+path=ROOT>0/0
+breadcrumb=ROOT
+trace=trace-preview
+safe-portal=planned
+rollback=available
+health=nominal
+risk=low
+lock=open
+dark_phase=off
+host-effect=none
+external-effect=none
+```
+
+This state is not live movement. It is the seed fixture for tests, Optics render output, and future transition modeling.
+
+## Movement vocabulary
+
+Initial movement directions should be abstract and device-independent:
+
+```text
+up
+down
+left
+right
+enter
+back
+root
+```
+
+Recommended meanings:
+
+| Direction | Initial interpretation |
+| --- | --- |
+| `up` | Move toward parent, higher domain, or overview. |
+| `down` | Move toward child, deeper domain, or selected detail. |
+| `left` | Move to prior sibling, previous route, or previous axis. |
+| `right` | Move to next sibling, next route, or next axis. |
+| `enter` | Focus selected domain without host or external effect. |
+| `back` | Return to previous breadcrumb if rollback is available. |
+| `root` | Return to `origin=0/0` and `route=ROOT` in preview state. |
+
+These meanings are intentionally broad until fixtures and route tables exist.
+
+## Transition contract
+
+The first transition engine should be pure.
+
+Input:
+
+```text
+current_phase_state
+movement_direction
+operator_intent
+```
+
+Output:
+
+```text
+next_phase_state
+transition_result
+reason
+```
+
+The pure transition engine must not:
+
+- mutate shell state;
+- mutate origin outside the returned next-state value;
+- execute recovery;
+- touch the host filesystem;
+- touch host networking;
+- launch a process;
+- hide command output;
+- claim security enforcement;
+- claim Base1 boot readiness.
+
+## Safety rules
+
+A movement must be denied when:
+
+- `lock` is closed;
+- `risk` is high and the movement is not read-only;
+- `safe-portal` is blocked and the movement depends on recovery state;
+- `rollback` is unavailable and the movement requires reversible state;
+- `dark_phase` is observed, isolated, or blocked and no explicit safe action exists;
+- the movement would produce any host effect before explicit gating;
+- the movement would produce any external effect before explicit gating.
+
+Every denied movement should return a visible reason.
+
+## Optics relationship
+
+Optics PRO is the operator lens for Trilateral Phase Movement.
+
+Optics should show:
+
+- current origin;
+- current route;
+- current axis;
+- current path;
+- breadcrumb;
+- trace id;
+- safe portal state;
+- rollback state;
+- health;
+- risk;
+- lock;
+- dark phase state;
+- host effect;
+- external effect;
+- last movement result.
+
+Optics should not activate live movement in the first implementation.
+
+## Fyr relationship
+
+Fyr should eventually inspect and script Phase state, but early Fyr integration should remain read-only.
+
+Safe early commands or examples:
+
+```text
+fyr phase inspect
+fyr phase assert-root
+fyr phase assert-no-host-effect
+fyr phase assert-rollback-visible
+```
+
+Fyr must not promote staged candidates, mutate live Phase state, or trigger Base1 recovery from this model until explicit approval gates and tests exist.
+
+## Base1 relationship
+
+Base1 is where Phase movement can eventually become hardware-adjacent.
+
+Before any Base1 movement is real, the model needs:
+
+- VM evidence;
+- read-only hardware evidence;
+- recovery evidence;
+- rollback evidence;
+- operator confirmation flow;
+- post-run validation.
+
+Trilateral movement cannot claim Base1 boot or recovery readiness by itself.
+
+## Test plan
+
+Initial tests should cover:
+
+```text
+phase_state_default_fixture_has_required_labels
+phase_state_default_fixture_has_no_effects
+trilateral_move_preview_accepts_safe_route
+trilateral_move_preview_denies_closed_lock
+trilateral_move_preview_denies_missing_rollback_when_required
+trilateral_move_preview_preserves_trace_or_records_new_trace
+trilateral_move_preview_never_sets_host_effect_before_gate
+trilateral_move_preview_never_sets_external_effect_before_gate
+optics_renders_phase_state_labels
+```
+
+## First command surface
+
+The first operator command should be preview-only:
+
+```text
+phase move preview <direction>
+```
+
+Possible output:
+
+```text
+PHASE MOVE PREVIEW
+from.path=ROOT>0/0
+direction=right
+result=allowed-preview
+next.path=ROOT>0/1
+host-effect=none
+external-effect=none
+recovery-executed=no
+origin-mutated=no
+```
+
+This command should not perform live movement.
+
+## Promotion ladder
+
+```text
+D0 concept documented
+D1 default fixture added
+D2 invariant tests added
+D3 Optics renders fixture
+D4 pure transition model added
+D5 preview command added
+D6 denied movement reasons added
+D7 Fyr read-only inspection added
+D8 VM evidence added
+D9 real-device read-only evidence added
+D10 explicit-gated live experiment considered
+```
+
+## Non-claims
+
+Trilateral Phase Movement does not currently provide live Phase movement, origin mutation, recovery execution, runtime domain mutation, host mutation, external effects, sandboxing, crypto enforcement, system integrity guarantees, or Base1 boot readiness.
+
+This document is a development contract for moving toward those ideas safely and truthfully.

--- a/tests/real_system_development_guides_docs.rs
+++ b/tests/real_system_development_guides_docs.rs
@@ -1,0 +1,155 @@
+use std::fs;
+
+const REAL_SYSTEM_GUIDE: &str = "docs/project/REAL_SYSTEM_DEVELOPMENT_GUIDE.md";
+const TRILATERAL_GUIDE: &str = "docs/project/TRILATERAL_PHASE_MOVEMENT.md";
+const DOCS_INDEX: &str = "docs/README.md";
+const REPOSITORY_NAVIGATION: &str = "docs/REPOSITORY_NAVIGATION.md";
+
+#[test]
+fn real_system_development_guide_exists_and_defines_direction() {
+    let doc = fs::read_to_string(REAL_SYSTEM_GUIDE).expect("real system guide should exist");
+
+    for required in [
+        "Phase1 Real-System Development Guide",
+        "not being built as a simulator game",
+        "Simulation is a proving layer, not the destination.",
+        "Phase1-first operator environment",
+        "Base1 evidence-chain boot foundation",
+        "Fyr as the native Phase1 language",
+        "Optics PRO as the operator lens",
+        "A concept becomes real only when it moves through evidence",
+        "Do not jump directly to live movement.",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn real_system_development_guide_preserves_evidence_ladder_and_roles() {
+    let doc = fs::read_to_string(REAL_SYSTEM_GUIDE).expect("real system guide should exist");
+
+    for required in [
+        "Level R0: Concept",
+        "Level R1: Fixture",
+        "Level R2: Tested model",
+        "Level R3: Read-only command surface",
+        "Level R4: Runtime preview",
+        "Level R5: Guarded experiment",
+        "Level R6: VM evidence",
+        "Level R7: Real-device read-only evidence",
+        "Level R8: Real-device execution evidence",
+        "Level R9: Promoted real-system capability",
+        "Phase1 | Operator environment",
+        "Base1 | Real-system boot",
+        "Fyr | Native Phase1 language",
+        "Optics PRO | Operator lens",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn real_system_development_guide_preserves_concept_notes_and_boundaries() {
+    let doc = fs::read_to_string(REAL_SYSTEM_GUIDE).expect("real system guide should exist");
+
+    for required in [
+        "Trilateral Phase Movement",
+        "Plane A: spatial movement",
+        "Plane B: state movement",
+        "Plane C: safety movement",
+        "safe-portal=planned",
+        "rollback=available",
+        "dark_phase=off",
+        "host-effect=none",
+        "external-effect=none",
+        "candidate-only",
+        "approval-gated",
+        "Base1 claims need Base1 evidence.",
+        "Does this make the system more real without becoming unsafe or dishonest?",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn trilateral_phase_movement_guide_exists_and_defines_planes() {
+    let doc = fs::read_to_string(TRILATERAL_GUIDE).expect("trilateral guide should exist");
+
+    for required in [
+        "Trilateral Phase Movement",
+        "design contract and fixture-first implementation guide",
+        "Spatial plane",
+        "State plane",
+        "Safety plane",
+        "origin=0/0",
+        "route=ROOT",
+        "axis=ROOT",
+        "path=ROOT>0/0",
+        "breadcrumb=ROOT",
+        "trace=trace-preview",
+        "host-effect=none",
+        "external-effect=none",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn trilateral_phase_movement_guide_preserves_preview_only_transition_contract() {
+    let doc = fs::read_to_string(TRILATERAL_GUIDE).expect("trilateral guide should exist");
+
+    for required in [
+        "The first transition engine should be pure.",
+        "current_phase_state",
+        "movement_direction",
+        "next_phase_state",
+        "transition_result",
+        "phase move preview <direction>",
+        "recovery-executed=no",
+        "origin-mutated=no",
+        "This command should not perform live movement.",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn trilateral_phase_movement_guide_preserves_non_claims() {
+    let doc = fs::read_to_string(TRILATERAL_GUIDE).expect("trilateral guide should exist");
+
+    for required in [
+        "does not currently provide live Phase movement",
+        "origin mutation",
+        "recovery execution",
+        "runtime domain mutation",
+        "host mutation",
+        "external effects",
+        "sandboxing",
+        "crypto enforcement",
+        "system integrity guarantees",
+        "Base1 boot readiness",
+    ] {
+        assert!(doc.contains(required), "missing {required:?}: {doc}");
+    }
+}
+
+#[test]
+fn real_system_guides_are_linked_from_indexes() {
+    let docs_index = fs::read_to_string(DOCS_INDEX).expect("docs index should exist");
+    let repository_navigation =
+        fs::read_to_string(REPOSITORY_NAVIGATION).expect("repository navigation should exist");
+
+    for required in [
+        "REAL_SYSTEM_DEVELOPMENT_GUIDE.md",
+        "TRILATERAL_PHASE_MOVEMENT.md",
+    ] {
+        assert!(
+            docs_index.contains(required),
+            "docs index missing {required:?}: {docs_index}"
+        );
+        assert!(
+            repository_navigation.contains(required),
+            "repository navigation missing {required:?}: {repository_navigation}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds durable project guidance for building Phase1 toward a real-life system rather than treating it as a simulator/game endpoint.

## Scope

- Add `docs/project/REAL_SYSTEM_DEVELOPMENT_GUIDE.md`
  - Defines the real-system north star
  - Preserves Phase1/Base1/Fyr/Optics roles
  - Adds an evidence ladder from concept to promoted real-system capability
  - Records concept notes for Trilateral Phase Movement, Optics PRO, safe portal/rollback, dark phase, Fyr staged runtime, Black Arts, and Base1
- Add `docs/project/TRILATERAL_PHASE_MOVEMENT.md`
  - Defines the three movement planes: spatial, state, and safety
  - Preserves the initial state fixture labels
  - Defines preview-only movement vocabulary and transition rules
  - Keeps live movement, origin mutation, recovery execution, host mutation, and external effects out of scope
- Link both guides from `docs/README.md` and `docs/REPOSITORY_NAVIGATION.md`
- Add `tests/real_system_development_guides_docs.rs` to guard the new docs and links

## Boundaries

This is documentation and docs-guard work only. It does not add live Phase movement, Optics live activation, origin mutation, Base1 boot execution, Fyr live system mutation, recovery execution, host mutation, network mutation, or external effects.

## Validation

Recommended:

```bash
cargo fmt --all -- --check
cargo test -p phase1 --test real_system_development_guides_docs
cargo test --workspace --all-targets
```
